### PR TITLE
chore: checkout with all history to generate changelog

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2-beta
         with:
           node-version: 14


### PR DESCRIPTION
[なんかchangelogが内容出なくておかしいなぁ](https://github.com/openameba/spindle/blob/main/packages/spindle-icons/CHANGELOG.md)と思っていましたが、actions/checkout@v2だと効率化されて[デフォルトでは1コミットしかチェックアウトせず](https://github.com/actions/checkout#whats-new)、コミットメッセージからchangelogが作成できないようでした。

ケースバイケースでどこまで取得したらいいのかわからないので、versioningのタスクではすべての履歴を取得するように変更しました。

お試しで実行してみた結果は、以下で確認できます。
https://github.com/openameba/spindle/runs/1296647860?check_suite_focus=true
