### PR TITLE
chore: update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm whoami
       - name: Publishing with lerna
-        run: npx lerna publish from-git
+        run: npx lerna publish from-git --yes


### PR DESCRIPTION
[公開前にビルドが必要になった](https://github.com/openameba/spindle/pull/41#discussion_r504342998)ので、依存モジュールをインストールします。

また、プロンプト表示せず、CI上でコマンドが実行できるようにしました。
