### PR TITLE
chore(spindle-ui): install React as peerDependencies

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -33,10 +33,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@types/react": "^16.8.6 || ^17.0.0",
+    "react": "^16.8.0 || ^17.0.0"
+  },
   "dependencies": {
-    "@types/react": "^16.9.43",
-    "ameba-color-palette.css": "^4.2.0",
-    "react": "^16.13.1"
+    "ameba-color-palette.css": "^4.2.0"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,7 +4393,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.43":
+"@types/react@*":
   version "16.9.43"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
   integrity sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==
@@ -16560,7 +16560,7 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@^16.13.1, react@^16.8.3:
+react@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
`<DropDown>`でHooksを使うようになったので、互換性のあるReactバージョンで利用できるようにしました。

事前に動作確認したい場合は、読み込み元のプロジェクトで以下のように設定します。

```
yarn add herablog/spindle#chore/peer
```

```TypeScript
import { DropDown } from 'spindle/dist0/Form';

// 必要であればCSSも読み込む

export function SomeFunc() {
  return (<DropDown><option>A</option></DropDown>);
}

```