### PR TITLE
feat(spindle-tokens): add category to color tokens

### DIFF
--- a/packages/spindle-tokens/lib/output-styles-as-style-dictionary.test.ts
+++ b/packages/spindle-tokens/lib/output-styles-as-style-dictionary.test.ts
@@ -122,6 +122,9 @@ describe('style output as style dictionary JSON', () => {
         path.resolve(output, fileName),
         '{\n' +
           '  "variable-name": {\n' +
+          '    "attributes": {\n' +
+          '      "category": "color"\n' +
+          '    },\n' +
           '    "comment": "lorem ipsum",\n' +
           '    "value": "rgba(0, 0, 0, 1)"\n' +
           '  }\n' +
@@ -145,6 +148,9 @@ describe('style output as style dictionary JSON', () => {
         path.resolve(output, fileName),
         '{\n' +
           '  "variable-name": {\n' +
+          '    "attributes": {\n' +
+          '      "category": "color"\n' +
+          '    },\n' +
           '    "comment": "Alias",\n' +
           '    "value": "{Color.Primitive.Green}"\n' +
           '  }\n' +
@@ -168,6 +174,9 @@ describe('style output as style dictionary JSON', () => {
         path.resolve(output, fileName),
         '{\n' +
           '  "variable-name": {\n' +
+          '    "attributes": {\n' +
+          '      "category": "color"\n' +
+          '    },\n' +
           '    "comment": "DO: !!, DO NOT: !!!",\n' +
           '    "value": "{Color.Primitive.Green}"\n' +
           '  }\n' +

--- a/packages/spindle-tokens/lib/output-styles-as-style-dictionary.ts
+++ b/packages/spindle-tokens/lib/output-styles-as-style-dictionary.ts
@@ -18,6 +18,9 @@ type Options = {
 type ColorToken = {
   comment?: string;
   value?: string;
+  attributes: {
+    category: 'color';
+  };
 };
 
 type DropShadowToken = {
@@ -64,7 +67,9 @@ export function exporter({
                   .join('.');
                 const name = i === 0 ? propArray : `${propArray}.${i}`;
 
-                const objectValue: ColorToken = {};
+                const objectValue: ColorToken = {
+                  attributes: { category: 'color' },
+                };
                 let aliasValue;
 
                 if (style.comment) {


### PR DESCRIPTION
主にネイティブアプリ用のデザイントークンファイルを作る際に、カテゴリごとにフィルタリングする用途がありそうなので、Style Dictionary用のJSONに`attributes: { category: 'color' }`を付与しました。これにより書き出すJSONにもカテゴリが追加されます。

https://github.com/amzn/style-dictionary/blob/4ff8a2d9298d430fcafcf4403fc25fd3e36c7cb6/lib/common/formats.js#L538-L541