### PR TITLE
feat(spindle-ui): forward ref to interactive components

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -38,7 +38,8 @@
     "react": "^16.8.0 || ^17.0.0"
   },
   "dependencies": {
-    "ameba-color-palette.css": "^4.2.0"
+    "ameba-color-palette.css": "^4.2.0",
+    "react-merge-refs": "^1.1.0"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.1.10",

--- a/packages/spindle-ui/src/Button/Button.test.tsx
+++ b/packages/spindle-ui/src/Button/Button.test.tsx
@@ -13,4 +13,12 @@ describe('<Button />', () => {
     userEvent.click(screen.getByRole('button'));
     expect(onButtonClick).toBeCalled();
   });
+
+  test('forward ref', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+
+    render(<Button ref={ref} />);
+
+    expect(screen.getByRole('button')).toEqual(ref.current);
+  });
 });

--- a/packages/spindle-ui/src/Button/Button.tsx
+++ b/packages/spindle-ui/src/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 type Layout = 'intrinsic' | 'fullWidth';
 
@@ -15,17 +15,21 @@ type Props = {
 
 const BLOCK_NAME = 'spui-Button';
 
-export const Button: React.FC<Props> = ({
-  children,
-  layout = 'intrinsic',
-  size = 'large',
-  variant = 'contained',
-  icon,
-  ...rest
-}: Props) => {
+export const Button = forwardRef<HTMLButtonElement, Props>(function Button(
+  {
+    children,
+    layout = 'intrinsic',
+    size = 'large',
+    variant = 'contained',
+    icon,
+    ...rest
+  }: Props,
+  ref,
+) {
   return (
     <button
       className={`${BLOCK_NAME} ${BLOCK_NAME}--${layout} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
+      ref={ref}
       {...rest}
     >
       {icon ? (
@@ -40,4 +44,4 @@ export const Button: React.FC<Props> = ({
       )}
     </button>
   );
-};
+});

--- a/packages/spindle-ui/src/Button/Button.tsx
+++ b/packages/spindle-ui/src/Button/Button.tsx
@@ -6,12 +6,14 @@ type Size = 'large' | 'medium' | 'small';
 
 type Variant = 'contained' | 'outlined' | 'lighted' | 'neutral' | 'danger';
 
-type Props = {
+interface Props
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'className'> {
+  children?: React.ReactNode;
   layout?: Layout;
   size?: Size;
   variant?: Variant;
   icon?: React.ReactNode;
-} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'className'>; // Layout styles should be added at containers
+}
 
 const BLOCK_NAME = 'spui-Button';
 

--- a/packages/spindle-ui/src/Form/Checkbox.test.tsx
+++ b/packages/spindle-ui/src/Form/Checkbox.test.tsx
@@ -18,4 +18,12 @@ describe('<Checkbox />', () => {
     userEvent.click(screen.getByRole('checkbox'));
     expect(screen.getByRole('checkbox')).toBeChecked();
   });
+
+  test('forward ref', () => {
+    const ref = React.createRef<HTMLInputElement>();
+
+    render(<Checkbox ref={ref} />);
+
+    expect(screen.getByRole('checkbox')).toEqual(ref.current);
+  });
 });

--- a/packages/spindle-ui/src/Form/Checkbox.tsx
+++ b/packages/spindle-ui/src/Form/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { CheckBold } from '../Icon';
 
@@ -6,10 +6,18 @@ type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // 
 
 const BLOCK_NAME = 'spui-Checkbox';
 
-export const Checkbox: React.FC<Props> = ({ children, ...rest }: Props) => {
+export const Checkbox = forwardRef<HTMLInputElement, Props>(function Checkbox(
+  { children, ...rest }: Props,
+  ref,
+) {
   return (
     <label className={`${BLOCK_NAME}-label`}>
-      <input className={`${BLOCK_NAME}-input`} type="checkbox" {...rest} />
+      <input
+        className={`${BLOCK_NAME}-input`}
+        ref={ref}
+        type="checkbox"
+        {...rest}
+      />
       <span className={`${BLOCK_NAME}-icon`}>
         <CheckBold aria-hidden="true" />
       </span>
@@ -17,4 +25,4 @@ export const Checkbox: React.FC<Props> = ({ children, ...rest }: Props) => {
       {children && <span className={`${BLOCK_NAME}-text`}>{children}</span>}
     </label>
   );
-};
+});

--- a/packages/spindle-ui/src/Form/Checkbox.tsx
+++ b/packages/spindle-ui/src/Form/Checkbox.tsx
@@ -2,7 +2,10 @@ import React, { forwardRef } from 'react';
 
 import { CheckBold } from '../Icon';
 
-type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // Layout styles should be added at containers
+interface Props
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'> {
+  children?: React.ReactNode;
+}
 
 const BLOCK_NAME = 'spui-Checkbox';
 

--- a/packages/spindle-ui/src/Form/DropDown.test.tsx
+++ b/packages/spindle-ui/src/Form/DropDown.test.tsx
@@ -32,4 +32,18 @@ describe('<DropDown />', () => {
     userEvent.selectOptions(screen.getByRole('combobox'), 'c');
     expect(onChange).toBeCalled();
   });
+
+  test('forward ref', () => {
+    const ref = React.createRef<HTMLSelectElement>();
+
+    render(
+      <DropDown ref={ref}>
+        <option value="a">A</option>
+        <option value="b">B</option>
+        <option value="c">C</option>
+      </DropDown>,
+    );
+
+    expect(screen.getByRole('combobox')).toEqual(ref.current);
+  });
 });

--- a/packages/spindle-ui/src/Form/DropDown.tsx
+++ b/packages/spindle-ui/src/Form/DropDown.tsx
@@ -3,9 +3,12 @@ import mergeRefs from 'react-merge-refs';
 
 import { ChevronDownBold } from '../Icon';
 
-type Props = {
+interface Props
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'className'> {
+  children?: React.ReactNode;
   hasError?: boolean;
-} & Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'className'>; // Layout styles should be added at containers
+  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+}
 
 const BLOCK_NAME = 'spui-DropDown';
 

--- a/packages/spindle-ui/src/Form/DropDown.tsx
+++ b/packages/spindle-ui/src/Form/DropDown.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import mergeRefs from 'react-merge-refs';
 
 import { ChevronDownBold } from '../Icon';
 
@@ -8,12 +9,10 @@ type Props = {
 
 const BLOCK_NAME = 'spui-DropDown';
 
-export const DropDown: React.FC<Props> = ({
-  children,
-  hasError = false,
-  onChange,
-  ...rest
-}: Props) => {
+export const DropDown = forwardRef<HTMLSelectElement, Props>(function DropDown(
+  { children, hasError = false, onChange, ...rest }: Props,
+  ref,
+) {
   const selectEl = useRef<HTMLSelectElement>(null);
 
   const [text, setText] = useState('');
@@ -56,7 +55,7 @@ export const DropDown: React.FC<Props> = ({
       </span>
       <select
         className={`${BLOCK_NAME}-select`}
-        ref={selectEl}
+        ref={mergeRefs([selectEl, ref])}
         onChange={handleChange}
         {...rest}
       >
@@ -65,4 +64,4 @@ export const DropDown: React.FC<Props> = ({
       <span className={`${BLOCK_NAME}-outline`}></span>
     </label>
   );
-};
+});

--- a/packages/spindle-ui/src/Form/InputLabel.tsx
+++ b/packages/spindle-ui/src/Form/InputLabel.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
-type Props = {
+interface Props
+  extends Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'className'> {
+  children?: React.ReactNode;
   id: string;
-} & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'className'>; // Layout styles should be added at containers
+}
 
 const BLOCK_NAME = 'spui-InputLabel';
 

--- a/packages/spindle-ui/src/Form/InvalidMessage.tsx
+++ b/packages/spindle-ui/src/Form/InvalidMessage.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 
 import { ExclamationmarkCircleFill } from '../Icon';
 
-type Props = {
+interface Props
+  extends Omit<React.HTMLAttributes<HTMLParagraphElement>, 'className'> {
+  children?: React.ReactNode;
   visible?: boolean;
-} & Omit<React.HTMLAttributes<HTMLParagraphElement>, 'className'>; // Layout styles should be added at containers
+}
 
 const BLOCK_NAME = 'spui-InvalidMessage';
 

--- a/packages/spindle-ui/src/Form/Radio.test.tsx
+++ b/packages/spindle-ui/src/Form/Radio.test.tsx
@@ -18,4 +18,12 @@ describe('<Radio />', () => {
     userEvent.click(screen.getByRole('radio'));
     expect(screen.getByRole('radio')).toBeChecked();
   });
+
+  test('forward ref', () => {
+    const ref = React.createRef<HTMLInputElement>();
+
+    render(<Radio id="test" ref={ref} />);
+
+    expect(screen.getByRole('radio')).toEqual(ref.current);
+  });
 });

--- a/packages/spindle-ui/src/Form/Radio.tsx
+++ b/packages/spindle-ui/src/Form/Radio.tsx
@@ -2,9 +2,11 @@ import React, { forwardRef } from 'react';
 
 import { CheckBold } from '../Icon';
 
-type Props = {
+interface Props
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'> {
+  children?: React.ReactNode;
   id: string;
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // Layout styles should be added at containers
+}
 
 const BLOCK_NAME = 'spui-Radio';
 

--- a/packages/spindle-ui/src/Form/Radio.tsx
+++ b/packages/spindle-ui/src/Form/Radio.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { CheckBold } from '../Icon';
 
@@ -8,14 +8,19 @@ type Props = {
 
 const BLOCK_NAME = 'spui-Radio';
 
-export const Radio: React.FC<Props> = ({
-  children,
-  id = '',
-  ...rest
-}: Props) => {
+export const Radio = forwardRef<HTMLInputElement, Props>(function Radio(
+  { children, id = '', ...rest }: Props,
+  ref,
+) {
   return (
     <label className={`${BLOCK_NAME}-label`} htmlFor={id}>
-      <input className={`${BLOCK_NAME}-input`} id={id} type="radio" {...rest} />
+      <input
+        className={`${BLOCK_NAME}-input`}
+        id={id}
+        ref={ref}
+        type="radio"
+        {...rest}
+      />
       <span className={`${BLOCK_NAME}-icon`}>
         <CheckBold aria-hidden="true" />
       </span>
@@ -23,4 +28,4 @@ export const Radio: React.FC<Props> = ({
       {children && <span className={`${BLOCK_NAME}-text`}>{children}</span>}
     </label>
   );
-};
+});

--- a/packages/spindle-ui/src/Form/TextArea.test.tsx
+++ b/packages/spindle-ui/src/Form/TextArea.test.tsx
@@ -11,4 +11,12 @@ describe('<TextArea />', () => {
     userEvent.type(screen.getByRole('textbox'), 'Hello,{enter}World!');
     expect(screen.getByRole('textbox')).toHaveValue('Hello,\nWorld!');
   });
+
+  test('forward ref', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+
+    render(<TextArea id="text" ref={ref} />);
+
+    expect(screen.getByRole('textbox')).toEqual(ref.current);
+  });
 });

--- a/packages/spindle-ui/src/Form/TextArea.tsx
+++ b/packages/spindle-ui/src/Form/TextArea.tsx
@@ -1,9 +1,11 @@
 import React, { forwardRef } from 'react';
 
-type Props = {
+interface Props
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'className'> {
+  children?: React.ReactNode;
   hasError?: boolean;
   id: string;
-} & Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'className'>; // Layout styles should be added at containers
+}
 
 const BLOCK_NAME = 'spui-TextArea';
 

--- a/packages/spindle-ui/src/Form/TextArea.tsx
+++ b/packages/spindle-ui/src/Form/TextArea.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 type Props = {
   hasError?: boolean;
@@ -7,19 +7,20 @@ type Props = {
 
 const BLOCK_NAME = 'spui-TextArea';
 
-export const TextArea: React.FC<Props> = ({
-  children,
-  hasError = false,
-  id = '',
-  ...rest
-}: Props) => {
-  return (
-    <textarea
-      className={[`${BLOCK_NAME}`, hasError ? 'is-error' : ''].join(' ')}
-      id={id}
-      {...rest}
-    >
-      {children}
-    </textarea>
-  );
-};
+export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
+  function TextArea(
+    { children, hasError = false, id = '', ...rest }: Props,
+    ref,
+  ) {
+    return (
+      <textarea
+        className={[`${BLOCK_NAME}`, hasError ? 'is-error' : ''].join(' ')}
+        id={id}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </textarea>
+    );
+  },
+);

--- a/packages/spindle-ui/src/Form/TextField.test.tsx
+++ b/packages/spindle-ui/src/Form/TextField.test.tsx
@@ -11,4 +11,12 @@ describe('<TextField />', () => {
     userEvent.type(screen.getByRole('textbox'), 'Hello, World!');
     expect(screen.getByRole('textbox')).toHaveValue('Hello, World!');
   });
+
+  test('forward ref', () => {
+    const ref = React.createRef<HTMLInputElement>();
+
+    render(<TextField id="text" ref={ref} />);
+
+    expect(screen.getByRole('textbox')).toEqual(ref.current);
+  });
 });

--- a/packages/spindle-ui/src/Form/TextField.tsx
+++ b/packages/spindle-ui/src/Form/TextField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 type Variant = 'large' | 'medium';
 
@@ -10,12 +10,10 @@ type Props = {
 
 const BLOCK_NAME = 'spui-TextField';
 
-export const TextField: React.FC<Props> = ({
-  hasError = false,
-  id = '',
-  variant = 'medium',
-  ...rest
-}: Props) => {
+export const TextField = forwardRef<HTMLInputElement, Props>(function TextField(
+  { hasError = false, id = '', variant = 'medium', ...rest }: Props,
+  ref,
+) {
   return (
     <input
       className={[
@@ -24,7 +22,8 @@ export const TextField: React.FC<Props> = ({
         hasError ? 'is-error' : '',
       ].join(' ')}
       id={id}
+      ref={ref}
       {...rest}
     />
   );
-};
+});

--- a/packages/spindle-ui/src/Form/TextField.tsx
+++ b/packages/spindle-ui/src/Form/TextField.tsx
@@ -2,11 +2,12 @@ import React, { forwardRef } from 'react';
 
 type Variant = 'large' | 'medium';
 
-type Props = {
+interface Props
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'> {
   hasError?: boolean;
   id: string;
   variant?: Variant; // to avoid duplication; <input> has size attribute
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // Layout styles should be added at containers
+}
 
 const BLOCK_NAME = 'spui-TextField';
 

--- a/packages/spindle-ui/src/Form/ToggleSwitch.test.tsx
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { ToggleSwitch } from './ToggleSwitch';
+
+describe('<ToggleSwitch />', () => {
+  test('forward ref', () => {
+    const ref = React.createRef<HTMLInputElement>();
+
+    render(<ToggleSwitch id="test" ref={ref} />);
+
+    expect(screen.getByRole('checkbox')).toEqual(ref.current);
+  });
+});

--- a/packages/spindle-ui/src/Form/ToggleSwitch.tsx
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 type Props = {
   id: string;
@@ -6,17 +6,20 @@ type Props = {
 
 const BLOCK_NAME = 'spui-ToggleSwitch';
 
-export const ToggleSwitch: React.FC<Props> = ({ id = '', ...rest }: Props) => {
-  return (
-    <label className={BLOCK_NAME}>
-      <input
-        className={`${BLOCK_NAME}-input`}
-        id={id}
-        type="checkbox"
-        {...rest}
-      />
-      <span className={`${BLOCK_NAME}-visual`}></span>
-      <span className={`${BLOCK_NAME}-outline`}></span>
-    </label>
-  );
-};
+export const ToggleSwitch = forwardRef<HTMLInputElement, Props>(
+  function ToggleSwitch({ id = '', ...rest }: Props, ref) {
+    return (
+      <label className={BLOCK_NAME}>
+        <input
+          className={`${BLOCK_NAME}-input`}
+          id={id}
+          ref={ref}
+          type="checkbox"
+          {...rest}
+        />
+        <span className={`${BLOCK_NAME}-visual`}></span>
+        <span className={`${BLOCK_NAME}-outline`}></span>
+      </label>
+    );
+  },
+);

--- a/packages/spindle-ui/src/Form/ToggleSwitch.tsx
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.tsx
@@ -1,8 +1,9 @@
 import React, { forwardRef } from 'react';
 
-type Props = {
+interface Props
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'> {
   id: string;
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // Layout styles should be added at containers
+}
 
 const BLOCK_NAME = 'spui-ToggleSwitch';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16297,6 +16297,11 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-merge-refs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
+  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+
 react-popper-tooltip@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz#329569eb7b287008f04fcbddb6370452ad3f9eac"


### PR DESCRIPTION
BREAKING CHANGE: Components have different behavior after using React.forwardRef
https://reactjs.org/docs/forwarding-refs.html

---

後回しにしていた[Forwarding Refs対応](https://reactjs.org/docs/forwarding-refs.html)をしました。利用プロジェクトが増えつつあるので、早めに対応しておこうという意図になります。

本来はBREAKING CHANGEでメジャーバージョンを上げるべきですが、

> Spindle UIは試験開発中のため、大幅に変更される可能性があります。安定版リリースまでの間はバージョン番号は0となり、バージョンに関わらずbreaking changeが行われることがありますので、利用時には注意してください。
https://github.com/openameba/spindle/blob/main/packages/spindle-ui/README.md

のため、同一メジャーバージョンでリリース予定です。(そろそろ仕様・利用法が固まりそうなので、もろもろ含めてv1になるかも)