### PR TITLE
refactor(spindle-ui): omit className from props in atomic components

### DIFF
--- a/packages/spindle-ui/src/Button/Button.tsx
+++ b/packages/spindle-ui/src/Button/Button.tsx
@@ -11,7 +11,7 @@ type Props = {
   size?: Size;
   variant?: Variant;
   icon?: React.ReactNode;
-} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-Button';
 

--- a/packages/spindle-ui/src/Form/Checkbox.tsx
+++ b/packages/spindle-ui/src/Form/Checkbox.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { CheckBold } from '../Icon';
 
-type Props = React.InputHTMLAttributes<HTMLInputElement>;
+type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-Checkbox';
 

--- a/packages/spindle-ui/src/Form/DropDown.tsx
+++ b/packages/spindle-ui/src/Form/DropDown.tsx
@@ -4,7 +4,7 @@ import { ChevronDownBold } from '../Icon';
 
 type Props = {
   hasError?: boolean;
-} & React.SelectHTMLAttributes<HTMLSelectElement>;
+} & Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-DropDown';
 

--- a/packages/spindle-ui/src/Form/InputLabel.tsx
+++ b/packages/spindle-ui/src/Form/InputLabel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Props = {
   id: string;
-} & React.LabelHTMLAttributes<HTMLLabelElement>;
+} & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-InputLabel';
 

--- a/packages/spindle-ui/src/Form/InvalidMessage.tsx
+++ b/packages/spindle-ui/src/Form/InvalidMessage.tsx
@@ -4,7 +4,7 @@ import { ExclamationmarkCircleFill } from '../Icon';
 
 type Props = {
   visible?: boolean;
-} & React.HTMLAttributes<HTMLParagraphElement>;
+} & Omit<React.HTMLAttributes<HTMLParagraphElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-InvalidMessage';
 

--- a/packages/spindle-ui/src/Form/Radio.tsx
+++ b/packages/spindle-ui/src/Form/Radio.tsx
@@ -4,7 +4,7 @@ import { CheckBold } from '../Icon';
 
 type Props = {
   id: string;
-} & React.InputHTMLAttributes<HTMLInputElement>;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-Radio';
 

--- a/packages/spindle-ui/src/Form/TextArea.tsx
+++ b/packages/spindle-ui/src/Form/TextArea.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 type Props = {
   hasError?: boolean;
   id: string;
-} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+} & Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-TextArea';
 

--- a/packages/spindle-ui/src/Form/TextField.tsx
+++ b/packages/spindle-ui/src/Form/TextField.tsx
@@ -6,7 +6,7 @@ type Props = {
   hasError?: boolean;
   id: string;
   variant?: Variant; // to avoid duplication; <input> has size attribute
-} & React.InputHTMLAttributes<HTMLInputElement>;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-TextField';
 

--- a/packages/spindle-ui/src/Form/ToggleSwitch.tsx
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Props = {
   id: string;
-} & React.InputHTMLAttributes<HTMLInputElement>;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'>; // Layout styles should be added at containers
 
 const BLOCK_NAME = 'spui-ToggleSwitch';
 


### PR DESCRIPTION
#115 の対応で、`className`を受け取らないコンポーネントは、TS利用時に分かるように変更しました。

`Omit`で対応してみたけど、他にいい方法あるかしら🤔

close #115