### PR TITLE
fix(spindle-ui): fix CSS variable name

### DIFF
--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -167,7 +167,7 @@
 
 @media (hover: hover) {
   .spui-LinkButton--lighted:hover {
-    background-color: var(--LinkButton--lighted-onHover-backgroundColor0);
+    background-color: var(--LinkButton--lighted-onHover-backgroundColor);
   }
 }
 


### PR DESCRIPTION
とあるプロジェクトでLinkButtonを使用していたところ、変数名の間違いを見つけたのでそれを修正しました。

<img width="971" alt="variable '--LinkButton--lighted-onHover-backgroundColor0' is undefined and used without a fallback" src="https://user-images.githubusercontent.com/309466/111429664-a15dd200-873c-11eb-929d-f1848a33e474.png">