### PR TITLE
feat(spindle-ui): add ButtonGroup component

### DIFF
--- a/packages/spindle-ui/src/ButtonGroup/ButtonGroup.css
+++ b/packages/spindle-ui/src/ButtonGroup/ButtonGroup.css
@@ -1,0 +1,68 @@
+/*
+ * Button Group
+*/
+.spui-ButtonGroup {
+  display: flex;
+}
+
+/* Direction */
+.spui-ButtonGroup--row {
+  flex-direction: row;
+}
+
+.spui-ButtonGroup--column {
+  flex-direction: column;
+}
+
+/* Size */
+
+/* NOTE: gap property should be used in the near future */
+
+/* stylelint-disable plugin/selector-bem-pattern */
+.spui-ButtonGroup--large.spui-ButtonGroup--row > * {
+  margin-right: 16px;
+}
+
+.spui-ButtonGroup--large.spui-ButtonGroup--row > *:last-child {
+  margin-right: 0;
+}
+
+.spui-ButtonGroup--large.spui-ButtonGroup--column > * {
+  margin-bottom: 16px;
+}
+
+.spui-ButtonGroup--large.spui-ButtonGroup--column > *:last-child {
+  margin-bottom: 0;
+}
+
+.spui-ButtonGroup--medium.spui-ButtonGroup--row > * {
+  margin-right: 12px;
+}
+
+.spui-ButtonGroup--medium.spui-ButtonGroup--row > *:last-child {
+  margin-right: 0;
+}
+
+.spui-ButtonGroup--medium.spui-ButtonGroup--column > * {
+  margin-bottom: 12px;
+}
+
+.spui-ButtonGroup--medium.spui-ButtonGroup--column > *:last-child {
+  margin-bottom: 0;
+}
+
+.spui-ButtonGroup--small.spui-ButtonGroup--row > * {
+  margin-right: 8px;
+}
+
+.spui-ButtonGroup--small.spui-ButtonGroup--row > *:last-child {
+  margin-right: 0;
+}
+
+.spui-ButtonGroup--small.spui-ButtonGroup--column > * {
+  margin-bottom: 12px;
+}
+
+.spui-ButtonGroup--small.spui-ButtonGroup--column > *:last-child {
+  margin-bottom: 0;
+}

--- a/packages/spindle-ui/src/ButtonGroup/ButtonGroup.stories.mdx
+++ b/packages/spindle-ui/src/ButtonGroup/ButtonGroup.stories.mdx
@@ -1,0 +1,204 @@
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { ButtonGroup } from './ButtonGroup';
+import { Button } from '../Button';
+
+# Button Group
+
+<Meta title="ButtonGroup" component={ButtonGroup} />
+
+![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
+
+<Source
+  language='javascript'
+  code={`import { ButtonGroup } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language='css'
+  code={`@import './node_modules/@openameba/spindle-ui/ButtonGroup/ButtonGroup.css'`}
+/>
+
+<Source
+  language='html'
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/ButtonGroup/ButtonGroup.css">`}
+/>
+
+## Row Direction with Large Buttons
+
+<Preview withSource="open">
+  <Story name="Row Direction with Large Buttons">
+    <ButtonGroup direction="row" size="large">
+      <Button size="large" variant="contained">Contained</Button>
+      <Button size="large" variant="outlined">Outlined</Button>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="row" size="large">
+  <Button size="large" variant="contained">Contained</Button>
+  <Button size="large" variant="outlined">Outlined</Button>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--row spui-ButtonGroup--large">
+  <button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--large spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Column Direction with Large Buttons
+
+<Preview withSource="open">
+  <Story name="Column Direction with Large Buttons">
+    <ButtonGroup direction="column" size="large">
+      <Button variant="contained">Contained</Button>
+      <Button variant="outlined">Outlined</Button>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="column" size="large">
+  <Button size="large" variant="contained">Contained</Button>
+  <Button size="large" variant="outlined">Outlined</Button>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--large">
+  <button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--large spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Row Direction with Medium Buttons
+
+<Preview withSource="open">
+  <Story name="Row Direction with Medium Buttons">
+    <ButtonGroup direction="row" size="medium">
+      <Button size="medium" variant="contained">Contained</Button>
+      <Button size="medium" variant="outlined">Outlined</Button>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="row" size="medium">
+  <Button size="medium" variant="contained">Contained</Button>
+  <Button size="medium" variant="outlined">Outlined</Button>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--row spui-ButtonGroup--medium">
+  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Column Direction with Medium Buttons
+
+<Preview withSource="open">
+  <Story name="Column Direction with Medium Buttons">
+    <ButtonGroup direction="column" size="medium">
+      <Button size="medium" variant="contained">Contained</Button>
+      <Button size="medium" variant="outlined">Outlined</Button>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="column" size="medium">
+  <Button size="medium" variant="contained">Contained</Button>
+  <Button size="medium" variant="outlined">Outlined</Button>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--medium">
+  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Row Direction with Small Buttons
+
+<Preview withSource="open">
+  <Story name="Row Direction with Small Buttons">
+    <ButtonGroup direction="row" size="small">
+      <Button size="small" variant="contained">Contained</Button>
+      <Button size="small" variant="outlined">Outlined</Button>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="row" size="small">
+  <Button size="small" variant="contained">Contained</Button>
+  <Button size="small" variant="outlined">Outlined</Button>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--row spui-ButtonGroup--small">
+  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Column Direction with Small Buttons
+
+<Preview withSource="open">
+  <Story name="Column Direction with Small Buttons">
+    <ButtonGroup direction="column" size="small">
+      <Button size="small" variant="contained">Contained</Button>
+      <Button size="small" variant="outlined">Outlined</Button>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="column" size="small">
+  <Button size="small" variant="contained">Contained</Button>
+  <Button size="small" variant="outlined">Outlined</Button>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--small">
+  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>

--- a/packages/spindle-ui/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/spindle-ui/src/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+type Direction = 'row' | 'column';
+
+type Size = 'large' | 'medium' | 'small';
+
+type Props = {
+  direction?: Direction;
+  size?: Size;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const BLOCK_NAME = 'spui-ButtonGroup';
+
+export const ButtonGroup: React.FC<Props> = ({
+  children,
+  className,
+  direction = 'row',
+  size = 'large',
+  ...rest
+}: Props) => {
+  const classnames = [
+    BLOCK_NAME,
+    `${BLOCK_NAME}--${direction}`,
+    `${BLOCK_NAME}--${size}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classnames} {...rest}>
+      {children}
+    </div>
+  );
+};

--- a/packages/spindle-ui/src/ButtonGroup/index.ts
+++ b/packages/spindle-ui/src/ButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export { ButtonGroup } from './ButtonGroup';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -1,6 +1,7 @@
 /* stylelint-disable plugin/selector-bem-pattern */
 @import 'ameba-color-palette.css';
 @import './Button/Button.css';
+@import './ButtonGroup/ButtonGroup.css';
 @import './Form/index.css';
 @import './IconButton/IconButton.css';
 @import './LinkButton/LinkButton.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -1,8 +1,9 @@
 import { Button } from './Button';
+import { ButtonGroup } from './ButtonGroup';
 import * as Form from './Form';
 import * as Icon from './Icon';
 import { IconButton } from './IconButton';
 import { LinkButton } from './LinkButton';
 
 // Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
-export { Button, Form, Icon, IconButton, LinkButton };
+export { Button, ButtonGroup, Form, Icon, IconButton, LinkButton };


### PR DESCRIPTION
[ボタンを組み合わせて](https://spindle.ameba.design/57edc1abc/p/89add9-button/b/23f24c)使うときのために、`<ButtonLayout>` コンポーネントを作成しました。

実際どれくらい使われるかは不明ですが、きれいにボタンが並んで便利な感じはします:eyes:

![](https://user-images.githubusercontent.com/869023/98202339-265a0300-1f75-11eb-8c98-3ed25c536f59.png)

