### PR TITLE
feat(spindle-ui): add full width option to button

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -26,6 +26,13 @@
 }
 
 /*
+ * Button layout
+*/
+.spui-Button--fullWidth {
+  width: 100%;
+}
+
+/*
  * Button sizes
 */
 .spui-Button--large {
@@ -35,13 +42,11 @@
   min-height: 48px;
   padding-left: 16px;
   padding-right: 16px;
-  width: 100%;
 }
 
 .spui-Button--medium {
   border-radius: calc(40em / 18);
   font-size: 18px; /* TODO: Replace relative value (em or rem) */
-  max-width: 240px;
   min-height: 40px;
   min-width: 88px;
   padding-left: 16px;
@@ -51,7 +56,6 @@
 .spui-Button--small {
   border-radius: calc(32em / 13);
   font-size: 13px; /* TODO: Replace relative value (em or rem) */
-  max-width: 160px;
   min-height: 32px;
   min-width: 60px;
   padding-left: 10px;

--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -53,6 +53,36 @@ import { Button } from './Button';
   `}
 />
 
+## Large Full Width
+
+<Preview withSource="open">
+  <Story name="Large Full Width">
+    <Button layout="fullWidth" size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
+    <Button layout="fullWidth" size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
+    <Button layout="fullWidth" size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+    <Button layout="fullWidth" size="large" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Button layout="fullWidth" size="large" variant="contained">Contained</Button>
+<Button layout="fullWidth" size="large" variant="outlined">Outlined</Button>
+<Button layout="fullWidth" size="large" variant="neutral">Neutral</Button>
+<Button layout="fullWidth" size="large" variant="danger">Danger</Button>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained">Contained</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--outlined">Outlined</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--neutral">Neutral</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--danger">Danger</button>
+  `}
+/>
+
 ## Medium
 
 <Preview withSource="open">
@@ -80,6 +110,36 @@ import { Button } from './Button';
 <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
 <button class="spui-Button spui-Button--medium spui-Button--neutral">Neutral</button>
 <button class="spui-Button spui-Button--medium spui-Button--danger">Danger</button>
+  `}
+/>
+
+## Medium Full Width
+
+<Preview withSource="open">
+  <Story name="Medium Full Width">
+    <Button layout="fullWidth" size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
+    <Button layout="fullWidth" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
+    <Button layout="fullWidth" size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+    <Button layout="fullWidth" size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Button layout="fullWidth" size="medium" variant="contained">Contained</Button>
+<Button layout="fullWidth" size="medium" variant="outlined">Outlined</Button>
+<Button layout="fullWidth" size="medium" variant="neutral">Neutral</Button>
+<Button layout="fullWidth" size="medium" variant="danger">Danger</Button>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--contained">Contained</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined">Outlined</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral">Neutral</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger">Danger</button>
   `}
 />
 
@@ -113,6 +173,36 @@ import { Button } from './Button';
   `}
 />
 
+## Small Full Width
+
+<Preview withSource="open">
+  <Story name="Small Full Width">
+    <Button layout="fullWidth" size="small" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
+    <Button layout="fullWidth" size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
+    <Button layout="fullWidth" size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+    <Button layout="fullWidth" size="small" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Button layout="fullWidth" size="small" variant="contained">Contained</Button>
+<Button layout="fullWidth" size="small" variant="outlined">Outlined</Button>
+<Button layout="fullWidth" size="small" variant="neutral">Neutral</Button>
+<Button layout="fullWidth" size="small" variant="danger">Danger</Button>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--contained">Contained</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--outlined">Outlined</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral">Neutral</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--danger">Danger</button>
+  `}
+/>
+
 ## Disabled
 
 <Preview withSource="open">
@@ -140,5 +230,35 @@ import { Button } from './Button';
 <button class="spui-Button spui-Button--medium spui-Button--outlined" disabled>Outlined</button>
 <button class="spui-Button spui-Button--medium spui-Button--neutral" disabled>Neutral</button>
 <button class="spui-Button spui-Button--medium spui-Button--danger" disabled>Danger</button>
+  `}
+/>
+
+## Disabled Full Width
+
+<Preview withSource="open">
+  <Story name="Disabled Full Width">
+    <Button layout="fullWidth" disabled size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
+    <Button layout="fullWidth" disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
+    <Button layout="fullWidth" disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+    <Button layout="fullWidth" disabled size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Button layout="fullWidth" disabled size="medium" variant="contained">Contained</Button>
+<Button layout="fullWidth" disabled size="medium" variant="outlined">Outlined</Button>
+<Button layout="fullWidth" disabled size="medium" variant="neutral">Neutral</Button>
+<Button layout="fullWidth" disabled size="medium" variant="danger">Danger</Button>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--contained" disabled>Contained</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined" disabled>Outlined</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral" disabled>Neutral</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger" disabled>Danger</button>
   `}
 />

--- a/packages/spindle-ui/src/Button/Button.tsx
+++ b/packages/spindle-ui/src/Button/Button.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
+type Layout = 'intrinsic' | 'fullWidth';
+
 type Size = 'large' | 'medium' | 'small';
 
 type Variant = 'contained' | 'outlined' | 'neutral' | 'danger';
 
 type Props = {
+  layout?: Layout;
   size?: Size;
   variant?: Variant;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
@@ -13,13 +16,14 @@ const BLOCK_NAME = 'spui-Button';
 
 export const Button: React.FC<Props> = ({
   children,
+  layout = 'intrinsic',
   size = 'large',
   variant = 'contained',
   ...rest
 }: Props) => {
   return (
     <button
-      className={`${BLOCK_NAME} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
+      className={`${BLOCK_NAME} ${BLOCK_NAME}--${layout} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
       {...rest}
     >
       {children}


### PR DESCRIPTION
https://github.com/openameba/spindle/pull/86#discussion_r518590065 での話し合いで、Buttonはサイズに関わらずmax-widthを持たず、文字サイズに合わせる or コンテナに対して横幅100%指定となりましたので、対応しました。
