### PR TITLE
feat(spindle-ui): set focus style with focus-visible

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -19,9 +19,14 @@
   opacity: 0.3;
 }
 
-.spui-Button:focus {
+.spui-Button:focus,
+.spui-Button:focus-visible {
   box-shadow: 0 0 0 1px var(--color-surface-primary),
     0 0 0 3px var(--color-focus-clarity);
+}
+
+.spui-Button:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 /*

--- a/packages/spindle-ui/src/Form/Checkbox.css
+++ b/packages/spindle-ui/src/Form/Checkbox.css
@@ -57,8 +57,13 @@
 }
 
 /* box-shadow is used to apply border-radius as outline */
-.spui-Checkbox-input:focus ~ .spui-Checkbox-outline {
+.spui-Checkbox-input:focus ~ .spui-Checkbox-outline,
+.spui-Checkbox-input:focus-visible ~ .spui-Checkbox-outline {
   box-shadow: 0 0 0 2px var(--color-focus-clarity);
+}
+
+.spui-Checkbox-input:focus:not(:focus-visible) ~ .spui-Checkbox-outline {
+  box-shadow: none;
 }
 
 .spui-Checkbox-text:not(:empty) {

--- a/packages/spindle-ui/src/Form/DropDown.css
+++ b/packages/spindle-ui/src/Form/DropDown.css
@@ -69,9 +69,15 @@
   width: 100%;
 }
 
-.spui-DropDown-select:focus ~ .spui-DropDown-outline {
+.spui-DropDown-select:focus ~ .spui-DropDown-outline,
+.spui-DropDown-select:focus-visible ~ .spui-DropDown-outline {
   border-color: var(--color-border-high-emphasis);
   box-shadow: 0 0 0 3px var(--color-focus-ambiguous);
+}
+
+.spui-DropDown-select:focus:not(:focus-visible) ~ .spui-DropDown-outline {
+  border-color: var(--color-border-medium-emphasis);
+  box-shadow: none;
 }
 
 .spui-DropDown-label.is-error .spui-DropDown-visual,

--- a/packages/spindle-ui/src/Form/Radio.css
+++ b/packages/spindle-ui/src/Form/Radio.css
@@ -58,8 +58,13 @@
 }
 
 /* box-shadow is used to apply border-radius as outline */
-.spui-Radio-input:focus ~ .spui-Radio-outline {
+.spui-Radio-input:focus ~ .spui-Radio-outline,
+.spui-Radio-input:focus-visible ~ .spui-Radio-outline {
   box-shadow: 0 0 0 2px var(--color-focus-clarity);
+}
+
+.spui-Radio-input:focus:not(:focus-visible) ~ .spui-Radio-outline {
+  box-shadow: none;
 }
 
 .spui-Radio-text:not(:empty) {

--- a/packages/spindle-ui/src/Form/TextArea.css
+++ b/packages/spindle-ui/src/Form/TextArea.css
@@ -21,9 +21,15 @@
   color: var(--color-text-disabled);
 }
 
-.spui-TextArea:focus {
+.spui-TextArea:focus,
+.spui-TextArea:focus-visible {
   border-color: var(--color-border-high-emphasis);
   box-shadow: 0 0 0 3px var(--color-focus-ambiguous);
+}
+
+.spui-TextArea:focus:not(:focus-visible) {
+  border-color: var(--color-border-medium-emphasis);
+  box-shadow: none;
 }
 
 .spui-TextArea.is-error {

--- a/packages/spindle-ui/src/Form/TextField.css
+++ b/packages/spindle-ui/src/Form/TextField.css
@@ -19,9 +19,15 @@
   color: var(--color-text-disabled);
 }
 
-.spui-TextField:focus {
+.spui-TextField:focus,
+.spui-TextField:focus-visible {
   border-color: var(--color-border-high-emphasis);
   box-shadow: 0 0 0 3px var(--color-focus-ambiguous);
+}
+
+.spui-TextField:focus:not(:focus-visible) {
+  border-color: var(--color-border-medium-emphasis);
+  box-shadow: none;
 }
 
 .spui-TextField.is-error {

--- a/packages/spindle-ui/src/Form/ToggleSwitch.css
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.css
@@ -73,6 +73,12 @@
 }
 
 /* box-shadow is used to apply border-radius as outline */
-.spui-ToggleSwitch-input:focus ~ .spui-ToggleSwitch-outline {
+.spui-ToggleSwitch-input:focus ~ .spui-ToggleSwitch-outline,
+.spui-ToggleSwitch-input:focus-visible ~ .spui-ToggleSwitch-outline {
   box-shadow: 0 0 0 2px var(--color-focus-clarity);
+}
+
+.spui-ToggleSwitch-input:focus:not(:focus-visible)
+  ~ .spui-ToggleSwitch-outline {
+  box-shadow: none;
 }


### PR DESCRIPTION
フォーカススタイルを[:focus-visibleに対応しているブラウザ](https://caniuse.com/css-focus-visible)にはそちらで、対応していないブラウザには今まで通り:focusで指定するように変更しました。

確認するときは実際タップ、タブ移動して見る他、Chrome DevToolsの「Force element state」機能がおすすめです。
![Screen Shot 2020-11-27 at 5 49 47 PM](https://user-images.githubusercontent.com/869023/100430213-cff66500-30d9-11eb-9cde-af75cce88eb5.png)
