### PR TITLE
fix(spindle-ui): avoid inaccurate type in LinkButton

### DIFF
--- a/packages/spindle-ui/src/LinkButton/LinkButton.tsx
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.tsx
@@ -6,12 +6,14 @@ type Size = 'large' | 'medium' | 'small';
 
 type Variant = 'contained' | 'outlined' | 'neutral' | 'danger';
 
-type Props = {
+interface Props
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'className'> {
+  children?: React.ReactNode;
   layout?: Layout;
   size?: Size;
   variant?: Variant;
   icon?: React.ReactNode;
-} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'className'>;
+}
 
 const BLOCK_NAME = 'spui-LinkButton';
 


### PR DESCRIPTION
`type`で`Omit`と`forwardRef `併用すると`Pick<>....`と変換されてしまうので`interface`に変更しました。どっちみち`Props`は`interface`にしようかなと思っていたので、他のコンポーネントも別で変更予定です。(このパターンに該当するのは現状`<LinkButton>`だけ)

<details>
<summary>type</summary>

```TypeScript
import React from 'react';
export declare const LinkButton: React.ForwardRefExoticComponent<{
    layout?: "intrinsic" | "fullWidth" | undefined;
    size?: "small" | "medium" | "large" | undefined;
    variant?: "contained" | "outlined" | "neutral" | "danger" | undefined;
    icon?: React.ReactNode;
} & Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, "media" | "hidden" | "dir" | "slot" | "style" | "title" | "color" | "children" | "type" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "suppressHydrationWarning" | "accessKey" | "contentEditable" | "contextMenu" | "draggable" | "id" | "lang" | "placeholder" | "spellCheck" | "tabIndex" | "translate" | "radioGroup" | "role" | "about" | "datatype" | "inlist" | "prefix" | "property" | "resource" | "typeof" | "vocab" | "autoCapitalize" | "autoCorrect" | "autoSave" | "itemProp" | "itemScope" | "itemType" | "itemID" | "itemRef" | "results" | "security" | "unselectable" | "inputMode" | "is" | "aria-activedescendant" | "aria-atomic" | "aria-autocomplete" | "aria-busy" | "aria-checked" | "aria-colcount" | "aria-colindex" | "aria-colspan" | "aria-controls" | "aria-current" | "aria-describedby" | "aria-details" | "aria-disabled" | "aria-dropeffect" | "aria-errormessage" | "aria-expanded" | "aria-flowto" | "aria-grabbed" | "aria-haspopup" | "aria-hidden" | "aria-invalid" | "aria-keyshortcuts" | "aria-label" | "aria-labelledby" | "aria-level" | "aria-live" | "aria-modal" | "aria-multiline" | "aria-multiselectable" | "aria-orientation" | "aria-owns" | "aria-placeholder" | "aria-posinset" | "aria-pressed" | "aria-readonly" | "aria-relevant" | "aria-required" | "aria-roledescription" | "aria-rowcount" | "aria-rowindex" | "aria-rowspan" | "aria-selected" | "aria-setsize" | "aria-sort" | "aria-valuemax" | "aria-valuemin" | "aria-valuenow" | "aria-valuetext" | "dangerouslySetInnerHTML" | "onCopy" | "onCopyCapture" | "onCut" | "onCutCapture" | "onPaste" | "onPasteCapture" | "onCompositionEnd" | "onCompositionEndCapture" | "onCompositionStart" | "onCompositionStartCapture" | "onCompositionUpdate" | "onCompositionUpdateCapture" | "onFocus" | "onFocusCapture" | "onBlur" | "onBlurCapture" | "onChange" | "onChangeCapture" | "onBeforeInput" | "onBeforeInputCapture" | "onInput" | "onInputCapture" | "onReset" | "onResetCapture" | "onSubmit" | "onSubmitCapture" | "onInvalid" | "onInvalidCapture" | "onLoad" | "onLoadCapture" | "onError" | "onErrorCapture" | "onKeyDown" | "onKeyDownCapture" | "onKeyPress" | "onKeyPressCapture" | "onKeyUp" | "onKeyUpCapture" | "onAbort" | "onAbortCapture" | "onCanPlay" | "onCanPlayCapture" | "onCanPlayThrough" | "onCanPlayThroughCapture" | "onDurationChange" | "onDurationChangeCapture" | "onEmptied" | "onEmptiedCapture" | "onEncrypted" | "onEncryptedCapture" | "onEnded" | "onEndedCapture" | "onLoadedData" | "onLoadedDataCapture" | "onLoadedMetadata" | "onLoadedMetadataCapture" | "onLoadStart" | "onLoadStartCapture" | "onPause" | "onPauseCapture" | "onPlay" | "onPlayCapture" | "onPlaying" | "onPlayingCapture" | "onProgress" | "onProgressCapture" | "onRateChange" | "onRateChangeCapture" | "onSeeked" | "onSeekedCapture" | "onSeeking" | "onSeekingCapture" | "onStalled" | "onStalledCapture" | "onSuspend" | "onSuspendCapture" | "onTimeUpdate" | "onTimeUpdateCapture" | "onVolumeChange" | "onVolumeChangeCapture" | "onWaiting" | "onWaitingCapture" | "onAuxClick" | "onAuxClickCapture" | "onClick" | "onClickCapture" | "onContextMenu" | "onContextMenuCapture" | "onDoubleClick" | "onDoubleClickCapture" | "onDrag" | "onDragCapture" | "onDragEnd" | "onDragEndCapture" | "onDragEnter" | "onDragEnterCapture" | "onDragExit" | "onDragExitCapture" | "onDragLeave" | "onDragLeaveCapture" | "onDragOver" | "onDragOverCapture" | "onDragStart" | "onDragStartCapture" | "onDrop" | "onDropCapture" | "onMouseDown" | "onMouseDownCapture" | "onMouseEnter" | "onMouseLeave" | "onMouseMove" | "onMouseMoveCapture" | "onMouseOut" | "onMouseOutCapture" | "onMouseOver" | "onMouseOverCapture" | "onMouseUp" | "onMouseUpCapture" | "onSelect" | "onSelectCapture" | "onTouchCancel" | "onTouchCancelCapture" | "onTouchEnd" | "onTouchEndCapture" | "onTouchMove" | "onTouchMoveCapture" | "onTouchStart" | "onTouchStartCapture" | "onPointerDown" | "onPointerDownCapture" | "onPointerMove" | "onPointerMoveCapture" | "onPointerUp" | "onPointerUpCapture" | "onPointerCancel" | "onPointerCancelCapture" | "onPointerEnter" | "onPointerEnterCapture" | "onPointerLeave" | "onPointerLeaveCapture" | "onPointerOver" | "onPointerOverCapture" | "onPointerOut" | "onPointerOutCapture" | "onGotPointerCapture" | "onGotPointerCaptureCapture" | "onLostPointerCapture" | "onLostPointerCaptureCapture" | "onScroll" | "onScrollCapture" | "onWheel" | "onWheelCapture" | "onAnimationStart" | "onAnimationStartCapture" | "onAnimationEnd" | "onAnimationEndCapture" | "onAnimationIteration" | "onAnimationIterationCapture" | "onTransitionEnd" | "onTransitionEndCapture" | "download" | "href" | "hrefLang" | "ping" | "rel" | "target" | "referrerPolicy"> & React.RefAttributes<HTMLAnchorElement>>;
//# sourceMappingURL=LinkButton.d.ts.map
```

</details>

<details>
<summary>interface</summary>

```TypeScript
import React from 'react';
declare type Layout = 'intrinsic' | 'fullWidth';
declare type Size = 'large' | 'medium' | 'small';
declare type Variant = 'contained' | 'outlined' | 'neutral' | 'danger';
interface Props extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'className'> {
    children?: React.ReactNode;
    layout?: Layout;
    size?: Size;
    variant?: Variant;
    icon?: React.ReactNode;
}
export declare const LinkButton: React.ForwardRefExoticComponent<Props & React.RefAttributes<HTMLAnchorElement>>;
export {};
//# sourceMappingURL=LinkButton.d.ts.map
```

</details>