### PR TITLE
fix(spindle-ui): button size & weight

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -6,6 +6,8 @@
 */
 .spui-Button {
   box-sizing: border-box;
+  font-family: inherit;
+  font-weight: bold;
   line-height: 1.3;
   outline: none;
   -webkit-tap-highlight-color: var(--Button-tapHighlightColor, --gray-5-alpha);
@@ -37,16 +39,16 @@
 */
 .spui-Button--large {
   /* To be relative value with font size; this means base height / base font size  */
-  border-radius: calc(48em / 18);
-  font-size: 18px; /* TODO: Replace relative value (em or rem) */
+  border-radius: calc(48em / 16);
+  font-size: 16px; /* TODO: Replace relative value (em or rem) */
   min-height: 48px;
   padding-left: 16px;
   padding-right: 16px;
 }
 
 .spui-Button--medium {
-  border-radius: calc(40em / 18);
-  font-size: 18px; /* TODO: Replace relative value (em or rem) */
+  border-radius: calc(40em / 14);
+  font-size: 14px; /* TODO: Replace relative value (em or rem) */
   min-height: 40px;
   min-width: 88px;
   padding-left: 16px;


### PR DESCRIPTION
Buttonのサイズと太さがドキュメントと合っていなかったため修正。
ref: https://spindle.ameba.design/57edc1abc/p/89add9-button/b/1952d0

`font-family` はglobalに指定されるであろう Spindle標準の指定を継承する前提にした。
