### PR TITLE
chore: apply frozen-lockfile to lerna bootstrap in CI

### DIFF
--- a/.github/workflows/build-icon.yml
+++ b/.github/workflows/build-icon.yml
@@ -24,7 +24,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn bootstrap
+      - run: npx lerna bootstrap -- --frozen-lockfile
       - name: Update UI catalog
         env:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn bootstrap
+      - run: npx lerna bootstrap -- --frozen-lockfile
       # Build application to check if the system works or not
       # TODO: Build script for spindle-icon should be added
       - name: build application

--- a/.github/workflows/deploy-ui-catalog.yml
+++ b/.github/workflows/deploy-ui-catalog.yml
@@ -24,7 +24,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn bootstrap
+      - run: npx lerna bootstrap -- --frozen-lockfile
       - name: Update UI catalog
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -24,7 +24,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn bootstrap
+      - run: npx lerna bootstrap -- --frozen-lockfile
       - run: npx lerna run --scope @openameba/spindle-ui storybook:build
       - run: |
           npx lerna add --scope @openameba/spindle-ui --dev reg-keygen-git-hash-plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn bootstrap
+      - run: npx lerna bootstrap -- --frozen-lockfile
       - name: Set git user
         run: |
           git config --global user.email "<>"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,5 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn bootstrap
+      - run: npx lerna bootstrap -- --frozen-lockfile
       - run: yarn test


### PR DESCRIPTION
[lerna bootstrap内部の`yarn install`で不必要なyarn.lock差分が出てしまっていた](https://github.com/openameba/spindle/runs/1484909092?check_suite_focus=true)ので、CI上では、常に`--frozen-lockfile`が適用されるように変更しました。
