### PR TITLE
chore(release): publish

### DIFF
--- a/packages/spindle-tokens/CHANGELOG.md
+++ b/packages/spindle-tokens/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2021-10-14)
+
+
+### Bug Fixes
+
+* **spindle-tokens:** fix typo ([ddf81af](https://github.com/openameba/spindle/commit/ddf81af2a841039ae2cf80ab863f6dbeee27dbe8))
+* **spindle-tokens:** token alias ([25c98de](https://github.com/openameba/spindle/commit/25c98de1a548015ddad0ed3f9fac585e66e82cb6))
+
+
+### Features
+
+* **spindle-tokens:** add JSON Flat format ([bd2b333](https://github.com/openameba/spindle/commit/bd2b3332c710cc121c9725d03039c2d6f71b9a8d))
+* **spindle-tokens:** add tokens exported from Figma ([e884c7b](https://github.com/openameba/spindle/commit/e884c7b2d10aab74f1ad87b591ced78b2dcf3681))
+* **spindle-tokens:** create package ([d9c5e72](https://github.com/openameba/spindle/commit/d9c5e72120d049bb5306c54120c043422b76ecac))
+* **spindle-tokens:** extract style dictionary style alias ([6a7df30](https://github.com/openameba/spindle/commit/6a7df3075856c4c44664880867b1ad17a6dc7708))
+* **spindle-tokens:** shadow tokens ([12bb018](https://github.com/openameba/spindle/commit/12bb0181ee6fe6bc8de7d169bcb45153868c4f2b))

--- a/packages/spindle-tokens/package.json
+++ b/packages/spindle-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openameba/spindle-tokens",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Spindle design tokens.",
   "homepage": "https://github.com/openameba/spindle#readme",
   "license": "MIT",


### PR DESCRIPTION
`@openameba/spindle-tokens` がリリースされました。
