### PR TITLE
chore(spindle-ui): gitignore files for npm

### DIFF
--- a/packages/spindle-ui/.gitignore
+++ b/packages/spindle-ui/.gitignore
@@ -73,3 +73,13 @@ public
 
 # storing directory for reg-suit and storycap
 .reg-suit
+
+# components for npm
+*/*.css
+*/*.js
+*/*.d.ts
+*/*.map
+index.css
+index.js
+index.d.ts
+index*.map


### PR DESCRIPTION
[リリース後に自動でつくるPRにnpm用に移動したコンポーネントファイルが含まれてしまっていた](https://github.com/openameba/spindle/pull/95/files)ので、`.gitignore`に追加しコミットに含まれないようにしました。ローカルでビルドを試した場合にも同様にgit管理されないようになります。
