### PR TITLE
Fix hidden focus indicator by not support focus-visible browser

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -45,7 +45,6 @@
   justify-content: center;
   line-height: 1.3;
   margin: 0;
-  outline: none;
   -webkit-tap-highlight-color: var(--Button-tapHighlightColor);
   text-align: center;
   transition: background-color 0.3s;
@@ -55,9 +54,9 @@
   opacity: 0.3;
 }
 
-.spui-Button:focus,
-.spui-Button:focus-visible {
+.spui-Button:focus {
   box-shadow: var(--Button-onFocus-boxShadow);
+  outline: none;
 }
 
 .spui-Button:focus:not(:focus-visible) {

--- a/packages/spindle-ui/src/Form/Checkbox.css
+++ b/packages/spindle-ui/src/Form/Checkbox.css
@@ -57,8 +57,7 @@
 }
 
 /* box-shadow is used to apply border-radius as outline */
-.spui-Checkbox-input:focus ~ .spui-Checkbox-outline,
-.spui-Checkbox-input:focus-visible ~ .spui-Checkbox-outline {
+.spui-Checkbox-input:focus ~ .spui-Checkbox-outline {
   box-shadow: 0 0 0 2px var(--color-focus-clarity);
 }
 

--- a/packages/spindle-ui/src/Form/DropDown.css
+++ b/packages/spindle-ui/src/Form/DropDown.css
@@ -70,8 +70,7 @@
   width: 100%;
 }
 
-.spui-DropDown-select:focus ~ .spui-DropDown-outline,
-.spui-DropDown-select:focus-visible ~ .spui-DropDown-outline {
+.spui-DropDown-select:focus ~ .spui-DropDown-outline {
   border-color: var(--color-border-high-emphasis);
   box-shadow: 0 0 0 3px var(--color-focus-ambiguous);
 }

--- a/packages/spindle-ui/src/Form/Radio.css
+++ b/packages/spindle-ui/src/Form/Radio.css
@@ -58,8 +58,7 @@
 }
 
 /* box-shadow is used to apply border-radius as outline */
-.spui-Radio-input:focus ~ .spui-Radio-outline,
-.spui-Radio-input:focus-visible ~ .spui-Radio-outline {
+.spui-Radio-input:focus ~ .spui-Radio-outline {
   box-shadow: 0 0 0 2px var(--color-focus-clarity);
 }
 

--- a/packages/spindle-ui/src/Form/TextArea.css
+++ b/packages/spindle-ui/src/Form/TextArea.css
@@ -21,8 +21,7 @@
   color: var(--color-text-disabled);
 }
 
-.spui-TextArea:focus,
-.spui-TextArea:focus-visible {
+.spui-TextArea:focus {
   border-color: var(--color-border-high-emphasis);
   box-shadow: 0 0 0 3px var(--color-focus-ambiguous);
 }

--- a/packages/spindle-ui/src/Form/TextField.css
+++ b/packages/spindle-ui/src/Form/TextField.css
@@ -19,8 +19,7 @@
   color: var(--color-text-disabled);
 }
 
-.spui-TextField:focus,
-.spui-TextField:focus-visible {
+.spui-TextField:focus {
   border-color: var(--color-border-high-emphasis);
   box-shadow: 0 0 0 3px var(--color-focus-ambiguous);
 }

--- a/packages/spindle-ui/src/Form/ToggleSwitch.css
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.css
@@ -73,8 +73,7 @@
 }
 
 /* box-shadow is used to apply border-radius as outline */
-.spui-ToggleSwitch-input:focus ~ .spui-ToggleSwitch-outline,
-.spui-ToggleSwitch-input:focus-visible ~ .spui-ToggleSwitch-outline {
+.spui-ToggleSwitch-input:focus ~ .spui-ToggleSwitch-outline {
   box-shadow: 0 0 0 2px var(--color-focus-clarity);
 }
 

--- a/packages/spindle-ui/src/IconButton/IconButton.css
+++ b/packages/spindle-ui/src/IconButton/IconButton.css
@@ -45,7 +45,6 @@
   display: inline-flex;
   justify-content: center;
   margin: 0;
-  outline: none;
   -webkit-tap-highlight-color: var(--IconButton-tapHighlightColor);
   text-align: center;
   transition: background-color 0.3s;
@@ -55,9 +54,9 @@
   opacity: 0.3;
 }
 
-.spui-IconButton:focus,
-.spui-IconButton:focus-visible {
+.spui-IconButton:focus {
   box-shadow: var(--IconButton-onFocus-boxShadow);
+  outline: none;
 }
 
 .spui-IconButton:focus:not(:focus-visible) {

--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -46,16 +46,15 @@
   font-weight: bold;
   justify-content: center;
   line-height: 1.3;
-  outline: none;
   -webkit-tap-highlight-color: var(--LinkButton-tapHighlightColor);
   text-align: center;
   text-decoration: none;
   transition: background-color 0.3s;
 }
 
-.spui-LinkButton:focus,
-.spui-LinkButton:focus-visible {
+.spui-LinkButton:focus {
   box-shadow: var(--LinkButton-onFocus-boxShadow);
+  outline: none;
 }
 
 .spui-LinkButton:focus:not(:focus-visible) {


### PR DESCRIPTION
resolve: #156 

Browsers that do not support `:focus-visible` will disable all grouped selectors that contain `:focus-visible`.

- [x] Button
- [x] IconButton
- [x] LinkButton
- [x] Checkbox
- [x] DropDown
- [x] Radio
- [x] TextArea
- [x] TextField
- [x] ToggleSwitch

See also https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#selectively_showing_the_focus_indicator

```css
custom-button {
  display: inline-block;
  margin: 10px;
}

custom-button:focus {
  /* Provide a fallback style for browsers
     that don't support :focus-visible */
  outline: none;
  background: lightgrey;
}

custom-button:focus:not(:focus-visible) {
  /* Remove the focus indicator on mouse-focus for browsers
     that do support :focus-visible */
  background: transparent;
}

custom-button:focus-visible {
  /* Draw a very noticeable focus style for
     keyboard-focus on browsers that do support
     :focus-visible */
  outline: 4px dashed darkorange;
  background: transparent;
}
```