### PR TITLE
Update color palette to v4

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@types/react": "^16.9.43",
-    "ameba-color-palette.css": "openameba/ameba-color-palette.css#v3.0.0-beta.0",
+    "ameba-color-palette.css": "^4.2.0",
     "react": "^16.13.1"
   },
   "devDependencies": {

--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -138,7 +138,10 @@
     var(--color-surface-tertiary)
   );
   border: none;
-  color: var(--Button--neutral-backgroundColor, var(--color-text-mid-emphasis));
+  color: var(
+    --Button--neutral-backgroundColor,
+    var(--color-text-medium-emphasis)
+  );
   padding-bottom: 8px;
   padding-top: 8px;
 }

--- a/packages/spindle-ui/src/Form/Checkbox.css
+++ b/packages/spindle-ui/src/Form/Checkbox.css
@@ -20,7 +20,7 @@
 }
 
 .spui-Checkbox-icon {
-  border: solid 1px var(--color-border-mid-emphasis);
+  border: solid 1px var(--color-border-medium-emphasis);
   border-radius: 4px;
   box-sizing: border-box;
   display: inline-block;

--- a/packages/spindle-ui/src/Form/InputLabel.css
+++ b/packages/spindle-ui/src/Form/InputLabel.css
@@ -2,7 +2,7 @@
  * InputLabel
 */
 .spui-InputLabel {
-  color: var(--color-text-mid-emphasis);
+  color: var(--color-text-medium-emphasis);
   display: block;
   font-size: 14px;
   font-weight: bold;

--- a/packages/spindle-ui/src/Form/Radio.css
+++ b/packages/spindle-ui/src/Form/Radio.css
@@ -20,7 +20,7 @@
 }
 
 .spui-Radio-icon {
-  border: solid 1px var(--color-border-mid-emphasis);
+  border: solid 1px var(--color-border-medium-emphasis);
   border-radius: 50%;
   box-sizing: border-box;
   display: inline-block;

--- a/packages/spindle-ui/src/Form/TextField.css
+++ b/packages/spindle-ui/src/Form/TextField.css
@@ -3,7 +3,7 @@
 */
 .spui-TextField {
   background-color: var(--color-surface-primary);
-  border: solid 1px var(--color-border-mid-emphasis);
+  border: solid 1px var(--color-border-medium-emphasis);
   border-radius: 8px;
   box-sizing: border-box;
   color: var(--color-text-high-emphasis);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4911,9 +4911,10 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-ameba-color-palette.css@openameba/ameba-color-palette.css#v3.0.0-beta.0:
-  version "3.0.0-beta.0"
-  resolved "https://codeload.github.com/openameba/ameba-color-palette.css/tar.gz/36726138140c4f3f1cb2fa24ea5243ce6611de21"
+ameba-color-palette.css@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.2.0.tgz#e61fb906eb1210368f646b7745f79d1c384c18b4"
+  integrity sha512-5aYbuMY0aXSZjR+ot55SYyLX6cXib5J11AuAiMaMKY+87UawT6515JvPJ3LQxlivxK7/rA14+qnFuLTnLmDFNQ==
 
 analyze-desumasu-dearu@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
ameba-color-palette.cssをv4にあげました。v3.0.0-beta.0からのアップデートだったので、`v3.0.0-beta.1`の変更点も対応しました。
https://github.com/openameba/ameba-color-palette.css/releases/tag/v3.0.0-beta.1