### PR TITLE
feat(spindle-ui): CSS custom property experiment

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -1,5 +1,42 @@
 /*
  * Button
+ * NOTE: Styles can be overridden with "--Button-*" variables
+*/
+:root {
+  --Button-tapHighlightColor: var(--gray-5-alpha);
+  --Button-transitionDuration: 0.3s;
+  --Button-onDisabled-opacity: 0.3;
+  --Button-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
+    0 0 0 3px var(--color-focus-clarity);
+
+  --Button--contained-backgroundColor: var(--color-surface-accent-primary);
+  --Button--contained-color: var(--color-text-high-emphasis-inverse);
+  --Button--contained-onActive-backgroundColor: var(--primary-green-100);
+  --Button--contained-onHover-backgroundColor: var(--primary-green-100);
+
+  --Button--outlined-borderColor: var(--color-surface-accent-primary);
+  --Button--outlined-color: var(--color-surface-accent-primary);
+  --Button--outlined-onActive-backgroundColor: var(--primary-green-5);
+  --Button--outlined-onHover-backgroundColor: var(--primary-green-5);
+
+  --Button--lighted-backgroundColor: var(--color-surface-accent-primary-light);
+  --Button--lighted-color: var(--color-text-accent-primary);
+  --Button--lighted-onActive-backgroundColor: var(--primary-green-10);
+  --Button--lighted-onHover-backgroundColor: var(--primary-green-10);
+
+  --Button--neutral-backgroundColor: var(--color-surface-tertiary);
+  --Button--neutral-color: var(--color-text-medium-emphasis);
+  --Button--neutral-onActive-backgroundColor: var(--gray-20-alpha);
+  --Button--neutral-onHover-backgroundColor: var(--gray-20-alpha);
+
+  --Button--danger-borderColor: var(--color-text-caution);
+  --Button--danger-color: var(--color-text-caution);
+  --Button--danger-onActive-backgroundColor: var(--caution-red-5-alpha);
+  --Button--danger-onHover-backgroundColor: var(--caution-red-5-alpha);
+}
+
+/*
+ * Button base
 */
 .spui-Button {
   align-items: center;
@@ -10,19 +47,18 @@
   justify-content: center;
   line-height: 1.3;
   outline: none;
-  -webkit-tap-highlight-color: var(--gray-5-alpha);
+  -webkit-tap-highlight-color: var(--Button-tapHighlightColor);
   text-align: center;
-  transition: background-color 0.3s;
+  transition: background-color var(--Button-transitionDuration);
 }
 
 .spui-Button:disabled {
-  opacity: 0.3;
+  opacity: var(--Button-onDisabled-opacity);
 }
 
 .spui-Button:focus,
 .spui-Button:focus-visible {
-  box-shadow: 0 0 0 1px var(--color-surface-primary),
-    0 0 0 3px var(--color-focus-clarity);
+  box-shadow: var(--Button-onFocus-boxShadow);
 }
 
 .spui-Button:focus:not(:focus-visible) {
@@ -83,104 +119,103 @@
 */
 /* contained */
 .spui-Button--contained {
-  background-color: var(--color-surface-accent-primary);
+  background-color: var(--Button--contained-backgroundColor);
   border: none;
-  color: var(--color-text-high-emphasis-inverse);
+  color: var(--Button--contained-color);
   /* Button variants have different vertical padding to normalize height */
   padding-bottom: 8px;
   padding-top: 8px;
 }
 
 .spui-Button--contained:active {
-  background-color: var(--primary-green-100);
+  background-color: var(--Button--contained-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-Button--contained:not([disabled]):hover {
-    background-color: var(--primary-green-100);
+    background-color: var(--Button--contained-onHover-backgroundColor);
   }
 }
 
 /* outlined */
 .spui-Button--outlined {
   background-color: transparent;
-  border: 2px solid var(--color-surface-accent-primary);
-  color: var(--color-surface-accent-primary);
+  border: 2px solid var(--Button--outlined-borderColor);
+  color: var(--Button--outlined-color);
   padding-bottom: 6px;
   padding-top: 6px;
 }
 
 .spui-Button--outlined:active {
-  background-color: var(--primary-green-5);
+  background-color: var(--Button--outlined-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-Button--outlined:not([disabled]):hover {
-    background-color: var(--primary-green-5);
+    background-color: var(--Button--outlined-onHover-backgroundColor);
   }
 }
 
 /* lighted */
 .spui-Button--lighted {
-  background-color: var(--color-surface-accent-primary-light);
+  background-color: var(--Button--lighted-backgroundColor);
   border: none;
-  color: var(--color-text-accent-primary);
+  color: var(--Button--lighted-color);
   padding-bottom: 8px;
   padding-top: 8px;
 }
 
 .spui-Button--lighted:active {
-  background-color: var(--primary-green-10);
+  background-color: var(--Button--lighted-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-Button--lighted:not([disabled]):hover {
-    background-color: var(--primary-green-10);
+    background-color: var(--Button--lighted-onHover-backgroundColor);
   }
 }
 
 /* neutral */
 .spui-Button--neutral {
-  background-color: var(--color-surface-tertiary);
+  background-color: var(--Button--neutral-backgroundColor);
   border: none;
-  color: var(--color-text-medium-emphasis);
+  color: var(--Button--neutral-color);
   padding-bottom: 8px;
   padding-top: 8px;
 }
 
 .spui-Button--neutral:active {
-  background-color: var(--gray-20-alpha);
+  background-color: var(--Button--neutral-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-Button--neutral:not([disabled]):hover {
-    background-color: var(--gray-20-alpha);
+    background-color: var(--Button--neutral-onHover-backgroundColor);
   }
 }
 
 /* danger */
 .spui-Button--danger {
   background-color: transparent;
-  border: 2px solid var(--color-text-caution);
-  color: var(--color-text-caution);
+  border: 2px solid var(--Button--danger-borderColor);
+  color: var(--Button--danger-color);
   padding-bottom: 6px;
   padding-top: 6px;
 }
 
 .spui-Button--danger:active {
-  background-color: var(--caution-red-5-alpha);
+  background-color: var(--Button--danger-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-Button--danger:not([disabled]):hover {
-    background-color: var(--caution-red-5-alpha);
+    background-color: var(--Button--danger-onHover-backgroundColor);
   }
 }
 
 /*
  * with Icon
 */
-
 .spui-Button-icon {
   line-height: 0; /* Fix Icon position align */
 }

--- a/packages/spindle-ui/src/IconButton/IconButton.css
+++ b/packages/spindle-ui/src/IconButton/IconButton.css
@@ -1,5 +1,44 @@
 /*
  * IconButton
+ * NOTE: Styles can be overridden with "--IconButton-*" variables
+*/
+:root {
+  --IconButton-tapHighlightColor: var(--gray-5-alpha);
+  --IconButton-transitionDuration: 0.3s;
+  --IconButton-onDisabled-opacity: 0.3;
+  --IconButton-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
+    0 0 0 3px var(--color-focus-clarity);
+
+  --IconButton--contained-backgroundColor: var(--color-surface-accent-primary);
+  --IconButton--contained-color: var(--color-text-high-emphasis-inverse);
+  --IconButton--contained-onActive-backgroundColor: var(--primary-green-100);
+  --IconButton--contained-onHover-backgroundColor: var(--primary-green-100);
+
+  --IconButton--outlined-borderColor: var(--color-surface-accent-primary);
+  --IconButton--outlined-color: var(--color-surface-accent-primary);
+  --IconButton--outlined-onActive-backgroundColor: var(--primary-green-5);
+  --IconButton--outlined-onHover-backgroundColor: var(--primary-green-5);
+
+  --IconButton--lighted-backgroundColor: var(
+    --color-surface-accent-primary-light
+  );
+  --IconButton--lighted-color: var(--color-text-accent-primary);
+  --IconButton--lighted-onActive-backgroundColor: var(--primary-green-10);
+  --IconButton--lighted-onHover-backgroundColor: var(--primary-green-10);
+
+  --IconButton--neutral-backgroundColor: var(--color-surface-tertiary);
+  --IconButton--neutral-color: var(--color-text-medium-emphasis);
+  --IconButton--neutral-onActive-backgroundColor: var(--gray-20-alpha);
+  --IconButton--neutral-onHover-backgroundColor: var(--gray-20-alpha);
+
+  --IconButton--danger-borderColor: var(--color-text-caution);
+  --IconButton--danger-color: var(--color-text-caution);
+  --IconButton--danger-onActive-backgroundColor: var(--caution-red-5-alpha);
+  --IconButton--danger-onHover-backgroundColor: var(--caution-red-5-alpha);
+}
+
+/*
+ * IconButton
 */
 .spui-IconButton {
   align-items: center;
@@ -8,19 +47,18 @@
   display: inline-flex;
   justify-content: center;
   outline: none;
-  -webkit-tap-highlight-color: var(--gray-5-alpha);
+  -webkit-tap-highlight-color: var(--IconButton-tapHighlightColor);
   text-align: center;
-  transition: background-color 0.3s;
+  transition: background-color var(--IconButton-transitionDuration);
 }
 
 .spui-IconButton:disabled {
-  opacity: 0.3;
+  opacity: var(--IconButton-onDisabled-opacity);
 }
 
 .spui-IconButton:focus,
 .spui-IconButton:focus-visible {
-  box-shadow: 0 0 0 1px var(--color-surface-primary),
-    0 0 0 3px var(--color-focus-clarity);
+  box-shadow: var(--IconButton-onFocus-boxShadow);
 }
 
 .spui-IconButton:focus:not(:focus-visible) {
@@ -59,87 +97,87 @@
 */
 /* contained */
 .spui-IconButton--contained {
-  background-color: var(--color-surface-accent-primary);
+  background-color: var(--IconButton--contained-backgroundColor);
   border: none;
-  color: var(--color-text-high-emphasis-inverse);
+  color: var(--IconButton--contained-color);
 }
 
 .spui-IconButton--contained:active {
-  background-color: var(--primary-green-100);
+  background-color: var(--IconButton--contained-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-IconButton--contained:not([disabled]):hover {
-    background-color: var(--primary-green-100);
+    background-color: var(--IconButton--contained-onHover-backgroundColor);
   }
 }
 
 /* outlined */
 .spui-IconButton--outlined {
   background-color: transparent;
-  border: 2px solid var(--color-surface-accent-primary);
-  color: var(--color-surface-accent-primary);
+  border: 2px solid var(--IconButton--outlined-borderColor);
+  color: var(--IconButton--outlined-color);
 }
 
 .spui-IconButton--outlined:active {
-  background-color: var(--primary-green-5);
+  background-color: var(--IconButton--outlined-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-IconButton--outlined:not([disabled]):hover {
-    background-color: var(--primary-green-5);
+    background-color: var(--IconButton--outlined-onHover-backgroundColor);
   }
 }
 
 /* lighted */
 .spui-IconButton--lighted {
-  background-color: var(--color-surface-accent-primary-light);
+  background-color: var(--IconButton--lighted-backgroundColor);
   border: none;
-  color: var(--color-text-accent-primary);
+  color: var(--IconButton--lighted-color);
   padding-bottom: 8px;
   padding-top: 8px;
 }
 
 .spui-IconButton--lighted:active {
-  background-color: var(--primary-green-10);
+  background-color: var(--IconButton--lighted-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-IconButton--lighted:not([disabled]):hover {
-    background-color: var(--primary-green-10);
+    background-color: var(--IconButton--lighted-onHover-backgroundColor);
   }
 }
 
 /* neutral */
 .spui-IconButton--neutral {
-  background-color: var(--color-surface-tertiary);
+  background-color: var(--IconButton--neutral-backgroundColor);
   border: none;
-  color: var(--color-text-mid-emphasis);
+  color: var(--IconButton--neutral-color);
 }
 
 .spui-IconButton--neutral:active {
-  background-color: var(--gray-20-alpha);
+  background-color: var(--IconButton--neutral-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-IconButton--neutral:not([disabled]):hover {
-    background-color: var(--gray-20-alpha);
+    background-color: var(--IconButton--neutral-onHover-backgroundColor);
   }
 }
 
 /* danger */
 .spui-IconButton--danger {
   background-color: transparent;
-  border: 2px solid var(--color-text-caution);
-  color: var(--color-text-caution);
+  border: 2px solid var(--IconButton--danger-borderColor);
+  color: var(--IconButton--danger-color);
 }
 
 .spui-IconButton--danger:active {
-  background-color: var(--caution-red-5-alpha);
+  background-color: var(--IconButton--danger-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-IconButton--danger:hover {
-    background-color: var(--caution-red-5-alpha);
+    background-color: var(--IconButton--danger-onHover-backgroundColor);
   }
 }

--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -1,5 +1,44 @@
 /*
  * LinkButton
+ * NOTE: Styles can be overridden with "--LinkButton-*" variables
+*/
+:root {
+  --LinkButton-tapHighlightColor: var(--gray-5-alpha);
+  --LinkButton-transitionDuration: 0.3s;
+  --LinkButton-onDisabled-opacity: 0.3;
+  --LinkButton-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
+    0 0 0 3px var(--color-focus-clarity);
+
+  --LinkButton--contained-backgroundColor: var(--color-surface-accent-primary);
+  --LinkButton--contained-color: var(--color-text-high-emphasis-inverse);
+  --LinkButton--contained-onActive-backgroundColor: var(--primary-green-100);
+  --LinkButton--contained-onHover-backgroundColor: var(--primary-green-100);
+
+  --LinkButton--outlined-borderColor: var(--color-surface-accent-primary);
+  --LinkButton--outlined-color: var(--color-surface-accent-primary);
+  --LinkButton--outlined-onActive-backgroundColor: var(--primary-green-5);
+  --LinkButton--outlined-onHover-backgroundColor: var(--primary-green-5);
+
+  --LinkButton--lighted-backgroundColor: var(
+    --color-surface-accent-primary-light
+  );
+  --LinkButton--lighted-color: var(--color-text-accent-primary);
+  --LinkButton--lighted-onActive-backgroundColor: var(--primary-green-10);
+  --LinkButton--lighted-onHover-backgroundColor: var(--primary-green-10);
+
+  --LinkButton--neutral-backgroundColor: var(--color-surface-tertiary);
+  --LinkButton--neutral-color: var(--color-text-medium-emphasis);
+  --LinkButton--neutral-onActive-backgroundColor: var(--gray-20-alpha);
+  --LinkButton--neutral-onHover-backgroundColor: var(--gray-20-alpha);
+
+  --LinkButton--danger-borderColor: var(--color-text-caution);
+  --LinkButton--danger-color: var(--color-text-caution);
+  --LinkButton--danger-onActive-backgroundColor: var(--caution-red-5-alpha);
+  --LinkButton--danger-onHover-backgroundColor: var(--caution-red-5-alpha);
+}
+
+/*
+ * LinkButton
 */
 .spui-LinkButton {
   align-items: center;
@@ -10,16 +49,15 @@
   justify-content: center;
   line-height: 1.3;
   outline: none;
-  -webkit-tap-highlight-color: var(--gray-5-alpha);
+  -webkit-tap-highlight-color: var(--LinkButton-tapHighlightColor);
   text-align: center;
   text-decoration: none;
-  transition: background-color 0.3s;
+  transition: background-color var(--LinkButton-transitionDuration);
 }
 
 .spui-LinkButton:focus,
 .spui-LinkButton:focus-visible {
-  box-shadow: 0 0 0 1px var(--color-surface-primary),
-    0 0 0 3px var(--color-focus-clarity);
+  box-shadow: var(--LinkButton-onFocus-boxShadow);
 }
 
 .spui-LinkButton:focus:not(:focus-visible) {
@@ -80,97 +118,97 @@
 */
 /* contained */
 .spui-LinkButton--contained {
-  background-color: var(--color-surface-accent-primary);
+  background-color: var(--LinkButton--contained-backgroundColor);
   border: none;
-  color: var(--color-text-high-emphasis-inverse);
+  color: var(--LinkButton--contained-color);
   /* Button variants have different vertical padding to normalize height */
   padding-bottom: 8px;
   padding-top: 8px;
 }
 
 .spui-LinkButton--contained:active {
-  background-color: var(--primary-green-100);
+  background-color: var(--LinkButton--contained-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-LinkButton--contained:hover {
-    background-color: var(--primary-green-100);
+    background-color: var(--LinkButton--contained-onHover-backgroundColor);
   }
 }
 
 /* outlined */
 .spui-LinkButton--outlined {
   background-color: transparent;
-  border: 2px solid var(--color-surface-accent-primary);
-  color: var(--color-surface-accent-primary);
+  border: 2px solid var(--LinkButton--outlined-borderColor);
+  color: var(--LinkButton--outlined-color);
   padding-bottom: 6px;
   padding-top: 6px;
 }
 
 .spui-LinkButton--outlined:active {
-  background-color: var(--primary-green-5);
+  background-color: var(--LinkButton--outlined-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-LinkButton--outlined:hover {
-    background-color: var(--primary-green-5);
+    background-color: var(--LinkButton--outlined-onHover-backgroundColor);
   }
 }
 
 /* lighted */
 .spui-LinkButton--lighted {
-  background-color: var(--color-surface-accent-primary-light);
+  background-color: var(--LinkButton--lighted-backgroundColor);
   border: none;
-  color: var(--color-text-accent-primary);
+  color: var(--LinkButton--lighted-color);
   padding-bottom: 8px;
   padding-top: 8px;
 }
 
 .spui-LinkButton--lighted:active {
-  background-color: var(--primary-green-10);
+  background-color: var(--LinkButton--lighted-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-LinkButton--lighted:hover {
-    background-color: var(--primary-green-10);
+    background-color: var(--LinkButton--lighted-onHover-backgroundColor0);
   }
 }
 
 /* neutral */
 .spui-LinkButton--neutral {
-  background-color: var(--color-surface-tertiary);
+  background-color: var(--LinkButton--neutral-backgroundColor);
   border: none;
-  color: var(--color-text-medium-emphasis);
+  color: var(--LinkButton--neutral-color);
   padding-bottom: 8px;
   padding-top: 8px;
 }
 
 .spui-LinkButton--neutral:active {
-  background-color: var(--gray-20-alpha);
+  background-color: var(--LinkButton--neutral-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-LinkButton--neutral:hover {
-    background-color: var(--gray-20-alpha);
+    background-color: var(--LinkButton--neutral-onHover-backgroundColor);
   }
 }
 
 /* danger */
 .spui-LinkButton--danger {
   background-color: transparent;
-  border: 2px solid var(--color-text-caution);
-  color: var(--color-text-caution);
+  border: 2px solid var(--LinkButton--danger-borderColor);
+  color: var(--LinkButton--danger-color);
   padding-bottom: 6px;
   padding-top: 6px;
 }
 
 .spui-LinkButton--danger:active {
-  background-color: var(--caution-red-5-alpha);
+  background-color: var(--LinkButton--danger-onActive-backgroundColor);
 }
 
 @media (hover: hover) {
   .spui-LinkButton--danger:hover {
-    background-color: var(--caution-red-5-alpha);
+    background-color: var(--LinkButton--danger-onHover-backgroundColor);
   }
 }
 


### PR DESCRIPTION
やはりボタンのスタイルを特定用途のみカスタマイズしたい要望があるので、カスタムプロパティで指定できるようにしていました。[前回](https://github.com/openameba/spindle/pull/106)と異なり、nestedな値ではなく再代入方式にしたので、より様々なパターンで使えるようになったと思われます。もともとデザイン時に @MasatoHonda とは「ボタンのスタイルはカラーパレットに従っているけど実際には固有」と話していたことがあるので、その設計通りのコードにはなったかなという感じです。

この変更はmainに入れず、どっかのバージョンのbetaとして動作確認してみようかとおもってます。

## サイトのデザインまるまる変えたい場合 (テーマとして)

ameba-color-palette.css (`--color-*`) 自体を上書きします。

```css
:root {
  --color-surface-accent-primary: red;
  ...
}
```

## サイト全体でボタンのスタイルだけカスタマイズしたい

ボタンのカスタムプロパティ`--Button`を上書きします。

```css
:root {
  --Button--contained-backgroundColor: red;
  ...
}
```

## サイト内の一部分だけスタイルの異なるボタンを定義したい

直近の親要素などスコープを絞った状態で、ボタンのカスタムプロパティ`--Button`を上書きします。

```html
<div class="extra-button"><button class="spui-button"></button></div>
```

```css
.extra-button {
  --Button--contained-backgroundColor: red;
  ...
}
```

## 非対応ブラウザでの対応のためにpostcss-custom-propertiesなどで静的置換したい場合
Nestedなカスタムプロパティだとうまく動作しない場合もありましたが、代入方式だとうまく変換される気がします (手元で試したところ)

## TODO
- Doc更新
- [x] `<ButtonIcon>`にも適用