### PR TITLE
chore: take screenshot when push

### DIFF
--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -2,8 +2,8 @@ name: regression-test
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'packages/spindle-ui/**'
   pull_request:
     paths:
       - 'packages/spindle-ui/**'


### PR DESCRIPTION
https://github.com/openameba/spindle/pull/47#issuecomment-709900109 にて発生したような、Pull-requestが発行されていないと比較対象が存在しないためreg-suitに新規追加だと思われてしまうというのを修正しているPRです。

mainブランチがpushされた時には必ず取得、他のブランチがpushされた時にはpathsをみて取得、と本当は書きたかったですがそういう指定ができそうになかったので仕方なくpush時にもpathsだけを指定するようにしました:cry:
たぶん大丈夫だと思うのですが……

それほど発生しないであろう状況なので、変更として良いのか悪いのか、どうしたものかという気持ちではあります🤔