### PR TITLE
Thinking of IE 🤔

### DIFF
--- a/packages/spindle-ui/.storybook/preview-head.html
+++ b/packages/spindle-ui/.storybook/preview-head.html
@@ -3,3 +3,4 @@
     font-family: Meiryo, Yu Gothic Medium, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   }
 </style>
+<script>window.MSInputMethodContext && document.documentMode && document.write('<script src="https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js"><\x2fscript>');</script>

--- a/packages/spindle-ui/README.md
+++ b/packages/spindle-ui/README.md
@@ -44,6 +44,9 @@ export function SomeButton() {
 @import 'node_modules/@openameba/spindle-ui/Form/Checkbox.css';
 ```
 
+## ブラウザサポート
+Spindle UIはFirefox、Google Chrome、Microsoft Edge、Safariの最新版とInternet Explorer 11で動作確認しています。ただし、CSS custom propertiesを使用しているため、Internet Explorer 11での利用時には[ie11-custom-properties](https://www.npmjs.com/package/ie11-custom-properties)や[css-vars-ponyfill](https://github.com/jhildenbiddle/css-vars-ponyfill)などpolyfillとの併用が必要です。
+
 ## 開発方法
 
 ```

--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -68,6 +68,18 @@
 }
 
 /*
+ * Setting height to a value less then min-height fixes the align-items: center issue in IE11
+ * @see https://github.com/philipwalton/flexbugs/issues/231#issue-245848315
+*/
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .spui-Button--large,
+  .spui-Button--medium,
+  .spui-Button--small {
+    height: 1px;
+  }
+}
+
+/*
  * Button variants
 */
 /* contained */

--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { Button } from './Button';
 import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
@@ -317,3 +317,6 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 <button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>Neutral</button>
   `}
 />
+
+## Browser Compatibility
+<Description>active時やhover時など各stateのスタイルは、ブラウザごとに異なります。詳しくは[ButtonのStateパターン変更](https://github.com/openameba/spindle/issues/13)を参照してください。</Description>


### PR DESCRIPTION
実プロジェクトで利用するに当たり、IE11でも使えたほうが良いということでいくつか対応をしました。

- StorybookにIE11だけCSS custom propertiesのpolyfillを追加しました 89c9aa843e3d7346ea036dfa320705b4e1b62d55
- ブラウザサポートをドキュメント化しました 22f007e03b50608b0abbccfbb811256c4fad3d53
- IE11で`align-items: center` と`min-height`を併用すると中央配置されない問題を解決しました 6fc6a1380cface288f80d23b4f6e60f17c196b6a

## 確認すること
StorybookのボタンをIE11で確認します。

### Before
![Screen Shot 2020-11-17 at 2 37 35 PM](https://user-images.githubusercontent.com/869023/99351126-3f52a480-28e3-11eb-8987-d04b71048225.png)

### After
![Screen Shot 2020-11-17 at 2 07 18 PM](https://user-images.githubusercontent.com/869023/99350223-31038900-28e1-11eb-901b-63ba07074f03.png)

close #103