### PR TITLE
Button Layout

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -61,7 +61,7 @@
 /*
  * Layout
 */
-.spui-Button--fillWidth {
+.spui-Button--fixed {
   width: 100%;
 }
 

--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -59,6 +59,13 @@
 }
 
 /*
+ * Layout
+*/
+.spui-Button--fillWidth {
+  width: 100%;
+}
+
+/*
  * Button variants
 */
 /* contained */

--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -143,32 +143,32 @@ import { Button } from './Button';
   `}
 />
 
-## Medium With Layout Fill Width
+## Medium With Layout Fixed
 
 <Preview withSource="open">
-  <Story name="Medium With Layout Fill Width">
-    <Button layout="fillWidth" size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button layout="fillWidth" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button layout="fillWidth" size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button layout="fillWidth" size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+  <Story name="Medium With Layout Fixed">
+    <Button layout="fixed" size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
+    <Button layout="fixed" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
+    <Button layout="fixed" size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+    <Button layout="fixed" size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
-<Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
-<Button layout="fillWidth" size="medium" variant="neutral">Neutral</Button>
-<Button layout="fillWidth" size="medium" variant="danger">Danger</Button>
+<Button layout="fixed" size="medium" variant="contained">Contained</Button>
+<Button layout="fixed" size="medium" variant="outlined">Outlined</Button>
+<Button layout="fixed" size="medium" variant="neutral">Neutral</Button>
+<Button layout="fixed" size="medium" variant="danger">Danger</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--contained">Contained</button>
-<button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--outlined">Outlined</button>
-<button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--neutral">Neutral</button>
-<button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--danger">Danger</button>
+<button class="spui-Button spui-Button--fixed spui-Button--medium spui-Button--contained">Contained</button>
+<button class="spui-Button spui-Button--fixed spui-Button--medium spui-Button--outlined">Outlined</button>
+<button class="spui-Button spui-Button--fixed spui-Button--medium spui-Button--neutral">Neutral</button>
+<button class="spui-Button spui-Button--fixed spui-Button--medium spui-Button--danger">Danger</button>
   `}
 />

--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -142,3 +142,33 @@ import { Button } from './Button';
 <button class="spui-Button spui-Button--medium spui-Button--danger" disabled>Danger</button>
   `}
 />
+
+## Medium With Layout Fill Width
+
+<Preview withSource="open">
+  <Story name="Medium With Layout Fill Width">
+    <Button layout="fillWidth" size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
+    <Button layout="fillWidth" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
+    <Button layout="fillWidth" size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+    <Button layout="fillWidth" size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
+<Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
+<Button layout="fillWidth" size="medium" variant="neutral">Neutral</Button>
+<Button layout="fillWidth" size="medium" variant="danger">Danger</Button>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--contained">Contained</button>
+<button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--outlined">Outlined</button>
+<button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--neutral">Neutral</button>
+<button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--danger">Danger</button>
+  `}
+/>

--- a/packages/spindle-ui/src/Button/Button.tsx
+++ b/packages/spindle-ui/src/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-type Layout = 'intrinsic' | 'fillWidth';
+type Layout = 'intrinsic' | 'fixed';
 
 type Size = 'large' | 'medium' | 'small';
 

--- a/packages/spindle-ui/src/Button/Button.tsx
+++ b/packages/spindle-ui/src/Button/Button.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
+type Layout = 'intrinsic' | 'fillWidth';
+
 type Size = 'large' | 'medium' | 'small';
 
 type Variant = 'contained' | 'outlined' | 'neutral' | 'danger';
 
 type Props = {
+  layout?: Layout;
   size?: Size;
   variant?: Variant;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
@@ -13,13 +16,14 @@ const BLOCK_NAME = 'spui-Button';
 
 export const Button: React.FC<Props> = ({
   children,
+  layout = 'intrinsic',
   size = 'large',
   variant = 'contained',
   ...rest
 }: Props) => {
   return (
     <button
-      className={`${BLOCK_NAME} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
+      className={`${BLOCK_NAME} ${BLOCK_NAME}--${layout} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
       {...rest}
     >
       {children}

--- a/packages/spindle-ui/src/ButtonLayout/ButtonLayout.css
+++ b/packages/spindle-ui/src/ButtonLayout/ButtonLayout.css
@@ -1,0 +1,68 @@
+/*
+ * Button Layout
+*/
+.spui-ButtonLayout {
+  display: flex;
+}
+
+/* Direction */
+.spui-ButtonLayout--row {
+  flex-direction: row;
+}
+
+.spui-ButtonLayout--column {
+  flex-direction: column;
+}
+
+/* Size */
+
+/* NOTE: gap property should be used in the near future */
+
+/* stylelint-disable plugin/selector-bem-pattern */
+.spui-ButtonLayout--large.spui-ButtonLayout--row > * {
+  margin-right: 1em;
+}
+
+.spui-ButtonLayout--large.spui-ButtonLayout--row > *:last-child {
+  margin-right: 0;
+}
+
+.spui-ButtonLayout--large.spui-ButtonLayout--column > * {
+  margin-bottom: 1em;
+}
+
+.spui-ButtonLayout--large.spui-ButtonLayout--column > *:last-child {
+  margin-bottom: 0;
+}
+
+.spui-ButtonLayout--medium.spui-ButtonLayout--row > * {
+  margin-right: 0.75em;
+}
+
+.spui-ButtonLayout--medium.spui-ButtonLayout--row > *:last-child {
+  margin-right: 0;
+}
+
+.spui-ButtonLayout--medium.spui-ButtonLayout--column > * {
+  margin-bottom: 0.75em;
+}
+
+.spui-ButtonLayout--medium.spui-ButtonLayout--column > *:last-child {
+  margin-bottom: 0;
+}
+
+.spui-ButtonLayout--small.spui-ButtonLayout--row > * {
+  margin-right: 0.5em;
+}
+
+.spui-ButtonLayout--small.spui-ButtonLayout--row > *:last-child {
+  margin-right: 0;
+}
+
+.spui-ButtonLayout--small.spui-ButtonLayout--column > * {
+  margin-bottom: 0.75em;
+}
+
+.spui-ButtonLayout--small.spui-ButtonLayout--column > *:last-child {
+  margin-bottom: 0;
+}

--- a/packages/spindle-ui/src/ButtonLayout/ButtonLayout.css
+++ b/packages/spindle-ui/src/ButtonLayout/ButtonLayout.css
@@ -2,7 +2,9 @@
  * Button Layout
 */
 .spui-ButtonLayout {
+  align-items: center;
   display: flex;
+  justify-content: center;
 }
 
 /* Direction */

--- a/packages/spindle-ui/src/ButtonLayout/ButtonLayout.stories.mdx
+++ b/packages/spindle-ui/src/ButtonLayout/ButtonLayout.stories.mdx
@@ -21,12 +21,12 @@ import { Button } from '../Button';
   code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/ButtonLayout/ButtonLayout.css">`}
 />
 
-## Single Medium Button With Layout Fill Width
+## Single Medium Button With Layout Fixed
 
 <Preview withSource="open">
-  <Story name="Single Medium Button With Layout Fill Width">
+  <Story name="Single Medium Button With Layout Fixed">
     <ButtonLayout>
-      <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
+      <Button layout="fixed" size="medium" variant="contained">Contained</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -34,7 +34,7 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout>
-  <Button layout="fillWidth" size="large" variant="contained">Contained</Button>
+  <Button layout="fixed" size="large" variant="contained">Contained</Button>
 </ButtonLayout>
   `}
 />
@@ -43,7 +43,7 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout">
-  <button class="spui-Button spui-Button--fillWidth spui-Button--large spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--large spui-Button--contained">Contained</button>
 </div>
   `}
 />
@@ -113,8 +113,8 @@ import { Button } from '../Button';
 <Preview withSource="open">
   <Story name="Row Direction with Medium Buttons">
     <ButtonLayout direction="row" size="medium">
-      <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
-      <Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
+      <Button layout="fixed" size="medium" variant="contained">Contained</Button>
+      <Button layout="fixed" size="medium" variant="outlined">Outlined</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -122,8 +122,8 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout direction="row" size="medium">
-  <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
-  <Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
+  <Button layout="fixed" size="medium" variant="contained">Contained</Button>
+  <Button layout="fixed" size="medium" variant="outlined">Outlined</Button>
 </ButtonLayout>
   `}
 />
@@ -132,8 +132,8 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout spui-ButtonLayout--row spui-ButtonLayout--medium">
-  <button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--medium spui-Button--outlined">Outlined</button>
 </div>
   `}
 />
@@ -143,8 +143,8 @@ import { Button } from '../Button';
 <Preview withSource="open">
   <Story name="Column Direction with Medium Buttons">
     <ButtonLayout direction="column" size="medium">
-      <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
-      <Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
+      <Button layout="fixed" size="medium" variant="contained">Contained</Button>
+      <Button layout="fixed" size="medium" variant="outlined">Outlined</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -152,8 +152,8 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout direction="column" size="medium">
-  <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
-  <Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
+  <Button layout="fixed" size="medium" variant="contained">Contained</Button>
+  <Button layout="fixed" size="medium" variant="outlined">Outlined</Button>
 </ButtonLayout>
   `}
 />
@@ -162,8 +162,8 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout spui-ButtonLayout--column spui-ButtonLayout--medium">
-  <button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--medium spui-Button--outlined">Outlined</button>
 </div>
   `}
 />
@@ -173,8 +173,8 @@ import { Button } from '../Button';
 <Preview withSource="open">
   <Story name="Row Direction with Small Buttons">
     <ButtonLayout direction="row" size="small">
-      <Button layout="fillWidth" size="small" variant="contained">Contained</Button>
-      <Button layout="fillWidth" size="small" variant="outlined">Outlined</Button>
+      <Button layout="fixed" size="small" variant="contained">Contained</Button>
+      <Button layout="fixed" size="small" variant="outlined">Outlined</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -182,8 +182,8 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout direction="row" size="small">
-  <Button layout="fillWidth" size="small" variant="contained">Contained</Button>
-  <Button layout="fillWidth" size="small" variant="outlined">Outlined</Button>
+  <Button layout="fixed" size="small" variant="contained">Contained</Button>
+  <Button layout="fixed" size="small" variant="outlined">Outlined</Button>
 </ButtonLayout>
   `}
 />
@@ -192,8 +192,8 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout spui-ButtonLayout--row spui-ButtonLayout--small">
-  <button class="spui-Button spui-Button--fillWidth spui-Button--small spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--fillWidth spui-Button--small spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--small spui-Button--outlined">Outlined</button>
 </div>
   `}
 />
@@ -203,8 +203,8 @@ import { Button } from '../Button';
 <Preview withSource="open">
   <Story name="Column Direction with Small Buttons">
     <ButtonLayout direction="column" size="small">
-      <Button layout="fillWidth" size="small" variant="contained">Contained</Button>
-      <Button layout="fillWidth" size="small" variant="outlined">Outlined</Button>
+      <Button layout="fixed" size="small" variant="contained">Contained</Button>
+      <Button layout="fixed" size="small" variant="outlined">Outlined</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -212,8 +212,8 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout direction="column" size="small">
-  <Button layout="fillWidth" size="small" variant="contained">Contained</Button>
-  <Button layout="fillWidth" size="small" variant="outlined">Outlined</Button>
+  <Button layout="fixed" size="small" variant="contained">Contained</Button>
+  <Button layout="fixed" size="small" variant="outlined">Outlined</Button>
 </ButtonLayout>
   `}
 />
@@ -222,8 +222,8 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout spui-ButtonLayout--column spui-ButtonLayout--small">
-  <button class="spui-Button spui-Button--fillWidth spui-Button--small spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--fillWidth spui-Button--small spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fixed spui-Button--small spui-Button--outlined">Outlined</button>
 </div>
   `}
 />

--- a/packages/spindle-ui/src/ButtonLayout/ButtonLayout.stories.mdx
+++ b/packages/spindle-ui/src/ButtonLayout/ButtonLayout.stories.mdx
@@ -1,0 +1,202 @@
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { ButtonLayout } from './ButtonLayout';
+import { Button } from '../Button';
+
+# Button Layout
+
+<Meta title="ButtonLayout" component={ButtonLayout} />
+
+<Source
+  language='javascript'
+  code={`import { ButtonLayout } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language='css'
+  code={`@import './node_modules/@openameba/spindle-ui/ButtonLayout/ButtonLayout.css'`}
+/>
+
+<Source
+  language='html'
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/ButtonLayout/ButtonLayout.css">`}
+/>
+
+## Row Direction with Large Buttons
+
+<Preview withSource="open">
+  <Story name="Row Direction with Large Buttons">
+    <ButtonLayout direction="row" size="large">
+      <Button size="large" variant="contained">Contained</Button>
+      <Button size="large" variant="outlined">Outlined</Button>
+    </ButtonLayout>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonLayout direction="row" size="large">
+  <Button size="large" variant="contained">Contained</Button>
+  <Button size="large" variant="outlined">Outlined</Button>
+</ButtonLayout>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonLayout spui-ButtonLayout--row spui-ButtonLayout--large">
+  <button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--large spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Column Direction with Large Buttons
+
+<Preview withSource="open">
+  <Story name="Column Direction with Large Buttons">
+    <ButtonLayout direction="column" size="large">
+      <Button variant="contained">Contained</Button>
+      <Button variant="outlined">Outlined</Button>
+    </ButtonLayout>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonLayout direction="column" size="large">
+  <Button size="large" variant="contained">Contained</Button>
+  <Button size="large" variant="outlined">Outlined</Button>
+</ButtonLayout>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonLayout spui-ButtonLayout--column spui-ButtonLayout--large">
+  <button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--large spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Row Direction with Medium Buttons
+
+<Preview withSource="open">
+  <Story name="Row Direction with Medium Buttons">
+    <ButtonLayout direction="row" size="medium">
+      <Button size="medium" variant="contained">Contained</Button>
+      <Button size="medium" variant="outlined">Outlined</Button>
+    </ButtonLayout>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonLayout direction="row" size="medium">
+  <Button size="medium" variant="contained">Contained</Button>
+  <Button size="medium" variant="outlined">Outlined</Button>
+</ButtonLayout>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonLayout spui-ButtonLayout--row spui-ButtonLayout--medium">
+  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Column Direction with Medium Buttons
+
+<Preview withSource="open">
+  <Story name="Column Direction with Medium Buttons">
+    <ButtonLayout direction="column" size="medium">
+      <Button size="medium" variant="contained">Contained</Button>
+      <Button size="medium" variant="outlined">Outlined</Button>
+    </ButtonLayout>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonLayout direction="column" size="medium">
+  <Button size="medium" variant="contained">Contained</Button>
+  <Button size="medium" variant="outlined">Outlined</Button>
+</ButtonLayout>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonLayout spui-ButtonLayout--column spui-ButtonLayout--medium">
+  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Row Direction with Small Buttons
+
+<Preview withSource="open">
+  <Story name="Row Direction with Small Buttons">
+    <ButtonLayout direction="row" size="small">
+      <Button size="small" variant="contained">Contained</Button>
+      <Button size="small" variant="outlined">Outlined</Button>
+    </ButtonLayout>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonLayout direction="row" size="small">
+  <Button size="small" variant="contained">Contained</Button>
+  <Button size="small" variant="outlined">Outlined</Button>
+</ButtonLayout>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonLayout spui-ButtonLayout--row spui-ButtonLayout--small">
+  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Column Direction with Small Buttons
+
+<Preview withSource="open">
+  <Story name="Column Direction with Small Buttons">
+    <ButtonLayout direction="column" size="small">
+      <Button size="small" variant="contained">Contained</Button>
+      <Button size="small" variant="outlined">Outlined</Button>
+    </ButtonLayout>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonLayout direction="column" size="small">
+  <Button size="small" variant="contained">Contained</Button>
+  <Button size="small" variant="outlined">Outlined</Button>
+</ButtonLayout>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonLayout spui-ButtonLayout--column spui-ButtonLayout--small">
+  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>

--- a/packages/spindle-ui/src/ButtonLayout/ButtonLayout.stories.mdx
+++ b/packages/spindle-ui/src/ButtonLayout/ButtonLayout.stories.mdx
@@ -21,6 +21,33 @@ import { Button } from '../Button';
   code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/ButtonLayout/ButtonLayout.css">`}
 />
 
+## Single Medium Button With Layout Fill Width
+
+<Preview withSource="open">
+  <Story name="Single Medium Button With Layout Fill Width">
+    <ButtonLayout>
+      <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
+    </ButtonLayout>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonLayout>
+  <Button layout="fillWidth" size="large" variant="contained">Contained</Button>
+</ButtonLayout>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonLayout">
+  <button class="spui-Button spui-Button--fillWidth spui-Button--large spui-Button--contained">Contained</button>
+</div>
+  `}
+/>
+
 ## Row Direction with Large Buttons
 
 <Preview withSource="open">
@@ -86,8 +113,8 @@ import { Button } from '../Button';
 <Preview withSource="open">
   <Story name="Row Direction with Medium Buttons">
     <ButtonLayout direction="row" size="medium">
-      <Button size="medium" variant="contained">Contained</Button>
-      <Button size="medium" variant="outlined">Outlined</Button>
+      <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
+      <Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -95,8 +122,8 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout direction="row" size="medium">
-  <Button size="medium" variant="contained">Contained</Button>
-  <Button size="medium" variant="outlined">Outlined</Button>
+  <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
+  <Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
 </ButtonLayout>
   `}
 />
@@ -105,8 +132,8 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout spui-ButtonLayout--row spui-ButtonLayout--medium">
-  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--outlined">Outlined</button>
 </div>
   `}
 />
@@ -116,8 +143,8 @@ import { Button } from '../Button';
 <Preview withSource="open">
   <Story name="Column Direction with Medium Buttons">
     <ButtonLayout direction="column" size="medium">
-      <Button size="medium" variant="contained">Contained</Button>
-      <Button size="medium" variant="outlined">Outlined</Button>
+      <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
+      <Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -125,8 +152,8 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout direction="column" size="medium">
-  <Button size="medium" variant="contained">Contained</Button>
-  <Button size="medium" variant="outlined">Outlined</Button>
+  <Button layout="fillWidth" size="medium" variant="contained">Contained</Button>
+  <Button layout="fillWidth" size="medium" variant="outlined">Outlined</Button>
 </ButtonLayout>
   `}
 />
@@ -135,8 +162,8 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout spui-ButtonLayout--column spui-ButtonLayout--medium">
-  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fillWidth spui-Button--medium spui-Button--outlined">Outlined</button>
 </div>
   `}
 />
@@ -146,8 +173,8 @@ import { Button } from '../Button';
 <Preview withSource="open">
   <Story name="Row Direction with Small Buttons">
     <ButtonLayout direction="row" size="small">
-      <Button size="small" variant="contained">Contained</Button>
-      <Button size="small" variant="outlined">Outlined</Button>
+      <Button layout="fillWidth" size="small" variant="contained">Contained</Button>
+      <Button layout="fillWidth" size="small" variant="outlined">Outlined</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -155,8 +182,8 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout direction="row" size="small">
-  <Button size="small" variant="contained">Contained</Button>
-  <Button size="small" variant="outlined">Outlined</Button>
+  <Button layout="fillWidth" size="small" variant="contained">Contained</Button>
+  <Button layout="fillWidth" size="small" variant="outlined">Outlined</Button>
 </ButtonLayout>
   `}
 />
@@ -165,8 +192,8 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout spui-ButtonLayout--row spui-ButtonLayout--small">
-  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--fillWidth spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fillWidth spui-Button--small spui-Button--outlined">Outlined</button>
 </div>
   `}
 />
@@ -176,8 +203,8 @@ import { Button } from '../Button';
 <Preview withSource="open">
   <Story name="Column Direction with Small Buttons">
     <ButtonLayout direction="column" size="small">
-      <Button size="small" variant="contained">Contained</Button>
-      <Button size="small" variant="outlined">Outlined</Button>
+      <Button layout="fillWidth" size="small" variant="contained">Contained</Button>
+      <Button layout="fillWidth" size="small" variant="outlined">Outlined</Button>
     </ButtonLayout>
   </Story>
 </Preview>
@@ -185,8 +212,8 @@ import { Button } from '../Button';
 <Source
   code={`
 <ButtonLayout direction="column" size="small">
-  <Button size="small" variant="contained">Contained</Button>
-  <Button size="small" variant="outlined">Outlined</Button>
+  <Button layout="fillWidth" size="small" variant="contained">Contained</Button>
+  <Button layout="fillWidth" size="small" variant="outlined">Outlined</Button>
 </ButtonLayout>
   `}
 />
@@ -195,8 +222,8 @@ import { Button } from '../Button';
   language='html'
   code={`
 <div class="spui-ButtonLayout spui-ButtonLayout--column spui-ButtonLayout--small">
-  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--fillWidth spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-Button spui-Button--fillWidth spui-Button--small spui-Button--outlined">Outlined</button>
 </div>
   `}
 />

--- a/packages/spindle-ui/src/ButtonLayout/ButtonLayout.tsx
+++ b/packages/spindle-ui/src/ButtonLayout/ButtonLayout.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+type Direction = 'row' | 'column';
+
+type Size = 'large' | 'medium' | 'small';
+
+type Props = {
+  direction?: Direction;
+  size?: Size;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const BLOCK_NAME = 'spui-ButtonLayout';
+
+export const ButtonLayout: React.FC<Props> = ({
+  children,
+  className,
+  direction = 'row',
+  size = 'large',
+  ...rest
+}: Props) => {
+  const classnames = [
+    BLOCK_NAME,
+    `${BLOCK_NAME}--${direction}`,
+    `${BLOCK_NAME}--${size}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classnames} {...rest}>
+      {children}
+    </div>
+  );
+};

--- a/packages/spindle-ui/src/ButtonLayout/index.ts
+++ b/packages/spindle-ui/src/ButtonLayout/index.ts
@@ -1,0 +1,1 @@
+export { ButtonLayout } from './ButtonLayout';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -1,6 +1,7 @@
 /* stylelint-disable plugin/selector-bem-pattern */
 @import 'ameba-color-palette.css';
 @import './Button/Button.css';
+@import './ButtonLayout/ButtonLayout.css';
 @import './Form/Form.css';
 @import './Form/InputLabel.css';
 @import './Form/TextField.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -1,3 +1,4 @@
 export { Button } from './Button';
+export { ButtonLayout } from './ButtonLayout';
 export * as Form from './Form';
 export * as Icon from './Icon';


### PR DESCRIPTION
`<Button>` にレイアウト情報(今回は横幅固定する`fixed`)を持たせつつ、`<ButtonLayout>`でレイアウトしてみた例。

確認用にドラフトプルリクエストしてプレビューページを作ってみます。
