### PR TITLE
Outlined Buttonの背景を透過にする

### DIFF
--- a/packages/spindle-ui/.storybook/main.js
+++ b/packages/spindle-ui/.storybook/main.js
@@ -3,6 +3,7 @@ module.exports = {
   addons: [
     '@storybook/addon-actions',
     '@storybook/addon-a11y',
+    '@storybook/addon-backgrounds',
     '@storybook/addon-docs',
     '@storybook/addon-viewport',
   ]

--- a/packages/spindle-ui/.storybook/preview.js
+++ b/packages/spindle-ui/.storybook/preview.js
@@ -2,3 +2,27 @@ import { addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 
 addDecorator(withA11y);
+
+export const parameters = {
+  backgrounds: {
+    default: 'Surface Primary',
+    values: [
+      {
+        name: 'Background Color',
+        value: '#F5F6F6',
+      },
+      {
+        name: 'Surface Primary',
+        value: '#FFFFFF',
+      },
+      {
+        name: 'Surface Secondary',
+        value: 'rgba(8,18,26,0.04)',
+      },
+      {
+        name: 'Background Color Dark',
+        value: '#08121A'
+      }
+    ],
+  },
+};

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@storybook/addon-a11y": "^6.0.0",
     "@storybook/addon-actions": "^6.0.0",
+    "@storybook/addon-backgrounds": "^6.1.9",
     "@storybook/addon-docs": "^6.0.28",
     "@storybook/addon-viewport": "^6.0.28",
     "@storybook/react": "^6.0.0",

--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -98,7 +98,7 @@
 
 /* outlined */
 .spui-Button--outlined {
-  background-color: var(--color-text-high-emphasis-inverse);
+  background-color: transparent;
   border: 2px solid var(--color-surface-accent-primary);
   color: var(--color-surface-accent-primary);
   padding-bottom: 6px;
@@ -136,8 +136,7 @@
 
 /* danger */
 .spui-Button--danger {
-  background-color: var(--color-text-high-emphasis-inverse);
-
+  background-color: transparent;
   border: 2px solid var(--color-text-caution);
   color: var(--color-text-caution);
   padding-bottom: 6px;

--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -100,7 +100,7 @@
 
 /* outlined */
 .spui-LinkButton--outlined {
-  background-color: var(--color-text-high-emphasis-inverse);
+  background-color: transparent;
   border: 2px solid var(--color-surface-accent-primary);
   color: var(--color-surface-accent-primary);
   padding-bottom: 6px;
@@ -138,8 +138,7 @@
 
 /* danger */
 .spui-LinkButton--danger {
-  background-color: var(--color-text-high-emphasis-inverse);
-
+  background-color: transparent;
   border: 2px solid var(--color-text-caution);
   color: var(--color-text-caution);
   padding-bottom: 6px;


### PR DESCRIPTION
# 概要

デザイン仕様ではOutlined Buttonの背景は透過なので対応した。

# 変更内容
- Outlined Buttonの `background-color` を `transparent` に
- 背景色ごとのテストのため、Storybookに[BackgroundのAddon](https://storybook.js.org/docs/react/essentials/backgrounds)追加
![image](https://user-images.githubusercontent.com/445333/100727836-1adde880-340a-11eb-9107-299f0d9844cd.png)

