### PR TITLE
docs: add accessibility example for Toast component

### DIFF
--- a/packages/spindle-ui/.storybook/preview-body.html
+++ b/packages/spindle-ui/.storybook/preview-body.html
@@ -1,0 +1,6 @@
+<div
+  aria-live="polite"
+  id="polite-announcer"
+  role="status"
+  class="visually-hidden"
+></div>

--- a/packages/spindle-ui/.storybook/preview-head.html
+++ b/packages/spindle-ui/.storybook/preview-head.html
@@ -2,5 +2,14 @@
   body {
     font-family: Meiryo, Yu Gothic Medium, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   }
+  /* see: https://a11y-guidelines.ameba.design/1/1/1/#%E8%89%AF%E3%81%84%E5%AE%9F%E8%A3%85%E4%BE%8B-1 */
+  .visually-hidden {
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    width: 1px;
+  }
 </style>
 <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js"><\x2fscript>');</script>

--- a/packages/spindle-ui/src/Toast/Toast.stories.mdx
+++ b/packages/spindle-ui/src/Toast/Toast.stories.mdx
@@ -1,26 +1,48 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef, forwardRef } from 'react';
 import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { Toast } from './Toast';
 import { Button } from '../Button';
 
+export const usePoliteAnnouncer = (message) => {
+  const announcer = useRef(null);
+  useEffect(() => {
+    announcer.current = document.getElementById('polite-announcer');
+    return () => {
+      announcer.current = null;
+    };
+  }, []);
+  useEffect(() => {
+    const announcerContent = announcer.current;
+    if (announcerContent && message) {
+      announcerContent.textContent = message;
+    }
+    return () => {
+      if(message) {
+        announcerContent.textContent = '';
+      }
+    };
+  }, [message]);
+};
+
 export const ActivateButton = ({ hasError }) => {
-  const [active, setActive] = useState();
+  const [message, setMessage] = useState('');
+  usePoliteAnnouncer(message);
   return (
     <div>
       <Button
         size="medium"
         variant={hasError ? 'danger' : 'outlined'}
-        onClick={() => setActive((prev) => !prev)}
+        onClick={() => setMessage('Toast Content')}
       >
         Activate
       </Button>
       <Toast
-        active={active}
+        active={!!message}
         hasError={hasError}
-        onHide={() => setActive(false)}
+        onHide={() => setMessage('')}
       >
-        Toast Content
+        {message}
       </Toast>
     </div>
   );
@@ -110,3 +132,49 @@ export const ActivateButton = ({ hasError }) => {
   -
   このコンポーネントでは関与しませんが、ライブリージョンをアプリケーションで実装してください（参考：[実装方法 - 4.1.3 コンテンツの変更をユーザーに知らせる - Ameba Accessibility Guidelines](https://a11y-guidelines.ameba.design/4/1/3/#%E5%AE%9F%E8%A3%85%E6%96%B9%E6%B3%95)）
 </Description>
+<Description>
+  - 
+  ライブリージョンは次のように実装します。 `html` 側に `aria-live="polite"` 及び `role="status"` を持つ要素を予め埋め込んでおき、この要素にコンテンツを動的に挿入することで、スクリーンリーダーが自動でコンテンツを読み上げてくれます。
+</Description>
+
+<Source
+  code={`
+<html>
+  <body>
+    ...
+    <div
+      aria-live="polite"
+      id="polite-announcer"
+      role="status"
+      class="visually-hidden"
+    ></div>
+    ...
+  </body>
+</html>
+  `}
+/>
+
+<Source
+  code={`
+const usePoliteAnnouncer = (message) => {
+  const announcer = useRef(null);
+  useEffect(() => {
+    announcer.current = document.getElementById('polite-announcer');
+    return () => {
+      announcer.current = null;
+    };
+  }, []);
+  useEffect(() => {
+    const announcerContent = announcer.current;
+    if (announcerContent && message) {
+      announcerContent.textContent = message;
+    }
+    return () => {
+      if(message) {
+        announcerContent.textContent = '';
+      }
+    };
+  }, [message]);
+};
+  `}
+/>


### PR DESCRIPTION
https://github.com/openameba/spindle/pull/231 で追加したToastコンポーネントのstorybookに、アクセシビリティ周りのコードを付け足しました。
背景としては、今の状態だとアクセシビリティ対応をどのように行えば良いかぱっと見ではわからないためです。

ref: #232