### PR TITLE
Fix/remove min width button

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -86,7 +86,6 @@
   border-radius: calc(40em / 14);
   font-size: 0.875em;
   min-height: 40px;
-  min-width: 88px;
   padding-left: 16px;
   padding-right: 16px;
 }
@@ -95,7 +94,6 @@
   border-radius: calc(32em / 13);
   font-size: 0.8125em;
   min-height: 32px;
-  min-width: 60px;
   padding-left: 10px;
   padding-right: 10px;
 }

--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -84,7 +84,6 @@
   border-radius: calc(40em / 14);
   font-size: 0.875em;
   min-height: 40px;
-  min-width: 88px;
   padding-left: 16px;
   padding-right: 16px;
 }
@@ -93,7 +92,6 @@
   border-radius: calc(32em / 13);
   font-size: 0.8125em;
   min-height: 32px;
-  min-width: 60px;
   padding-left: 10px;
   padding-right: 10px;
 }


### PR DESCRIPTION
外部から幅を指定できるようにするために `<Button />`・`<LinkButton />` から `min-width` の指定を削除しました。

ref: #243