### PR TITLE
perf(spindle-ui): increase size budget for css

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "./dist/index.css",
-      "maxSize": "3 kB"
+      "maxSize": "10 kB"
     }
   ]
 }


### PR DESCRIPTION
これからコンポーネントが追加されていくので、`index.css`のファイルサイズバジェットをあげておきます。ホントはもっと大きくなりそうな気がしますが、このへんは都度調整していきます。

