### PR TITLE
chore(spindle-ui): add index.html to sample page

### DIFF
--- a/examples/css-modules/index.html
+++ b/examples/css-modules/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Spindle CSS Modules Example</title>
+  </head>
+  <body>
+    <script src="./dist/main.js"></script>
+  </body>
+</html>

--- a/examples/css-modules/package.json
+++ b/examples/css-modules/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "webpack",
-    "serve": "npx serve dist",
+    "serve": "npx serve ./",
     "test": "echo ok"
   },
   "license": "MIT",

--- a/examples/styled-components/index.html
+++ b/examples/styled-components/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Spindle styled-component Example</title>
+  </head>
+  <body>
+    <script src="./dist/main.js"></script>
+  </body>
+</html>

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "webpack",
-    "serve": "npx serve dist",
+    "serve": "npx serve ./",
     "test": "echo ok"
   },
   "license": "MIT",


### PR DESCRIPTION
styled-componentとCSS Modulesをserveしたときにわかりやすいよう `index.html` を追加。