### PR TITLE
Change module export setting

### DIFF
--- a/packages/spindle-ui/.npmignore
+++ b/packages/spindle-ui/.npmignore
@@ -1,5 +1,6 @@
 src
 dist
+public
 .storybook
 .reg-suit
 .firebaserc

--- a/packages/spindle-ui/.npmignore
+++ b/packages/spindle-ui/.npmignore
@@ -1,0 +1,17 @@
+src
+dist
+.storybook
+.reg-suit
+.firebaserc
+.gitignore
+.stylelintignore
+.stylelintrc.json
+jest.config.js
+postcss.config.js
+.svgrrc.json
+bundlesize.config.json
+firebase.json
+regconfig.json
+tsconfig.json
+design-doc.md
+setup-tests.ts

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@openameba/spindle-ui",
   "version": "0.3.0",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "style": "./dist/index.css",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "style": "./index.css",
   "scripts": {
     "test": "run-p bundlesize lint test:interaction",
     "lint": "yarn lint:style",
@@ -19,6 +19,7 @@
     "test:regression": "reg-suit run",
     "serve": "firebase serve",
     "clean": "npx rimraf dist",
+    "cp": "npx cpx 'dist/**/*' .",
     "prebuild": "yarn clean",
     "build": "run-p build:*",
     "build:script": "tsc",
@@ -26,12 +27,9 @@
     "preicon": "npx rimraf 'src/Icon/!(*.stories).tsx' && npx cpx '../spindle-icons/dist/svg/!(sprite).svg' icon-tmp",
     "icon": "svgr --out-dir src/Icon icon-tmp",
     "posticon": "npx rimraf icon-tmp",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build && yarn cp"
   },
   "license": "MIT",
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -1,3 +1,3 @@
 export { Button } from './Button';
 export * as Form from './Form';
-export * from './Icon';
+export * as Icon from './Icon';


### PR DESCRIPTION
Iconコンポーネントを`@openameba/spindle-ui/Icon`から取得できるように修正しました。

この変更により以下の形式でコンポーネントをimportできます。

```JavaScript
import { Clock } from '@openameba/spindle-ui/Icon';
```

or

```JavaScript
import { Icon } from '@openameba/spindle-ui';
const { Clock } = Icon;
```

---

```JavaScript
import { Checkbox } from '@openameba/spindle-ui/Form';
```

or

```JavaScript
import { Form } from '@openameba/spindle-ui';
const { Checkbox } = Form;
```
