### PR TITLE
feat(spindle-ui): add Icon with Text button

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -5,9 +5,12 @@
  * as it is sometimes different from app's color set.
 */
 .spui-Button {
+  align-items: center;
   box-sizing: border-box;
+  display: inline-flex;
   font-family: inherit;
   font-weight: bold;
+  justify-content: center;
   line-height: 1.3;
   outline: none;
   -webkit-tap-highlight-color: var(--Button-tapHighlightColor, --gray-5-alpha);
@@ -182,4 +185,27 @@
       var(--caution-red-5-alpha)
     );
   }
+}
+
+/*
+ * with Icon
+*/
+
+.spui-Button-icon {
+  line-height: 0; /* Fix Icon position align */
+}
+
+.spui-Button-icon--large {
+  font-size: 1.375em; /* Icon 22px / Text 16px = 1.375 */
+  margin-right: 6px;
+}
+
+.spui-Button-icon--medium {
+  font-size: 1.429em; /* Icon 20px / Text 14px =  1.42857142857 */
+  margin-right: 4px;
+}
+
+.spui-Button-icon--small {
+  font-size: 1.23em; /* Icon 16px / Text 13px = 1.23076923077 */
+  margin-right: 2px;
 }

--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { Button } from './Button';
+import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 # Button
 
@@ -260,5 +261,59 @@ import { Button } from './Button';
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined" disabled>Outlined</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral" disabled>Neutral</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger" disabled>Danger</button>
+  `}
+/>
+
+## With Icon
+
+<Preview withSource="open">
+  <Story name="With Icon">
+    <Button icon={<PlusBold/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
+    <Button icon={<ArrowRightBold/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
+    <Button icon={<OpenblankFill/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Button icon={<PlusBold/>} size="large" variant="contained">Contained</Button>
+<Button icon={<ArrowRightBold/>} size="medium" variant="outlined">Outlined</Button>
+<Button icon={<OpenblankFill/>} size="small" variant="neutral">Neutral</Button>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-Button spui-Button--intrinsic spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>Contained</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>Outlined</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>Neutral</button>
+  `}
+/>
+
+## Full Width With Icon
+
+<Preview withSource="open">
+  <Story name="Full Width With Icon">
+    <Button layout="fullWidth" icon={<PlusBold/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
+    <Button layout="fullWidth" icon={<ArrowRightBold/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
+    <Button layout="fullWidth" icon={<OpenblankFill/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Button layout="fullWidth" icon={<PlusBold/>} size="large" variant="contained">Contained</Button>
+<Button layout="fullWidth" icon={<ArrowRightBold/>} size="medium" variant="outlined">Outlined</Button>
+<Button layout="fullWidth" icon={<OpenblankFill/>} size="small" variant="neutral">Neutral</Button>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>Contained</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>Outlined</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>Neutral</button>
   `}
 />

--- a/packages/spindle-ui/src/Button/Button.tsx
+++ b/packages/spindle-ui/src/Button/Button.tsx
@@ -10,6 +10,7 @@ type Props = {
   layout?: Layout;
   size?: Size;
   variant?: Variant;
+  icon?: React.ReactNode;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 const BLOCK_NAME = 'spui-Button';
@@ -19,6 +20,7 @@ export const Button: React.FC<Props> = ({
   layout = 'intrinsic',
   size = 'large',
   variant = 'contained',
+  icon,
   ...rest
 }: Props) => {
   return (
@@ -26,7 +28,16 @@ export const Button: React.FC<Props> = ({
       className={`${BLOCK_NAME} ${BLOCK_NAME}--${layout} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
       {...rest}
     >
-      {children}
+      {icon ? (
+        <>
+          <span className={`${BLOCK_NAME}-icon ${BLOCK_NAME}-icon--${size}`}>
+            {icon}
+          </span>
+          {children}
+        </>
+      ) : (
+        children
+      )}
     </button>
   );
 };


### PR DESCRIPTION
アイコン付きテキストラベルのパターンを実装した。

![image](https://user-images.githubusercontent.com/445333/98388974-c8bdd780-2096-11eb-94f8-d7dfef863e2f.png)
