### PR TITLE
feat(spindle-ui): add LinkButton

### DIFF
--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -1,0 +1,180 @@
+/*
+ * LinkButton
+*/
+.spui-LinkButton {
+  align-items: center;
+  box-sizing: border-box;
+  display: inline-flex;
+  font-family: inherit;
+  font-weight: bold;
+  justify-content: center;
+  line-height: 1.3;
+  outline: none;
+  -webkit-tap-highlight-color: var(--gray-5-alpha);
+  text-align: center;
+  text-decoration: none;
+  transition: background-color 0.3s;
+}
+
+.spui-LinkButton:focus,
+.spui-LinkButton:focus-visible {
+  box-shadow: 0 0 0 1px var(--color-surface-primary),
+    0 0 0 3px var(--color-focus-clarity);
+}
+
+.spui-LinkButton:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+/*
+ * Layout
+*/
+.spui-LinkButton--fullWidth {
+  width: 100%;
+}
+
+/*
+ * Sizes
+*/
+.spui-LinkButton--large {
+  /* To be relative value with font size; this means base height / base font size  */
+  border-radius: calc(48em / 16);
+  font-size: 1em;
+  min-height: 48px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.spui-LinkButton--medium {
+  border-radius: calc(40em / 14);
+  font-size: 0.875em;
+  min-height: 40px;
+  min-width: 88px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.spui-LinkButton--small {
+  border-radius: calc(32em / 13);
+  font-size: 0.8125em;
+  min-height: 32px;
+  min-width: 60px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+/*
+ * Setting height to a value less then min-height fixes the align-items: center issue in IE11
+ * @see https://github.com/philipwalton/flexbugs/issues/231#issue-245848315
+*/
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .spui-LinkButton--large,
+  .spui-LinkButton--medium,
+  .spui-LinkButton--small {
+    height: 1px;
+  }
+}
+
+/*
+ * Variants
+*/
+/* contained */
+.spui-LinkButton--contained {
+  background-color: var(--color-surface-accent-primary);
+  border: none;
+  color: var(--color-text-high-emphasis-inverse);
+  /* Button variants have different vertical padding to normalize height */
+  padding-bottom: 8px;
+  padding-top: 8px;
+}
+
+.spui-LinkButton--contained:active {
+  background-color: var(--primary-green-100);
+}
+
+@media (hover: hover) {
+  .spui-LinkButton--contained:hover {
+    background-color: var(--primary-green-100);
+  }
+}
+
+/* outlined */
+.spui-LinkButton--outlined {
+  background-color: var(--color-text-high-emphasis-inverse);
+  border: 2px solid var(--color-surface-accent-primary);
+  color: var(--color-surface-accent-primary);
+  padding-bottom: 6px;
+  padding-top: 6px;
+}
+
+.spui-LinkButton--outlined:active {
+  background-color: var(--primary-green-5);
+}
+
+@media (hover: hover) {
+  .spui-LinkButton--outlined:hover {
+    background-color: var(--primary-green-5);
+  }
+}
+
+/* neutral */
+.spui-LinkButton--neutral {
+  background-color: var(--color-surface-tertiary);
+  border: none;
+  color: var(--color-text-medium-emphasis);
+  padding-bottom: 8px;
+  padding-top: 8px;
+}
+
+.spui-LinkButton--neutral:active {
+  background-color: var(--gray-20-alpha);
+}
+
+@media (hover: hover) {
+  .spui-LinkButton--neutral:hover {
+    background-color: var(--gray-20-alpha);
+  }
+}
+
+/* danger */
+.spui-LinkButton--danger {
+  background-color: var(--color-text-high-emphasis-inverse);
+
+  border: 2px solid var(--color-text-caution);
+  color: var(--color-text-caution);
+  padding-bottom: 6px;
+  padding-top: 6px;
+}
+
+.spui-LinkButton--danger:active {
+  background-color: var(--caution-red-5-alpha);
+}
+
+@media (hover: hover) {
+  .spui-LinkButton--danger:hover {
+    background-color: var(--caution-red-5-alpha);
+  }
+}
+
+/*
+ * with Icon
+*/
+
+.spui-LinkButton-icon {
+  line-height: 0; /* Fix Icon position align */
+}
+
+.spui-LinkButton-icon--large {
+  font-size: 1.375em; /* Icon 22px / Text 16px = 1.375 */
+  margin-right: 6px;
+}
+
+.spui-LinkButton-icon--medium {
+  font-size: 1.429em; /* Icon 20px / Text 14px =  1.42857142857 */
+  margin-right: 4px;
+}
+
+.spui-LinkButton-icon--small {
+  font-size: 1.23em; /* Icon 16px / Text 13px = 1.23076923077 */
+  margin-right: 2px;
+}

--- a/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
@@ -1,0 +1,262 @@
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { actions } from '@storybook/addon-actions';
+import { LinkButton } from './LinkButton';
+import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
+
+# LinkButton
+
+<Meta title="LinkButton" component={LinkButton} />
+
+![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
+
+<Source
+  language='javascript'
+  code={`import { LinkButton } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language='css'
+  code={`@import './node_modules/@openameba/spindle-ui/LinkButton/LinkButton.css'`}
+/>
+
+<Source
+  language='html'
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/LinkButton/LinkButton.css">`}
+/>
+
+## Large
+
+<Preview withSource="open">
+  <Story name="Large">
+    <LinkButton href="#" size="large" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
+    <LinkButton href="#" size="large" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
+    <LinkButton href="#" size="large" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+    <LinkButton href="#" size="large" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<LinkButton href="#" size="large" variant="contained">Contained</LinkButton>
+<LinkButton href="#" size="large" variant="outlined">Outlined</LinkButton>
+<LinkButton href="#" size="large" variant="neutral">Neutral</LinkButton>
+<LinkButton href="#" size="large" variant="danger">Danger</LinkButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--contained" href="#">Contained</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--outlined" href="#">Outlined</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--neutral" href="#">Neutral</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--danger" href="#">Danger</a>
+  `}
+/>
+
+## Large Full Width
+
+<Preview withSource="open">
+  <Story name="Large Full Width">
+    <LinkButton href="#" layout="fullWidth" size="large" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="large" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="large" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="large" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<LinkButton href="#" layout="fullWidth" size="large" variant="contained">Contained</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="large" variant="outlined">Outlined</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="large" variant="neutral">Neutral</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="large" variant="danger">Danger</LinkButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained" href="#">Contained</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--outlined" href="#">Outlined</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--neutral" href="#">Neutral</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--danger" href="#">Danger</a>
+  `}
+/>
+
+## Medium
+
+<Preview withSource="open">
+  <Story name="Medium">
+    <LinkButton href="#" size="medium" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
+    <LinkButton href="#" size="medium" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
+    <LinkButton href="#" size="medium" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+    <LinkButton href="#" size="medium" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<LinkButton href="#" size="medium" variant="contained">Contained</LinkButton>
+<LinkButton href="#" size="medium" variant="outlined">Outlined</LinkButton>
+<LinkButton href="#" size="medium" variant="neutral">Neutral</LinkButton>
+<LinkButton href="#" size="medium" variant="danger">Danger</LinkButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--contained" href="#">Contained</a>
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--outlined" href="#">Outlined</a>
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--neutral" href="#">Neutral</a>
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--danger" href="#">Danger</a>
+  `}
+/>
+
+## Medium Full Width
+
+<Preview withSource="open">
+  <Story name="Medium Full Width">
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<LinkButton href="#" layout="fullWidth" size="medium" variant="contained">Contained</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="medium" variant="outlined">Outlined</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="medium" variant="neutral">Neutral</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="medium" variant="danger">Danger</LinkButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--contained" href="#">Contained</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#">Outlined</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--neutral" href="#">Neutral</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--danger" href="#">Danger</a>
+  `}
+/>
+
+## Small
+
+<Preview withSource="open">
+  <Story name="Small">
+    <LinkButton href="#" size="small" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
+    <LinkButton href="#" size="small" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
+    <LinkButton href="#" size="small" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+    <LinkButton href="#" size="small" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<LinkButton href="#" size="small" variant="contained">Contained</LinkButton>
+<LinkButton href="#" size="small" variant="outlined">Outlined</LinkButton>
+<LinkButton href="#" size="small" variant="neutral">Neutral</LinkButton>
+<LinkButton href="#" size="small" variant="danger">Danger</LinkButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--contained" href="#">Contained</a>
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--outlined" href="#">Outlined</a>
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--neutral" href="#">Neutral</a>
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--danger" href="#">Danger</a>
+  `}
+/>
+
+## Small Full Width
+
+<Preview withSource="open">
+  <Story name="Small Full Width">
+    <LinkButton href="#" layout="fullWidth" size="small" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="small" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="small" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="small" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<LinkButton href="#" layout="fullWidth" size="small" variant="contained">Contained</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="small" variant="outlined">Outlined</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="small" variant="neutral">Neutral</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="small" variant="danger">Danger</LinkButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--contained" href="#">Contained</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--outlined" href="#">Outlined</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#">Neutral</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--danger" href="#">Danger</a>
+  `}
+/>
+
+## With Icon
+
+<Preview withSource="open">
+  <Story name="With Icon">
+    <LinkButton href="#" icon={<PlusBold/>} size="large" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
+    <LinkButton href="#" icon={<ArrowRightBold/>} size="medium" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
+    <LinkButton href="#" icon={<OpenblankFill/>} size="small" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<LinkButton href="#" icon={<PlusBold/>} size="large" variant="contained">Contained</LinkButton>
+<LinkButton href="#" icon={<ArrowRightBold/>} size="medium" variant="outlined">Outlined</LinkButton>
+<LinkButton href="#" icon={<OpenblankFill/>} size="small" variant="neutral">Neutral</LinkButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>Contained</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>Outlined</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>Neutral</a>
+  `}
+/>
+
+## Full Width With Icon
+
+<Preview withSource="open">
+  <Story name="Full Width With Icon">
+    <LinkButton href="#" layout="fullWidth" icon={<PlusBold/>} size="large" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
+    <LinkButton href="#" layout="fullWidth" icon={<ArrowRightBold/>} size="medium" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
+    <LinkButton href="#" layout="fullWidth" icon={<OpenblankFill/>} size="small" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<LinkButton href="#" layout="fullWidth" icon={<PlusBold/>} size="large" variant="contained">Contained</LinkButton>
+<LinkButton href="#" layout="fullWidth" icon={<ArrowRightBold/>} size="medium" variant="outlined">Outlined</LinkButton>
+<LinkButton href="#" layout="fullWidth" icon={<OpenblankFill/>} size="small" variant="neutral">Neutral</LinkButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>Contained</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>Outlined</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>Neutral</a>
+  `}
+/>
+
+## Browser Compatibility
+<Description>active時やhover時など各stateのスタイルは、ブラウザごとに異なります。詳しくは[ButtonのStateパターン変更](https://github.com/openameba/spindle/issues/13)を参照してください。</Description>

--- a/packages/spindle-ui/src/LinkButton/LinkButton.tsx
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.tsx
@@ -1,0 +1,49 @@
+import React, { forwardRef } from 'react';
+
+type Layout = 'intrinsic' | 'fullWidth';
+
+type Size = 'large' | 'medium' | 'small';
+
+type Variant = 'contained' | 'outlined' | 'neutral' | 'danger';
+
+type Props = {
+  layout?: Layout;
+  size?: Size;
+  variant?: Variant;
+  icon?: React.ReactNode;
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'className'>;
+
+const BLOCK_NAME = 'spui-LinkButton';
+
+export const LinkButton = forwardRef<HTMLAnchorElement, Props>(
+  function LinkButton(
+    {
+      children,
+      layout = 'intrinsic',
+      size = 'large',
+      variant = 'contained',
+      icon,
+      ...rest
+    }: Props,
+    ref,
+  ) {
+    return (
+      <a
+        className={`${BLOCK_NAME} ${BLOCK_NAME}--${layout} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
+        ref={ref}
+        {...rest}
+      >
+        {icon ? (
+          <>
+            <span className={`${BLOCK_NAME}-icon ${BLOCK_NAME}-icon--${size}`}>
+              {icon}
+            </span>
+            {children}
+          </>
+        ) : (
+          children
+        )}
+      </a>
+    );
+  },
+);

--- a/packages/spindle-ui/src/LinkButton/index.ts
+++ b/packages/spindle-ui/src/LinkButton/index.ts
@@ -1,0 +1,1 @@
+export { LinkButton } from './LinkButton';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -2,3 +2,4 @@
 @import 'ameba-color-palette.css';
 @import './Button/Button.css';
 @import './Form/index.css';
+@import './LinkButton/LinkButton.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -1,6 +1,7 @@
 import { Button } from './Button';
 import * as Form from './Form';
 import * as Icon from './Icon';
+import { LinkButton } from './LinkButton';
 
 // Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
-export { Button, Form, Icon };
+export { Button, Form, Icon, LinkButton };


### PR DESCRIPTION
Buttonのスタイルを`<a>`要素で使いたい要望があるので、`<LinkButton>`として用意することにしました。 w/ @hiloki 

`<Button>` の中で分岐したり共通化できる部分はありそうですが、微妙に動作が異なるのと1コンポーネント毎に独立して管理する方向で進めたいので、あらたな1コンポーネントとして定義しています。
(共通化はあきらかに必要になったタイミングで進めたいと思います)

`<Button>`と異なり、`<LinkButton>`には`disabled`の機能は用意されていません。

また、同時進行されている #113  #117  #118 の内容も含まれています。
