### PR TITLE
feat(spindle-ui): change sizes to relative units

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -43,7 +43,7 @@
 .spui-Button--large {
   /* To be relative value with font size; this means base height / base font size  */
   border-radius: calc(48em / 16);
-  font-size: 16px; /* TODO: Replace relative value (em or rem) */
+  font-size: 1em;
   min-height: 48px;
   padding-left: 16px;
   padding-right: 16px;
@@ -51,7 +51,7 @@
 
 .spui-Button--medium {
   border-radius: calc(40em / 14);
-  font-size: 14px; /* TODO: Replace relative value (em or rem) */
+  font-size: 0.875em;
   min-height: 40px;
   min-width: 88px;
   padding-left: 16px;
@@ -60,7 +60,7 @@
 
 .spui-Button--small {
   border-radius: calc(32em / 13);
-  font-size: 13px; /* TODO: Replace relative value (em or rem) */
+  font-size: 0.8125em;
   min-height: 32px;
   min-width: 60px;
   padding-left: 10px;

--- a/packages/spindle-ui/src/Form/Checkbox.css
+++ b/packages/spindle-ui/src/Form/Checkbox.css
@@ -4,7 +4,7 @@
 .spui-Checkbox-label {
   border-radius: 2px;
   color: var(--color-text-low-emphasis);
-  font-size: 13px;
+  font-size: 0.8125em;
   line-height: 1.4;
   padding: 0.1em 0.1em 0;
   position: relative;

--- a/packages/spindle-ui/src/Form/InputLabel.css
+++ b/packages/spindle-ui/src/Form/InputLabel.css
@@ -4,7 +4,7 @@
 .spui-InputLabel {
   color: var(--color-text-mid-emphasis);
   display: block;
-  font-size: 14px;
+  font-size: 0.875em;
   font-weight: bold;
   line-height: 1.4;
 }

--- a/packages/spindle-ui/src/Form/InvalidMessage.css
+++ b/packages/spindle-ui/src/Form/InvalidMessage.css
@@ -4,7 +4,7 @@
 .spui-InvalidMessage {
   color: var(--color-text-caution);
   display: block;
-  font-size: 12px;
+  font-size: 0.75em;
   font-weight: bold;
   line-height: 1.4;
   margin: 8px 0 0;

--- a/packages/spindle-ui/src/Form/Radio.css
+++ b/packages/spindle-ui/src/Form/Radio.css
@@ -4,7 +4,7 @@
 .spui-Radio-label {
   border-radius: 2px;
   color: var(--color-text-low-emphasis);
-  font-size: 16px;
+  font-size: 1em;
   font-weight: bold;
   padding: 0.1em 0;
   position: relative;

--- a/packages/spindle-ui/src/Form/TextField.css
+++ b/packages/spindle-ui/src/Form/TextField.css
@@ -7,7 +7,7 @@
   border-radius: 8px;
   box-sizing: border-box;
   color: var(--color-text-high-emphasis);
-  font-size: 16px;
+  font-size: 1em;
   margin: 0;
   min-height: 48px;
   outline: none;


### PR DESCRIPTION
Spindleコンポーネントのサイズは相対的にしておきたいですが、呼び出し元のアプリケーションのベースサイズ指定の仕方は様々な可能性があるので、親から継承された値を元に相対的になるようにしてみました。

実際の値は、Firebase PreviewのStorybookをみていただくとよさげさんです。
https://ameba-spindle--pr60-feature-em-unit-ezmh38dl.web.app/?path=/story/button--large

![](https://user-images.githubusercontent.com/869023/97270085-e3f83e00-1871-11eb-842c-0dbe67e3f90a.png)



具体的な検討事項は #11 に記載していますので、そちらも合わせて見ていただけると助かります。

こちらはより良い方法があるかもしれないので、ご意見ください！

close #11