### PR TITLE
chore(spindle-icons): prepare publishing icons

### DIFF
--- a/packages/spindle-icons/package.json
+++ b/packages/spindle-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openameba/spindle-icons",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "scripts": {
     "clean": "npx rimraf dist",
     "mkdir": "npx mkdirp dist",
@@ -12,7 +12,6 @@
     "icon:sprite": "svg-sprite --config sprite.json --shape-transform-svgo sprite.svgo.json dist/*.svg",
     "serve": "npx serve"
   },
-  "private": true,
   "license": "SEE LICENSE IN README.md",
   "files": [
     "dist"


### PR DESCRIPTION
アイコンをお試し利用するプロジェクトがありそうなので、npm公開する準備をしておきます。

バージョンは`0.1.0`から開始して、[Semantic Versioning 2.0.0](https://semver.org/)に従う予定です。
