### PR TITLE
Feat/add toast components

### DIFF
--- a/packages/spindle-ui/src/Toast/Toast.css
+++ b/packages/spindle-ui/src/Toast/Toast.css
@@ -1,0 +1,67 @@
+:root {
+  --Toast-z-index: 1;
+}
+
+.spui-Toast {
+  left: 0;
+  position: fixed;
+  right: 0;
+  text-align: center;
+  z-index: var(--Toast-z-index);
+}
+
+.spui-Toast--content {
+  background-color: var(--color-surface-accent-primary-light);
+  border-radius: 40px;
+  box-shadow: 0px 4.75px 14.25px rgba(8, 18, 26, 0.12);
+  box-sizing: border-box;
+  color: var(--color-text-accent-primary);
+  cursor: default;
+  display: inline-block;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0;
+  padding: 11px 16px;
+}
+
+.spui-Toast-content--error {
+  background-color: var(--color-surface-caution-light);
+  color: var(--color-text-caution);
+  position: relative;
+}
+
+.spui-Toast-content--error:before {
+  background-color: var(--color-surface-primary);
+  border-radius: 40px;
+  content: '';
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: -1;
+}
+
+.spui-Toast--top {
+  top: 16px;
+}
+
+.spui-Toast--bottom {
+  bottom: 0;
+}
+
+.spui-Toast--slide {
+  transform: translateY(-100px);
+  transition: transform 0.5s ease;
+}
+
+.spui-Toast-slide--in {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion) {
+  .spui-Toast--slide {
+    transition-duration: 0.1ms;
+  }
+}

--- a/packages/spindle-ui/src/Toast/Toast.stories.mdx
+++ b/packages/spindle-ui/src/Toast/Toast.stories.mdx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { actions } from '@storybook/addon-actions';
+import { Toast } from './Toast';
+import { Button } from '../Button';
+
+export const ActivateButton = ({ hasError }) => {
+  const [active, setActive] = useState();
+  return (
+    <div>
+      <Button
+        size="medium"
+        variant={hasError ? 'danger' : 'outlined'}
+        onClick={() => setActive((prev) => !prev)}
+      >
+        Activate
+      </Button>
+      <Toast
+        active={active}
+        hasError={hasError}
+        onHide={() => setActive(false)}
+      >
+        Toast Content
+      </Toast>
+    </div>
+  );
+};
+
+# Toast
+
+<Meta title="Toast" component={Toast} />
+
+![stability-experiment](https://img.shields.io/badge/stability-experiment-red.svg)
+
+<Description>
+  Toastコンポーネントは、利用者に一時的なお知らせをする際に利用します。画面上には常に一つしか表示できません。Toastは自動で消えてしまうため、見落とされても影響のない「重要ではないお知らせ」に用います。利用する際には、その他により適切な手段がないか必ず確認してください。
+</Description>
+<Description>
+  「重要なお知らせ」とは何か、他のnotification系のコンポーネントとの違いは別途まとめる予定です。
+</Description>
+
+<Source
+  language="javascript"
+  code={`import { Toast } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language="css"
+  code={`@import './node_modules/@openameba/spindle-ui/Toast/Toast.css'`}
+/>
+
+<Source
+  language="html"
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Toast/Toast.css">`}
+/>
+
+## Normal
+
+<Preview withSource="open">
+  <Story name="Normal">
+    <ActivateButton />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Toast active={true}>Success Content</Toast>
+  `}
+/>
+
+## Error
+
+<Preview withSource="open">
+  <Story name="Error">
+    <ActivateButton hasError />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Toast active={true} hasError>Error Content</Toast>
+  `}
+/>
+
+## このコンポーネントでやっていること
+
+<Description>
+  - reduced motionが指定された時に、トランジッションを短くします
+</Description>
+<Description>
+  -
+  hover、focusされている時には、時間制限を停止します。フォーカスが離れたのち、再度0秒から計測します
+</Description>
+<Description>- モードを奪うことになるため、自動的にfocusはしません</Description>
+<Description>
+  - デバイスのorientationに追従して表示位置・サイズを変更します
+</Description>
+
+## 利用時に注意してほしいこと
+
+<Description>
+  -
+  Toastは自動で消えてしまうため、見落とされても影響のない、「重要ではないお知らせ」に用います
+</Description>
+<Description>
+  -
+  もし「重要なお知らせ」に用いる場合、時間制限を外し、閉じるボタンを設置します（**※未実装**）
+</Description>
+<Description>
+  -
+  このコンポーネントでは関与しませんが、ライブリージョンをアプリケーションで実装してください
+</Description>

--- a/packages/spindle-ui/src/Toast/Toast.test.tsx
+++ b/packages/spindle-ui/src/Toast/Toast.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+import { Toast, BLOCK_NAME, ANIMATION_DURATION } from './Toast';
+
+describe('<Toast />', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('Inner isShow state should be changed by timer', () => {
+    const testAnimation = () => {
+      onHide.mockReset();
+
+      expect(screen.getByText(/content/).parentElement).toHaveClass(
+        `${BLOCK_NAME}-slide--in`,
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+      });
+
+      expect(screen.getByText(/content/).parentElement).not.toHaveClass(
+        `${BLOCK_NAME}-slide--in`,
+      );
+
+      act(() => {
+        const parentElement = screen.getByText(/content/).parentElement;
+        expect(parentElement).not.toBeNull();
+        if (parentElement) {
+          fireEvent.transitionEnd(parentElement);
+        }
+      });
+
+      expect(onHide).toBeCalledTimes(1);
+    };
+
+    const onHide = jest.fn();
+    const duration = 5000;
+    const { rerender } = render(
+      <Toast active onHide={onHide} duration={duration}>
+        content
+      </Toast>,
+    );
+
+    testAnimation();
+
+    /* === The following code check if timeoutID is null === */
+
+    rerender(
+      <Toast active={false} onHide={onHide} duration={duration}>
+        content
+      </Toast>,
+    );
+
+    expect(screen.getByText(/content/).parentElement).not.toHaveClass(
+      `${BLOCK_NAME}-slide--in`,
+    );
+
+    // If timeoutID is not null, Toast animation is not invoked again.
+    rerender(
+      <Toast active onHide={onHide} duration={duration}>
+        content
+      </Toast>,
+    );
+
+    testAnimation();
+  });
+
+  test('When it is hovered, duration should be reset', () => {
+    const onHide = jest.fn();
+    const duration = 4000;
+    render(
+      <Toast active onHide={onHide} duration={duration}>
+        content
+      </Toast>,
+    );
+
+    fireEvent.mouseOver(screen.getByText(/content/));
+
+    act(() => {
+      jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+    });
+
+    expect(screen.getByText(/content/).parentElement).toHaveClass(
+      `${BLOCK_NAME}-slide--in`,
+    );
+
+    fireEvent.mouseOut(screen.getByText(/content/));
+
+    act(() => {
+      jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+    });
+
+    expect(screen.getByText(/content/).parentElement).not.toHaveClass(
+      `${BLOCK_NAME}-slide--in`,
+    );
+
+    act(() => {
+      const parentElement = screen.getByText(/content/).parentElement;
+      expect(parentElement).not.toBeNull();
+      if (parentElement) {
+        fireEvent.transitionEnd(parentElement);
+      }
+    });
+
+    expect(onHide).toBeCalledTimes(1);
+  });
+
+  test('When it is focused, duration should be reset', () => {
+    const onHide = jest.fn();
+    const duration = 4000;
+    render(
+      <Toast active onHide={onHide} duration={duration}>
+        content
+      </Toast>,
+    );
+
+    fireEvent.focus(screen.getByText(/content/));
+
+    act(() => {
+      jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+    });
+
+    expect(screen.getByText(/content/).parentElement).toHaveClass(
+      `${BLOCK_NAME}-slide--in`,
+    );
+
+    fireEvent.blur(screen.getByText(/content/));
+
+    act(() => {
+      jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+    });
+
+    expect(screen.getByText(/content/).parentElement).not.toHaveClass(
+      `${BLOCK_NAME}-slide--in`,
+    );
+
+    act(() => {
+      const parentElement = screen.getByText(/content/).parentElement;
+      expect(parentElement).not.toBeNull();
+      if (parentElement) {
+        fireEvent.transitionEnd(parentElement);
+      }
+    });
+
+    expect(onHide).toBeCalledTimes(1);
+  });
+});

--- a/packages/spindle-ui/src/Toast/Toast.tsx
+++ b/packages/spindle-ui/src/Toast/Toast.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+type Position = 'top' | 'bottom';
+type Animation = 'slide' | 'fade';
+
+type Props = {
+  children?: React.ReactNode;
+  active?: boolean;
+  // milliseconds to hide
+  duration?: number;
+  onHide?: () => void;
+  position?: Position;
+  animation?: Animation;
+  hasError?: boolean;
+};
+
+export const BLOCK_NAME = 'spui-Toast';
+
+// Duration for css animation.
+export const ANIMATION_DURATION = 500;
+
+const MIN_DURATION = 4000;
+const MAX_DURATION = 100000;
+
+const getAnimationClassName = (
+  isShow: boolean,
+  animation: Animation,
+): string => {
+  return isShow ? `${BLOCK_NAME}-${animation}--in` : '';
+};
+
+const limitDuration = (duration: number) => {
+  if (duration < MIN_DURATION || duration > MAX_DURATION) {
+    return MIN_DURATION;
+  }
+  return duration;
+};
+
+export const Toast = ({
+  children,
+  active = false,
+  duration = 4000,
+  animation = 'slide',
+  position = 'top',
+  hasError = false,
+  onHide,
+}: Props): React.ReactElement => {
+  const [isShow, setIsShow] = useState<boolean>(false);
+  const animationClassName = getAnimationClassName(isShow, animation);
+  const errorContentClassName = hasError ? `${BLOCK_NAME}-content--error` : '';
+  const formattedDuration = limitDuration(duration) - ANIMATION_DURATION;
+  const timeoutID = useRef<number | null>(null);
+  const transitionElementRef = useRef<HTMLDivElement | null>(null);
+
+  const setIsShowWithTimeout = useCallback(() => {
+    // Out animation is executed after `formattedDuration` seconds.
+    if (timeoutID.current === null && isShow) {
+      timeoutID.current = window.setTimeout(() => {
+        setIsShow(false);
+      }, formattedDuration);
+    }
+  }, [isShow, timeoutID, setIsShow, formattedDuration]);
+
+  const resetTimeout = useCallback(() => {
+    if (timeoutID.current) {
+      window.clearTimeout(timeoutID.current);
+      timeoutID.current = null;
+    }
+  }, [timeoutID]);
+
+  const handleTransitionEnd = useCallback(() => {
+    if (onHide && !isShow) {
+      onHide();
+      timeoutID.current = null;
+    }
+  }, [isShow, setIsShow, onHide]);
+
+  useEffect(() => {
+    // Animation is not stopped even if `active` props is changed while running animation.
+    if (active && timeoutID.current === null) {
+      setIsShow(true);
+    }
+  }, [active]);
+
+  useEffect(() => {
+    setIsShowWithTimeout();
+    return resetTimeout;
+  }, [setIsShowWithTimeout, resetTimeout]);
+
+  useEffect(() => {
+    const transitionElement = transitionElementRef.current;
+
+    // When out animation is finished, `onHide` method is invoked.
+    if (transitionElement) {
+      transitionElement.addEventListener('transitionend', handleTransitionEnd);
+    }
+
+    return () => {
+      if (transitionElement) {
+        transitionElement.removeEventListener(
+          'transitionend',
+          handleTransitionEnd,
+        );
+      }
+    };
+  }, [transitionElementRef, handleTransitionEnd]);
+
+  return (
+    <div
+      className={`${BLOCK_NAME} ${BLOCK_NAME}--${position} ${BLOCK_NAME}--${animation} ${animationClassName}`}
+      ref={transitionElementRef}
+    >
+      <div
+        className={`${BLOCK_NAME}--content ${errorContentClassName}`}
+        tabIndex={0}
+        onMouseOver={resetTimeout}
+        onMouseOut={setIsShowWithTimeout}
+        onFocus={resetTimeout}
+        onBlur={setIsShowWithTimeout}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/packages/spindle-ui/src/Toast/index.ts
+++ b/packages/spindle-ui/src/Toast/index.ts
@@ -1,0 +1,1 @@
+export { Toast } from './Toast';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -5,3 +5,4 @@
 @import './Form/index.css';
 @import './IconButton/IconButton.css';
 @import './LinkButton/LinkButton.css';
+@import './Toast/Toast.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -4,6 +4,7 @@ import * as Form from './Form';
 import * as Icon from './Icon';
 import { IconButton } from './IconButton';
 import { LinkButton } from './LinkButton';
+import { Toast } from './Toast';
 
 // Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
-export { Button, ButtonGroup, Form, Icon, IconButton, LinkButton };
+export { Button, ButtonGroup, Form, Icon, IconButton, LinkButton, Toast };


### PR DESCRIPTION
Toastコンポーネントを追加しました。

Design Doc: #232 

## スクリーンショット

**Normal**

https://user-images.githubusercontent.com/34934510/123737054-42802b00-d8dd-11eb-86ab-367d9141e41c.mp4

**Error**

https://user-images.githubusercontent.com/34934510/123751379-a6611e80-d8f2-11eb-8d20-8f1d8e1d1565.mp4

-903f-c77024d481a2.mp4

## 確認項目

- [x] reduced motionが指定された時に、トランジッションをなくします
- [x] hover、focusされている時には、時間制限を停止します。フォーカスが離れたのち、再度0秒から計測します
- [x] モードを奪うことになるため、自動的にfocusはしません

## 対応していないこと
- `position` の設定を `top` のみにしています
- `animation` のサポートを `slide` のみにしています