### PR TITLE
chore: set base branch to create PR after releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
+          base: main
           branch: release/chores-into-default-branch
           delete-branch: true
           title: 'chore(release): publish'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          base: main
+          base: ${{ github.event.push.repository.default_branch }}
           branch: release/chores-into-default-branch
           delete-branch: true
           title: 'chore(release): publish'


### PR DESCRIPTION
たびたび恐縮ですが、[baseブランチとの差分がなくてPRが作成されない](https://github.com/openameba/spindle/runs/1421936302?check_suite_focus=true#step:11:56)ので、明示的に`main`ブランチを指定しました。

この動作はおそらく以下の機能によるものだと思います。

> If an updated pull request no longer differs from its base it will automatically be closed and the pull request branch deleted.
https://github.com/peter-evans/create-pull-request/blob/master/docs/updating.md#new-features-1