### PR TITLE
chore(spindle-ui): remove private:true to publish

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -29,7 +29,6 @@
     "prepublishOnly": "yarn build"
   },
   "license": "MIT",
-  "private": true,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
そろそろアイコンを他リポジトリに取り込みそうなので、`spindle-ui` をpublishできるように準備しておきます。
