### PR TITLE
fix(spindle-ui): set background transparent to outlined icon button

### DIFF
--- a/packages/spindle-ui/src/IconButton/IconButton.css
+++ b/packages/spindle-ui/src/IconButton/IconButton.css
@@ -76,7 +76,7 @@
 
 /* outlined */
 .spui-IconButton--outlined {
-  background-color: var(--color-text-high-emphasis-inverse);
+  background-color: transparent;
   border: 2px solid var(--color-surface-accent-primary);
   color: var(--color-surface-accent-primary);
 }


### PR DESCRIPTION
outlined `<IconButton>` の背景が透過になっていなかったので、対応しました。

![](https://user-images.githubusercontent.com/869023/102157505-f9c5cf00-3ec2-11eb-88e5-d1c56670b58e.png)


ref: https://github.com/openameba/spindle/pull/121