### PR TITLE
chore(spindle-ui): set base font family

### DIFF
--- a/packages/spindle-ui/.storybook/preview-head.html
+++ b/packages/spindle-ui/.storybook/preview-head.html
@@ -1,0 +1,5 @@
+<style>
+  body {
+    font-family: Meiryo, Yu Gothic Medium, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+</style>


### PR DESCRIPTION
Storybookのプレビュー内では、Spindleで規定されたフォントでコンポーネントを表示するようにします。
