### PR TITLE
chore(spindle-ui): add storybook viewport addon

### DIFF
--- a/packages/spindle-ui/.storybook/main.js
+++ b/packages/spindle-ui/.storybook/main.js
@@ -4,5 +4,6 @@ module.exports = {
     '@storybook/addon-actions',
     '@storybook/addon-a11y',
     '@storybook/addon-docs',
+    '@storybook/addon-viewport',
   ]
 };

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -42,6 +42,7 @@
     "@storybook/addon-a11y": "^6.0.0",
     "@storybook/addon-actions": "^6.0.0",
     "@storybook/addon-docs": "^6.0.28",
+    "@storybook/addon-viewport": "^6.0.28",
     "@storybook/react": "^6.0.0",
     "@svgr/cli": "^5.4.0",
     "@types/chai": "^4.2.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,6 +2978,23 @@
     ts-dedent "^1.1.1"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-viewport@^6.0.28":
+  version "6.0.28"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-6.0.28.tgz#20f096695699c90c1b5ba795ff858a46d4084a10"
+  integrity sha512-I2I6+V0GCtypn0AKw4s1EKHicPqHyQfcM9T7RMbeZIf11Dc71hbbRt9U6kajZ8go84qzXGPm8/Vd0kvDO28WaA==
+  dependencies:
+    "@storybook/addons" "6.0.28"
+    "@storybook/api" "6.0.28"
+    "@storybook/client-logger" "6.0.28"
+    "@storybook/components" "6.0.28"
+    "@storybook/core-events" "6.0.28"
+    "@storybook/theming" "6.0.28"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    prop-types "^15.7.2"
+    regenerator-runtime "^0.13.3"
+
 "@storybook/addons@6.0.26":
   version "6.0.26"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.0.26.tgz#343cbea3eee2d39413b80bc2d66535a7f61488fc"


### PR DESCRIPTION
アプリケーションで使っていくにつれ、横幅の確認も増えてきそうなのでviewportプラグインを入れました。(確か土岐さんもおすすめだったプラグインのはず)

DevTools開かずStorybook上で確認できそうです。

![](https://user-images.githubusercontent.com/869023/98236450-b5cbda00-1fa6-11eb-9a12-c4e0336ed4aa.png)
