### PR TITLE
chore: display logo on mobile screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="Spindle" height="400" src="./docs/images/spindle-logo.png" width="400">
+  <img alt="Spindle" src="./docs/images/spindle-logo.png" width="400">
 </p>
 
 # Spindle (In development)


### PR DESCRIPTION
横幅の狭いディスプレイでロゴが縦長になってしまうのを解決しました。

本来は `style="height: auto"` などつけてレスポンシブにするのがよさげさんですが、表示時に`style`は消されてしまうので`height`属性を消す方法で対応しました。

これにより、アスペクト比がない画像によるレイアウトシフトが発生しますがしかたなく・・:cry:


![github com_openameba_spindle](https://user-images.githubusercontent.com/869023/96944163-0fe38e80-1515-11eb-86d6-43c1461eeeb4.png)
