### PR TITLE
chore: fix server port

### DIFF
--- a/packages/spindle-syntax-themes/package.json
+++ b/packages/spindle-syntax-themes/package.json
@@ -21,7 +21,7 @@
     "build:example": "npx rimraf public && npx cpx '*.{html,css,ico}' public",
     "predeploy": "yarn build:example",
     "deploy": "firebase deploy --only hosting",
-    "serve": "npx serve"
+    "serve": "npx serve -p 5000"
   },
   "devDependencies": {
     "@acot/acot-config": "^0.0.12",


### PR DESCRIPTION
## 概要
`npx serve`のデフォルトポートが5000から3000番に変更されていたので、5000で固定するようにしました。
https://github.com/vercel/serve/releases/tag/13.0.0

mainブランチでテストが通らなくなっていたのは、acotでlocalhost:5000を見ようとしていたからのようです。