### PR TITLE
Build icons via Webhook

### DIFF
--- a/.github/workflows/build-icon.yml
+++ b/.github/workflows/build-icon.yml
@@ -1,0 +1,48 @@
+name: build icon via webhook
+
+on:
+  workflow_dispatch:
+    inputs:
+      modified_components:
+        description: 'JSON array for modified components'
+        required: true
+        default: '["ALL"]'
+
+jobs:
+  build_icons:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: 14
+      - name: restore lerna
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn bootstrap
+      - name: Update UI catalog
+        env:
+          FILE_KEY: ${{ secrets.FIGMA_ICON_FILE_KEY }}
+          NODE_ID: ${{ secrets.FIGMA_ICON_NODE_ID }}
+          ICON_NAMES: ${{ github.event.inputs.modified_components }}
+        run: |
+          echo '{ "fileKey": "$FILE_KEY", "nodeId": "$NODE_ID", "dest": "dist", "iconNames": "$ICON_NAMES" }' > packages/spindle-icons/figma.json
+          npx lerna run --scope @openameba/spindle-icons build
+          npx lerna run --scope @openameba/spindle-ui icon
+          yarn format
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: 'feat(spindle-icons): update icons'
+          branch: feat/build-icon-via-webhook
+          delete-branch: true
+          title: 'feat(spindle-icons): update icons'
+          body: ${{ github.event.inputs.modified_components }}
+          labels: |
+            spindle-icons
+            spindle-ui

--- a/.github/workflows/build-icon.yml
+++ b/.github/workflows/build-icon.yml
@@ -31,7 +31,7 @@ jobs:
           NODE_ID: ${{ secrets.FIGMA_ICON_NODE_ID }}
           ICON_NAMES: ${{ github.event.inputs.modified_components }}
         run: |
-          echo '{ "fileKey": "$FILE_KEY", "nodeId": "$NODE_ID", "dest": "dist", "iconNames": "$ICON_NAMES" }' > packages/spindle-icons/figma.json
+          node -p "JSON.stringify({ fileKey: '$FILE_KEY', nodeId: '$NODE_ID', dest: 'dist', iconNames: '$ICON_NAMES' })" > packages/spindle-icons/figma.json
           npx lerna run --scope @openameba/spindle-icons build
           npx lerna run --scope @openameba/spindle-ui icon
           yarn format

--- a/packages/spindle-icons/docs/design-doc.md
+++ b/packages/spindle-icons/docs/design-doc.md
@@ -32,13 +32,14 @@ https://www.figma.com/file/${FILE_ID}/icon?node-id=${NODE_ID}
 
 なお、セキュリティ上の問題から、Figmaファイルの閲覧権限が適切か確認してください。また、パーソナルアクセストークンは他人に漏らさないように扱ってください。
 
-取得したFile KeyとNode IDは、`figma.json`という名前でファイルを作成し、保存します。Node IDが「0%3A1」のようにURLエンコードされている場合は、デコードした値を指定します。`dest`にはSVGを出力するディレクトリを指定します。`figma.json`は、間違ってFigmaファイルが公開されないように、git管理されていません。
+取得したFile KeyとNode IDは、`figma.json`という名前でファイルを作成し、保存します。Node IDが「0%3A1」のようにURLエンコードされている場合は、デコードした値を指定します。`dest`にはSVGを出力するディレクトリを指定します。特定のアイコンのみ取得したい場合には、`iconNames`に配列形式でアイコン名を指定します。`ALL`を指定するとすべてのアイコンを取得しますが、ファイル数が多い場合にはダウンロードに時間がかかります。なお、`figma.json`は、間違ってFigmaファイルが公開されないように、git管理されていません。
 
 ```json
 {
   "fileKey": "${FILE_ID}",
   "nodeId": "${NODE_ID}",
-  "dest": "dist"
+  "dest": "dist",
+  "iconNames": ["clock"]
 }
 ```
 


### PR DESCRIPTION
[FigmaのWebhook](https://www.figma.com/developers/api#webhooks-v2-events)で、アイコンの更新が検知できそうなので、自動的に変更があったファイルのみアイコンを生成して、プルリクエストを送るようにしてみようと思います。

大まかなフローは以下の通りです。

- FigmaでIconの変更し、パブリッシュする (手動)
- Figmaが`LIBRARY_PUBLISH `イベントで登録したWebhookにデータを送信する (どこかに作る予定)
  - 送られてきたデータをもとに[GitHub APIにPOST](https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-a-workflow-dispatch-event)する
- このPRに含まれる処理が動き、アイコンが作られ、PRが自動的に作られる (はず)

デフォルトブランチ取り込まないとworkflowが動かせなそうな感じがするので、取り込んだあと手動で動かしてみます。
その後、Figmaとつなぐ部分を作ろうと思います。
