### PR TITLE
fix(spindle-ui): remove transition effect

### DIFF
--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -138,6 +138,7 @@
   color: var(--LinkButton--outlined-color);
   padding-bottom: 6px;
   padding-top: 6px;
+  transition: none;
 }
 
 .spui-LinkButton--outlined:active {


### PR DESCRIPTION
Page Speed InsightsのCLS項目で「試し読みボタン」に対して、「サポートされてないCSSプロパティ」の指摘があったので対応しました。

![image](https://user-images.githubusercontent.com/11627772/130756658-dc7e0325-429d-4e68-beff-7a0501b7af36.png)

なお、診断内にある「合成されていないアニメーションは使用しないでください」についてですが、レンダリング初期段階をトリガーにして処理されるCSSのプロパティを指しており、パフォーマンスの低下を招く一因となるようです。
ref: https://web.dev/non-composited-animations/?utm_source=lighthouse&utm_medium=unknown

## 原因
.spui-LinkButtonのクラスに設定されているプロパティ [transition: background-color .3s; ](https://github.com/openameba/spindle/blob/ef2d34fdd7cc9d6dc2880fa1f35871254f60696f/packages/spindle-ui/src/LinkButton/LinkButton.css#L52)ですが、
.spui-LinkButton--outlinedクラスに設定されているプロパティ [background-color: transparent; ](https://github.com/openameba/spindle/blob/ef2d34fdd7cc9d6dc2880fa1f35871254f60696f/packages/spindle-ui/src/LinkButton/LinkButton.css#L136) に対しては無効となるプロパティと思われます。（transparentの色はtransitionで変化させることができないみたいです。）

## 対応したこと
.spui-LinkButton--outlined のクラスに transition: noneを追加して効果を打ち消すようにしました。

