### PR TITLE
chore: fail if need update lockfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn bootstrap
       # Build application to check if the system works or not
       # TODO: Build script for spindle-icon should be added

--- a/.github/workflows/deploy-ui-catalog.yml
+++ b/.github/workflows/deploy-ui-catalog.yml
@@ -23,7 +23,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn bootstrap
       - name: Update UI catalog
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn bootstrap
       - run: yarn test


### PR DESCRIPTION
yarn.lockの更新が必要な際にCIで落ちて欲しいので、CIでの `yarn install` に `--frozen-lockfile` を軒並み付けました。