### PR TITLE
docs(spindle-icons): update example page

### DIFF
--- a/packages/spindle-icons/README.md
+++ b/packages/spindle-icons/README.md
@@ -16,7 +16,7 @@ yarn add @openameba/spindle-icons
 ```
 
 ## 利用方法
-Spindle Iconsで生成されたSVGアイコンは、以下の方法で利用できます。利用できるアイコンは[アイコンリスト](docs/icons.md)を参照してください。
+Spindle Iconsで生成されたSVGアイコンは、以下の方法で利用できます。利用できるアイコンは[アイコンリスト](docs/icons.md)を参照してください。img要素、Inline SVG、SVG Spriteでの利用法は[サンプルページ](example/index.html)を参考にしてください。
 
 ### img要素
 最も簡単な利用方法は、img要素としてSVGファイルを読み込むことです。いくつかのスクリーンリーダーでは、SVG読み込みするimg要素の`alt`属性のテキストを省略するため、`role="img"`を付与します。

--- a/packages/spindle-icons/example/index.html
+++ b/packages/spindle-icons/example/index.html
@@ -3,8 +3,8 @@
     color: green;
   }
 
-  /* SVG can extend font color with fill:currentColor */
-  .icon-sprite {
+  /* SVG can extend color and size */
+  svg {
     fill: currentColor;
     height: 100px;
     width: 100px;
@@ -13,7 +13,9 @@
 
 <svg class="icon-sprite" role="img">
   <title>Clock</title>
-  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../dist/sprite.svg#clock"></use>
+  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../dist/svg/sprite.svg#clock"></use>
 </svg>
 
-<img alt="Clock" height="100" src="../dist/clock.svg" width="100" />
+<img alt="Clock" height="100" src="../dist/svg/clock.svg" width="100" />
+
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M12 22C6.5 22 2 17.5 2 12S6.5 2 12 2s10 4.5 10 10-4.5 10-10 10zm0-18c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm6 8c0-.6-.4-1-1-1h-4V7c0-.6-.4-1-1-1s-1 .4-1 1v4c0 1.1.9 2 2 2h4c.6 0 1-.4 1-1z"/></svg>


### PR DESCRIPTION
Spindle Iconsのサンプルページをアップデートしました。

- READMEから参照できるようにしました
- 表示できていなかったアイコンを表示しました
- インラインSVGでの利用法を追加しました

![exampleページのスクリーンショット](https://user-images.githubusercontent.com/869023/117617477-9147f900-b1a7-11eb-95d5-f1aab3ec2680.png)
