### PR TITLE
feat(spindle-ui): improve button style when text is scaling up

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -28,31 +28,33 @@
  * Button sizes
 */
 .spui-Button--large {
-  border-radius: 24px;
+  /* To be relative value with font size; this means base height / base font size  */
+  border-radius: calc(48em / 18);
   font-size: 18px; /* TODO: Replace relative value (em or rem) */
-  /* To use em value; this equals (48px / $font-size)em  */
-  height: calc(48em / 18);
-  padding: 0 16px;
+  min-height: 48px;
+  padding-left: 16px;
+  padding-right: 16px;
   width: 100%;
 }
 
 .spui-Button--medium {
-  border-radius: 20px;
+  border-radius: calc(40em / 18);
   font-size: 18px; /* TODO: Replace relative value (em or rem) */
-  /* To use em value; this equals (40px / $font-size)em  */
-  height: calc(40em / 18);
   max-width: 240px;
+  min-height: 40px;
   min-width: 88px;
-  padding: 0 16px;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .spui-Button--small {
-  border-radius: 16px;
-  font-size: 14px; /* TODO: Replace relative value (em or rem) */
-  /* To use em value; this equals (32px / $font-size)em  */
-  height: calc(32em / 14);
+  border-radius: calc(32em / 13);
+  font-size: 13px; /* TODO: Replace relative value (em or rem) */
+  max-width: 160px;
+  min-height: 32px;
   min-width: 60px;
-  padding: 0 10px;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 /*
@@ -69,6 +71,9 @@
     --Button--contained-color,
     var(--color-text-high-emphasis-inverse)
   );
+  /* Button variants have different vertical padding to normalize height */
+  padding-bottom: 8px;
+  padding-top: 8px;
 }
 
 .spui-Button--contained:not([disabled]):hover {
@@ -87,6 +92,8 @@
   border: 2px solid
     var(--Button--outlined-borderColor, var(--color-surface-accent-primary));
   color: var(--Button--outlined-color, var(--color-surface-accent-primary));
+  padding-bottom: 6px;
+  padding-top: 6px;
 }
 
 .spui-Button--outlined:not([disabled]):hover {
@@ -104,6 +111,8 @@
   );
   border: none;
   color: var(--Button--neutral-backgroundColor, var(--color-text-mid-emphasis));
+  padding-bottom: 8px;
+  padding-top: 8px;
 }
 
 .spui-Button--neutral:not([disabled]):hover {
@@ -121,6 +130,8 @@
   );
   border: 2px solid var(--Button--danger-borderColor, var(--color-text-caution));
   color: var(--Button--danger-color, var(--color-text-caution));
+  padding-bottom: 6px;
+  padding-top: 6px;
 }
 
 .spui-Button--danger:not([disabled]):hover {


### PR DESCRIPTION
ボタン内のテキストが拡大された時(ズームではなくフォントサイズ自体が大きくなった時)用にスタイルを更新しました。

仕様は #28 を参照ください。

## 通常smallボタン
<img width="100" alt="Screen Shot 2020-11-04 at 7 34 47 PM" src="https://user-images.githubusercontent.com/869023/98101002-fa874080-1ed4-11eb-9e02-fd98a1ffcb2a.png">

## 文字サイズ200%smallボタン
<img width="172" alt="Screen Shot 2020-11-04 at 7 35 10 PM" src="https://user-images.githubusercontent.com/869023/98101051-0bd04d00-1ed5-11eb-8381-5555fdcccb31.png">

## 文字サイズ200%で長いテキストなsmallボタン
<img width="173" alt="Screen Shot 2020-11-04 at 7 35 25 PM" src="https://user-images.githubusercontent.com/869023/98101103-1be82c80-1ed5-11eb-87b8-07fc02d30f56.png">

close #28