### PR TITLE
chore: ignore merge commit to detect changes with lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,6 +5,7 @@
   "packages": [
     "packages/*"
   ],
+  "includeMergedTags": true,
   "command": {
     "version": {
       "message": "chore(release): publish",


### PR DESCRIPTION
[ファイルに変更がないのに、変更のあるパッケージとして扱われてしまう現象](https://github.com/openameba/spindle/pull/96)を解決するために、[include-merged-tags](https://github.com/lerna/lerna/tree/main/commands/version#--include-merged-tags)を追加してmerge commitが含まれる(つまり変更点の取得時に無視される)対応をしました。

ローカルmainブランチにて

変更前
```
$ npx lerna changed
lerna notice cli v3.22.1
lerna info versioning independent
lerna info Assuming all packages changed
@openameba/spindle-icons
@openameba/spindle-ui
lerna success found 2 packages ready to publish
```

変更後
```
npx lerna changed
lerna notice cli v3.22.1
lerna info versioning independent
lerna info Looking for changed packages since @openameba/spindle-icons@0.6.0
@openameba/spindle-ui
lerna success found 1 package ready to publish
```
