### PR TITLE
chore: ignore public directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist/
+public/


### PR DESCRIPTION
https://github.com/openameba/spindle/pull/82#pullrequestreview-523924524 に書いた、publicディレクトリをeslintが検査してしまうのを修正するPRです。

```console
$ DEBUG=eslint:file-enumerator yarn run lint:script
```

を実行すると、どのファイルに対して何をしたかが確認できます。