### PR TITLE
Lightedから試験中ステータスを削除

### DIFF
--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -320,12 +320,6 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 ## Lighted
 
-![stability-experiment](https://img.shields.io/badge/stability-experiment-red.svg)
-
-<Description>
-  Neutralからの状態変化先のスタイルとして定義しており、単独での利用は推奨していません。Lightedは試験的なVarientであるため、今後に破壊的な変更や削除がおこなわれる可能性があることに注意して利用してください。
-</Description>
-
 <Preview withSource="open">
   <Story name="Lighted">
     <Button size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}>Lighted</Button>

--- a/packages/spindle-ui/src/IconButton/IconButton.stories.mdx
+++ b/packages/spindle-ui/src/IconButton/IconButton.stories.mdx
@@ -176,12 +176,6 @@ import { PlusBold } from '../Icon';
 
 ## Lighted
 
-![stability-experiment](https://img.shields.io/badge/stability-experiment-red.svg)
-
-<Description>
-  Neutralからの状態変化先のスタイルとして定義しており、単独での利用は推奨していません。Lightedは試験的なVarientであるため、今後に破壊的な変更や削除がおこなわれる可能性があることに注意して利用してください。
-</Description>
-
 <Preview withSource="open">
   <Story name="Lighted">
     <IconButton size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>


### PR DESCRIPTION
# 概要

`Button` のバリエーションにあった `Lighted` を本番採用するコンポーネントにするため、Storybook上の試験中扱いのバッジを削除した

fix: #164 