### PR TITLE
chore(spindle-ui): make public

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -32,6 +32,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@types/react": "^16.9.43",
     "ameba-color-palette.css": "openameba/ameba-color-palette.css#v3.0.0-beta.0",


### PR DESCRIPTION
いつも忘れてしまうんですが、scoped packageなので、明示的に`public`にしなければでした。
