### PR TITLE
refactor(spindle-ui): export components for project using TS < v3.8

### DIFF
--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -1,3 +1,6 @@
-export { Button } from './Button';
-export * as Form from './Form';
-export * as Icon from './Icon';
+import { Button } from './Button';
+import * as Form from './Form';
+import * as Icon from './Icon';
+
+// Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
+export { Button, Form, Icon };


### PR DESCRIPTION
読み込み元のプロジェクトがTypeScript 3.8未満だと`export * as` が解決できないので、より広範囲のバージョンで使える記法に変更します。

(今回対応の部分に関しては新記法使うメリットもあまりないため)
