### PR TITLE
chore: deploy UI catalog (Storybook) with branch and tag

### DIFF
--- a/.github/workflows/deploy-ui-catalog.yml
+++ b/.github/workflows/deploy-ui-catalog.yml
@@ -1,0 +1,22 @@
+name: deploy UI catalog
+
+on:
+  push:
+    branches:
+      - deploy/ui-catalog
+    tags:
+      - '@openameba/*'
+
+jobs:
+  deploy_ui_catalog:
+    name: deploy_ui_catalog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: 14
+      - name: Update UI catalog
+        run: |
+          npx lerna run --scope @openameba/spindle-ui storybook:build
+          npx lerna run --scope @openameba/spindle-ui storybook:deploy -- --token $FIREBASE_TOKEN

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,3 @@ jobs:
           npm whoami
       - name: Publishing with lerna
         run: npx lerna publish from-git
-      - name: Hosting UI catalog when Spindle UI has been updated
-        run: |
-          if npx lerna changed | grep @openameba/spindle-ui; then
-            npx lerna run --scope @openameba/spindle-ui storybook:build
-            npx lerna run --scope @openameba/spindle-ui storybook:deploy -- --token $FIREBASE_TOKEN
-          fi


### PR DESCRIPTION
#17 で対応したStorybookのデプロイフローなのですが、「個別に上げたいタイミングもあるよなぁ」ということから、ブランチ名と今までとタグ名でできるようにしてみました。

`publish.yml` の時は、変更があった場合のみ実行されるようにしていましたが、そこまで問題になるような動作でないので、判定を外しています。

