### PR TITLE
feat(spindle-ui): update button state pattern

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -8,6 +8,7 @@
   box-sizing: border-box;
   line-height: 1.3;
   outline: none;
+  -webkit-tap-highlight-color: var(--Button-tapHighlightColor, --gray-5-alpha);
   text-align: center;
   transition: background-color var(--Button-transitionDuration, 0.3s);
 }
@@ -71,11 +72,20 @@
   );
 }
 
-.spui-Button--contained:not([disabled]):hover {
+.spui-Button--contained:active {
   background-color: var(
-    --Button--contained-onHover-backgroundColor,
+    --Button--contained-onActive-backgroundColor,
     var(--primary-green-100)
   );
+}
+
+@media (hover: hover) {
+  .spui-Button--contained:not([disabled]):hover {
+    background-color: var(
+      --Button--contained-onHover-backgroundColor,
+      var(--primary-green-100)
+    );
+  }
 }
 
 /* outlined */
@@ -89,11 +99,20 @@
   color: var(--Button--outlined-color, var(--color-surface-accent-primary));
 }
 
-.spui-Button--outlined:not([disabled]):hover {
+.spui-Button--outlined:active {
   background-color: var(
-    --Button--outlined-onHover-backgroundColor,
+    --Button--outlined-onActive-backgroundColor,
     var(--primary-green-5)
   );
+}
+
+@media (hover: hover) {
+  .spui-Button--outlined:not([disabled]):hover {
+    background-color: var(
+      --Button--outlined-onHover-backgroundColor,
+      var(--primary-green-5)
+    );
+  }
 }
 
 /* neutral */
@@ -106,11 +125,20 @@
   color: var(--Button--neutral-backgroundColor, var(--color-text-mid-emphasis));
 }
 
-.spui-Button--neutral:not([disabled]):hover {
+.spui-Button--neutral:active {
   background-color: var(
-    --Button--neutral-onHover-backgroundColor,
+    --Button--neutral-onActive-backgroundColor,
     var(--gray-20-alpha)
   );
+}
+
+@media (hover: hover) {
+  .spui-Button--neutral:not([disabled]):hover {
+    background-color: var(
+      --Button--neutral-onHover-backgroundColor,
+      var(--gray-20-alpha)
+    );
+  }
 }
 
 /* danger */
@@ -123,9 +151,18 @@
   color: var(--Button--danger-color, var(--color-text-caution));
 }
 
-.spui-Button--danger:not([disabled]):hover {
+.spui-Button--danger:active {
   background-color: var(
-    --Button--danger-onHover-backgroundColor,
+    --Button--danger-onActive-backgroundColor,
     var(--caution-red-5-alpha)
   );
+}
+
+@media (hover: hover) {
+  .spui-Button--danger:not([disabled]):hover {
+    background-color: var(
+      --Button--danger-onHover-backgroundColor,
+      var(--caution-red-5-alpha)
+    );
+  }
 }


### PR DESCRIPTION
すでに認証プロジェクトで導入済みのButtonの新しいステートパターンを適用しました。変更の理由は #13 を参照してください。

## hover
hoverが可能なブラウザ(IE以外のPCブラウザ)で表示されます。

![ameba-spindle--pr77-feature-button-state-om7ndyu6 web app__path=_story_button--large (5)](https://user-images.githubusercontent.com/869023/98068245-dd377f80-1e9e-11eb-8bff-14d023666208.png)

## active
PCブラウザクリック時とAndroid Chrome タップ時に表示されます。
![ameba-spindle--pr77-feature-button-state-om7ndyu6 web app__path=_story_button--large (6)](https://user-images.githubusercontent.com/869023/98068378-3dc6bc80-1e9f-11eb-8892-1b59defcfe61.png)

## focus
PCブラウザでのキーフォーカス時、Android Chromeでは長く押した時に表示されます。

![ameba-spindle--pr77-feature-button-state-om7ndyu6 web app__path=_story_button--large (4)](https://user-images.githubusercontent.com/869023/98068397-46b78e00-1e9f-11eb-9524-a3869fb4d2c2.png)


## Tap highlight color
iOS Safariで表示されます。

close #13 