### PR TITLE
feat(spindle-ui): add IconButton component

### DIFF
--- a/packages/spindle-ui/src/IconButton/IconButton.css
+++ b/packages/spindle-ui/src/IconButton/IconButton.css
@@ -1,0 +1,85 @@
+/*
+ * IconButton
+*/
+.spui-IconButton {
+  align-items: center;
+  border-radius: 100%;
+  box-sizing: border-box;
+  display: inline-flex;
+  justify-content: center;
+  outline: none;
+  text-align: center;
+  transition: background-color 0.3s;
+}
+
+.spui-IconButton:disabled {
+  opacity: 0.3;
+}
+
+.spui-IconButton:focus {
+  box-shadow: 0 0 0 1px var(--color-surface-primary),
+    0 0 0 3px var(--color-focus-clarity);
+}
+
+/*
+ * IconButton sizes
+*/
+.spui-IconButton--large {
+  font-size: 1.375em;
+  height: 48px;
+  width: 48px;
+}
+
+.spui-IconButton--medium {
+  font-size: 1.25em;
+  height: 40px;
+  width: 40px;
+}
+
+.spui-IconButton--small {
+  font-size: 1em;
+  height: 32px;
+  width: 32px;
+}
+
+.spui-IconButton--exSmall {
+  font-size: 1em;
+  height: 24px;
+  width: 24px;
+}
+
+/*
+ * IconButton variants
+*/
+/* contained */
+.spui-IconButton--contained {
+  background-color: var(--color-surface-accent-primary);
+  border: none;
+  color: var(--color-text-high-emphasis-inverse);
+}
+
+.spui-IconButton--contained:not([disabled]):hover {
+  background-color: var(--primary-green-100);
+}
+
+/* outlined */
+.spui-IconButton--outlined {
+  background-color: var(--color-text-high-emphasis-inverse);
+  border: 2px solid var(--color-surface-accent-primary);
+  color: var(--color-surface-accent-primary);
+}
+
+.spui-IconButton--outlined:not([disabled]):hover {
+  background-color: var(--primary-green-5);
+}
+
+/* neutral */
+.spui-IconButton--neutral {
+  background-color: var(--color-surface-tertiary);
+  border: none;
+  color: var(--color-text-mid-emphasis);
+}
+
+.spui-IconButton--neutral:not([disabled]):hover {
+  background-color: var(--gray-20-alpha);
+}

--- a/packages/spindle-ui/src/IconButton/IconButton.css
+++ b/packages/spindle-ui/src/IconButton/IconButton.css
@@ -16,9 +16,14 @@
   opacity: 0.3;
 }
 
-.spui-IconButton:focus {
+.spui-IconButton:focus,
+.spui-IconButton:focus-visible {
   box-shadow: 0 0 0 1px var(--color-surface-primary),
     0 0 0 3px var(--color-focus-clarity);
+}
+
+.spui-IconButton:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 /*
@@ -71,6 +76,25 @@
 
 .spui-IconButton--outlined:not([disabled]):hover {
   background-color: var(--primary-green-5);
+}
+
+/* lighted */
+.spui-IconButton--lighted {
+  background-color: var(--color-surface-accent-primary-light);
+  border: none;
+  color: var(--color-text-accent-primary);
+  padding-bottom: 8px;
+  padding-top: 8px;
+}
+
+.spui-IconButton--lighted:active {
+  background-color: var(--primary-green-10);
+}
+
+@media (hover: hover) {
+  .spui-IconButton--lighted:not([disabled]):hover {
+    background-color: var(--primary-green-10);
+  }
 }
 
 /* neutral */

--- a/packages/spindle-ui/src/IconButton/IconButton.stories.mdx
+++ b/packages/spindle-ui/src/IconButton/IconButton.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { IconButton } from './IconButton';
 import { PlusBold } from '../Icon';
@@ -6,6 +6,8 @@ import { PlusBold } from '../Icon';
 # Icon Button
 
 <Meta title="IconButton" component={IconButton} />
+
+![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
 
 <Source
   language='javascript'
@@ -156,3 +158,33 @@ import { PlusBold } from '../Icon';
 <button class="spui-IconButton spui-IconButton--medium spui-IconButton--neutral" disabled>+</button>
   `}
 />
+
+## Lighted
+
+![stability-experiment](https://img.shields.io/badge/stability-experiment-red.svg)
+
+<Description>
+  Neutralからの状態変化先のスタイルとして定義しており、単独での利用は推奨していません。Lightedは試験的なVarientであるため、今後に破壊的な変更や削除がおこなわれる可能性があることに注意して利用してください。
+</Description>
+
+<Preview withSource="open">
+  <Story name="Lighted">
+    <IconButton size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<IconButton size="large" variant="lighted">+</IconButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-IconButton spui-IconButton--large spui-IconButton--lighted">+</button>
+  `}
+/>
+
+## Browser Compatibility
+<Description>active時やhover時など各stateのスタイルは、ブラウザごとに異なります。詳しくは[ButtonのStateパターン変更](https://github.com/openameba/spindle/issues/13)を参照してください。</Description>

--- a/packages/spindle-ui/src/IconButton/IconButton.stories.mdx
+++ b/packages/spindle-ui/src/IconButton/IconButton.stories.mdx
@@ -1,0 +1,158 @@
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { actions } from '@storybook/addon-actions';
+import { IconButton } from './IconButton';
+import { PlusBold } from '../Icon';
+
+# Icon Button
+
+<Meta title="IconButton" component={IconButton} />
+
+<Source
+  language='javascript'
+  code={`import { IconButton } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language='css'
+  code={`@import './node_modules/@openameba/spindle-ui/IconButton/IconButton.css'`}
+/>
+
+<Source
+  language='html'
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/IconButton/IconButton.css">`}
+/>
+
+## Large
+
+<Preview withSource="open">
+  <Story name="Large">
+    <IconButton size="large" variant="contained" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<IconButton size="large" variant="contained">+</IconButton>
+<IconButton size="large" variant="outlined">+</IconButton>
+<IconButton size="large" variant="neutral">+</IconButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-IconButton spui-IconButton--large spui-IconButton--contained">+</button>
+<button class="spui-IconButton spui-IconButton--large spui-IconButton--outlined">+</button>
+<button class="spui-IconButton spui-IconButton--large spui-IconButton--neutral">+</button>
+  `}
+/>
+
+## Medium
+
+<Preview withSource="open">
+  <Story name="Medium">
+    <IconButton size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<IconButton size="medium" variant="contained">+</IconButton>
+<IconButton size="medium" variant="outlined">+</IconButton>
+<IconButton size="medium" variant="neutral">+</IconButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-IconButton spui-IconButton--medium spui-IconButton--contained">+</button>
+<button class="spui-IconButton spui-IconButton--medium spui-IconButton--outlined">+</button>
+<button class="spui-IconButton spui-IconButton--medium spui-IconButton--neutral">+</button>
+  `}
+/>
+
+## Small
+
+<Preview withSource="open">
+  <Story name="Small">
+    <IconButton size="small" variant="contained" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<IconButton size="small" variant="contained">+</IconButton>
+<IconButton size="small" variant="outlined">+</IconButton>
+<IconButton size="small" variant="neutral">+</IconButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-IconButton spui-IconButton--small spui-IconButton--contained">+</button>
+<button class="spui-IconButton spui-IconButton--small spui-IconButton--outlined">+</button>
+<button class="spui-IconButton spui-IconButton--small spui-IconButton--neutral">+</button>
+  `}
+/>
+
+## Ex Small
+
+<Preview withSource="open">
+  <Story name="ExSmall">
+    <IconButton size="exSmall" variant="contained" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="exSmall" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="exSmall" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<IconButton size="exSmall" variant="contained">+</IconButton>
+<IconButton size="exSmall" variant="outlined">+</IconButton>
+<IconButton size="exSmall" variant="neutral">+</IconButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-IconButton spui-IconButton--exSmall spui-IconButton--contained">+</button>
+<button class="spui-IconButton spui-IconButton--exSmall spui-IconButton--outlined">+</button>
+<button class="spui-IconButton spui-IconButton--exSmall spui-IconButton--neutral">+</button>
+  `}
+/>
+
+## Disabled
+
+<Preview withSource="open">
+  <Story name="Disabled">
+    <IconButton disabled size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<IconButton disabled size="medium" variant="contained">+</IconButton>
+<IconButton disabled size="medium" variant="outlined">+</IconButton>
+<IconButton disabled size="medium" variant="neutral">+</IconButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-IconButton spui-IconButton--medium spui-IconButton--contained" disabled>+</button>
+<button class="spui-IconButton spui-IconButton--medium spui-IconButton--outlined" disabled>+</button>
+<button class="spui-IconButton spui-IconButton--medium spui-IconButton--neutral" disabled>+</button>
+  `}
+/>

--- a/packages/spindle-ui/src/IconButton/IconButton.test.tsx
+++ b/packages/spindle-ui/src/IconButton/IconButton.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { IconButton } from './IconButton';
+
+describe('<IconButton />', () => {
+  test('click', () => {
+    const onButtonClick = jest.fn();
+
+    render(<IconButton onClick={onButtonClick} />);
+
+    userEvent.click(screen.getByRole('button'));
+    expect(onButtonClick).toBeCalled();
+  });
+});

--- a/packages/spindle-ui/src/IconButton/IconButton.tsx
+++ b/packages/spindle-ui/src/IconButton/IconButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+type Size = 'large' | 'medium' | 'small' | 'exSmall';
+
+type Variant = 'contained' | 'outlined' | 'neutral';
+
+type Props = {
+  size?: Size;
+  variant?: Variant;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+const BLOCK_NAME = 'spui-IconButton';
+
+export const IconButton: React.FC<Props> = ({
+  children,
+  size = 'large',
+  variant = 'contained',
+  ...rest
+}: Props) => {
+  return (
+    <button
+      className={`${BLOCK_NAME} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/spindle-ui/src/IconButton/IconButton.tsx
+++ b/packages/spindle-ui/src/IconButton/IconButton.tsx
@@ -1,28 +1,31 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 type Size = 'large' | 'medium' | 'small' | 'exSmall';
 
 type Variant = 'contained' | 'outlined' | 'neutral';
 
-type Props = {
+interface Props
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'className'> {
+  children?: React.ReactNode;
   size?: Size;
   variant?: Variant;
-} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+}
 
 const BLOCK_NAME = 'spui-IconButton';
 
-export const IconButton: React.FC<Props> = ({
-  children,
-  size = 'large',
-  variant = 'contained',
-  ...rest
-}: Props) => {
-  return (
-    <button
-      className={`${BLOCK_NAME} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
-      {...rest}
-    >
-      {children}
-    </button>
-  );
-};
+export const IconButton = forwardRef<HTMLButtonElement, Props>(
+  function IconButton(
+    { children, size = 'large', variant = 'contained', ...rest }: Props,
+    ref,
+  ) {
+    return (
+      <button
+        className={`${BLOCK_NAME} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  },
+);

--- a/packages/spindle-ui/src/IconButton/index.ts
+++ b/packages/spindle-ui/src/IconButton/index.ts
@@ -1,0 +1,1 @@
+export { IconButton } from './IconButton';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -2,4 +2,5 @@
 @import 'ameba-color-palette.css';
 @import './Button/Button.css';
 @import './Form/index.css';
+@import './IconButton/IconButton.css';
 @import './LinkButton/LinkButton.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -1,7 +1,8 @@
 import { Button } from './Button';
 import * as Form from './Form';
 import * as Icon from './Icon';
+import { IconButton } from './IconButton';
 import { LinkButton } from './LinkButton';
 
 // Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
-export { Button, Form, Icon, LinkButton };
+export { Button, Form, Icon, IconButton, LinkButton };


### PR DESCRIPTION
[`<IconButton>`コンポーネント](https://spindle.ameba.design/57edc1abc/p/89add9-button/b/1952d0/t/807d56)を作成しました。こちらは一つのアイコンが入ることのみ想定したボタンです。

![](https://user-images.githubusercontent.com/869023/98192768-fbfd4b00-1f5e-11eb-925f-09ce83394543.png)
https://ameba-spindle--pr81-feat-icon-button-7xpem25g.web.app/?path=/docs/iconbutton--large

