### PR TITLE
chore(spindle-tokens): make private for now

### DIFF
--- a/packages/spindle-tokens/package.json
+++ b/packages/spindle-tokens/package.json
@@ -4,6 +4,7 @@
   "description": "Spindle design tokens.",
   "homepage": "https://github.com/openameba/spindle#readme",
   "license": "MIT",
+  "private": true,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Spindle Tokensの最初は単独でリリース作業をしたいので、一度privateにしておき、先にアイコンのリリースをしてしまいます。


```sh
% npx lerna changed
lerna notice cli v4.0.0
lerna info versioning independent
lerna info Looking for changed packages since @openameba/spindle-icons@0.16.0
@openameba/spindle-icons
@openameba/spindle-tokens
@openameba/spindle-ui
```