### PR TITLE
chore(spindle-icons): make preparation task optional

### DIFF
--- a/.github/workflows/build-icon.yml
+++ b/.github/workflows/build-icon.yml
@@ -25,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: npx lerna bootstrap -- --frozen-lockfile
-      - name: Update UI catalog
+      - name: Update Icons
         env:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
           FILE_KEY: ${{ secrets.FIGMA_ICON_FILE_KEY }}

--- a/packages/spindle-icons/package.json
+++ b/packages/spindle-icons/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "npx rimraf dist",
     "mkdir": "npx mkdirp dist",
-    "prebuild": "run-s clean mkdir",
+    "prepare": "run-s clean mkdir",
     "build": "run-s icon:get icon:optimize icon:sprite",
     "postbuild": "ts-node scripts/icon-doc.ts",
     "icon:get": "ts-node scripts/get-icons.ts",


### PR DESCRIPTION
Iconの自動更新(追加/更新)では、ディレクトリのcleanupは必要ないので、オプショナルとして実行するようにしました。これで、[関係のないファイルまで消されてしまう問題](https://github.com/openameba/spindle/pull/93/files)が解消されると思われます。

※ 削除対応は別途します。

ref: #133