### PR TITLE
Docs/update toast

### DIFF
--- a/packages/spindle-ui/src/Toast/Toast.stories.mdx
+++ b/packages/spindle-ui/src/Toast/Toast.stories.mdx
@@ -108,5 +108,5 @@ export const ActivateButton = ({ hasError }) => {
 </Description>
 <Description>
   -
-  このコンポーネントでは関与しませんが、ライブリージョンをアプリケーションで実装してください
+  このコンポーネントでは関与しませんが、ライブリージョンをアプリケーションで実装してください（参考：[実装方法 - 4.1.3 コンテンツの変更をユーザーに知らせる - Ameba Accessibility Guidelines](https://a11y-guidelines.ameba.design/4/1/3/#%E5%AE%9F%E8%A3%85%E6%96%B9%E6%B3%95)）
 </Description>


### PR DESCRIPTION
https://github.com/openameba/spindle/pull/231 で追加いただいたToastの注意書き部分をアップデートしました。
`aria-live`属性は、動的に追加した要素の場合に支援技術に検知されないため、componentでは関与しないと記載していたのですが、ちょっと伝わりづらそうというフィードバックをうけて参考リンクを追記しました。