### PR TITLE
feat(spindle-ui): change sizes to relative units

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -60,6 +60,7 @@
     "jest": "^26.1.0",
     "postcss-cli": "^8.0.0",
     "postcss-import": "^12.0.1",
+    "postcss-pxtorem": "herablog/postcss-pxtorem#useem",
     "reg-suit": "^0.10.7",
     "sinon": "^9.0.2",
     "stylelint": "^13.6.1",

--- a/packages/spindle-ui/postcss.config.js
+++ b/packages/spindle-ui/postcss.config.js
@@ -5,5 +5,10 @@ module.exports = {
    * - for IE11
    */
   // TODO: minify css for production
-  plugins: [require('autoprefixer'), require('postcss-import')],
+  /* eslint-disable @typescript-eslint/no-var-requires */
+  plugins: [
+    require('autoprefixer'),
+    require('postcss-import'),
+    require('postcss-pxtorem')({ useEM: true }),
+  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4832,10 +4832,10 @@ axios@^0.19.0:
   dependencies:
     follow-redirects "1.5.10"
 
-axios@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
-  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+axios@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
   dependencies:
     follow-redirects "^1.10.0"
 
@@ -14654,6 +14654,12 @@ postcss-modules-values@^3.0.0:
     icss-utils "^4.0.0"
     postcss "^7.0.6"
 
+postcss-pxtorem@herablog/postcss-pxtorem#useem:
+  version "5.1.1"
+  resolved "https://codeload.github.com/herablog/postcss-pxtorem/tar.gz/993d74441a704b0f89447a3521a49089875b92c7"
+  dependencies:
+    postcss "^7.0.27"
+
 postcss-reporter@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-6.0.1.tgz#7c055120060a97c8837b4e48215661aafb74245f"
@@ -14740,6 +14746,15 @@ postcss@>=5.0.19, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.
   version "7.0.32"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
   integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.27:
+  version "7.0.35"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
+  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"


### PR DESCRIPTION
Spindleコンポーネントのサイズは相対的にしておきたいですが、呼び出し元のアプリケーションのベースサイズ指定の仕方は様々な可能性があるので、親から継承された値を元に相対的になるようにしてみました。

実際の値は、Firebase PreviewのStorybookをみていただくとよさげさんです。
https://ameba-spindle--pr60-feature-em-unit-ezmh38dl.web.app/?path=/story/button--large

![](https://user-images.githubusercontent.com/869023/97270085-e3f83e00-1871-11eb-842c-0dbe67e3f90a.png)



具体的な検討事項は #11 に記載していますので、そちらも合わせて見ていただけると助かります。

こちらはより良い方法があるかもしれないので、ご意見ください！

close #11