### PR TITLE
HeroCarouselを追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,5 +18,13 @@
   "env": {
     "browser": true,
     "node": true
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.tsx"],
+      "rules": {
+        "react/prop-types": "off"
+      }
+    }
+  ]
 }

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.css
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.css
@@ -1,0 +1,109 @@
+/*
+ * HeroCarousel
+ * NOTE: Styles can be overridden with "--HeroCarousel-*" variables
+*/
+:root {
+  --HeroCarousel-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
+    0 0 0 3px var(--color-focus-clarity);
+}
+
+.spui-HeroCarousel-container {
+  align-items: center;
+  display: flex;
+  height: 11.6em;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0.6rem 0;
+}
+
+.spui-HeroCarousel-list {
+  display: flex;
+  margin-right: 0.88em;
+  padding: 0 0.44em;
+  transition: transform 0.5s;
+  width: 16.7em;
+}
+
+.spui-HeroCarousel-controls {
+  align-items: center;
+  border: 1px solid var(--color-border-low-emphasis);
+  border-radius: 100px;
+  display: flex;
+  margin: 0.88em auto 0;
+  width: fit-content;
+}
+
+.spui-HeroCarousel-control {
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  display: flex;
+  height: 3em;
+  justify-content: center;
+  padding: 0;
+  width: 3em;
+}
+
+.spui-HeroCarousel-control:hover {
+  opacity: 0.7;
+}
+
+.spui-HeroCarousel-control:focus {
+  box-shadow: var(--HeroCarousel-onFocus-boxShadow);
+  outline: none;
+}
+
+.spui-HeroCarousel-control:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.spui-HeroCarousel-control--prev {
+  border-radius: 100px 0 0 100px;
+  border-right: 1px solid var(--color-border-low-emphasis);
+}
+
+.spui-HeroCarousel-control--next {
+  border-left: 1px solid var(--color-border-low-emphasis);
+  border-radius: 0 100px 100px 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spui-HeroCarousel-list {
+    transition: 1ms;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .spui-HeroCarousel-container {
+    height: 13em;
+  }
+
+  .spui-HeroCarousel-list {
+    margin-right: 1.5em;
+    padding: 0 0.75em;
+    width: 18.5em;
+  }
+
+  .spui-HeroCarousel-controls {
+    margin-top: 1.25em;
+  }
+
+  .spui-HeroCarousel-control {
+    height: 3.3em;
+    width: 3.3em;
+  }
+}
+
+/* stylelint-disable plugin/selector-bem-pattern */
+.spui-HeroCarousel-control > svg {
+  color: var(--color-text-low-emphasis);
+  height: 1.35em;
+  width: 1.35em;
+}
+
+@media screen and (min-width: 768px) {
+  .spui-HeroCarousel-control > svg {
+    height: 1.5em;
+    width: 1.5em;
+  }
+}

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.stories.mdx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.stories.mdx
@@ -1,0 +1,95 @@
+import { useState, useEffect, useRef, forwardRef } from 'react';
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { actions } from '@storybook/addon-actions';
+import { HeroCarousel } from './HeroCarousel';
+
+export const carouselList = [
+  {
+    title: '1. 生きたコンテンツをつむぐ',
+    imageUrl:
+      'https://images.microcms-assets.io/assets/24995dc41d5c40808fe4a9e3f6fb2b20/e2526e7bfa494168a2e547cfe55ac89f/top_mv.jpg?w=640&h=336&fit=crop&fm=webp&q=85',
+    link: 'https://about.ameba.jp/',
+  },
+  {
+    title: '2. 長期間続けるためのシステム開発',
+    imageUrl:
+      'https://images.microcms-assets.io/assets/24995dc41d5c40808fe4a9e3f6fb2b20/8582f4d2842741f78a7d8496019a2be2/team_article_003_cover.png?w=640&h=336&fm=webp&q=85',
+    link: 'https://about.ameba.jp/contents/czriiu_tv/',
+  },
+  {
+    title: '3. 「Spindle」成立の軌跡',
+    imageUrl:
+      'https://images.microcms-assets.io/assets/24995dc41d5c40808fe4a9e3f6fb2b20/eb868ea0d6af41aaaff3091b7c1d4cfb/team_article_002_cover.png?w=640&h=336&fm=webp&q=85',
+    link: 'https://about.ameba.jp/contents/ed88wdx61mf1/',
+  },
+  {
+    title: '4. Amebaでブログを書こう',
+    imageUrl:
+      'https://stat100.ameba.jp/ameblo/sp/img/amebloJp/ogp_image.png',
+    link: 'https://ameblo.jp/',
+  },
+  {
+    title: '5. 「人」や「文化」をご紹介',
+    imageUrl:
+      'https://images.microcms-assets.io/assets/24995dc41d5c40808fe4a9e3f6fb2b20/2ed4baaeb1b24a0096bef49b087fbe38/team_article_004__cover%402x.jpg?w=640&h=336&fit=crop&fm=webp&q=85',
+    link: 'https://about.ameba.jp/team/',
+  },
+];
+
+# HeroCarousel
+
+<Meta title="HeroCarousel" component={HeroCarousel} />
+
+![stability-wip](https://img.shields.io/badge/stability-work_in_progress-lightgrey.svg)
+
+<Source
+  language="javascript"
+  code={`import { HeroCarousel } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language="css"
+  code={`@import './node_modules/@openameba/spindle-ui/HeroCarousel/HeroCarousel.css'`}
+/>
+
+<Source
+  language="html"
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/HeroCarousel/HeroCarousel.css">`}
+/>
+
+## Normal
+
+<Preview withSource="open">
+  <Story name="Normal">
+    <HeroCarousel carouselList={carouselList} />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<HeroCarousel carouselList={carouselList} />
+  `}
+/>
+
+<Description>
+  carouselListはlink, imageUrl, titleの3つからなります。titleが2行以上になる場合は三点リーダーで省略されます。
+</Description>
+
+## このコンポーネントでやっていること
+<Description>
+  - スライドの自動再生を停止/再開するボタンが配置されています。また、前後のスライドに移動するボタンも配置されています
+</Description>
+<Description>
+  - キーボード・フォーカスがスライドに入っているとき、自動再生は止まります。また、スライドにマウス・ホバーしているときも止まります
+</Description>
+<Description>
+  - reduced motionが指定された時に、アニメーションを軽減または削除します
+</Description>
+
+## 利用時に注意してほしいこと
+<Description>
+  - HeroCarouselは、表示するコンテンツが複数存在する前提で実装されています。そのため、1つのコンテンツに対して使用することは避けてください
+</Description>
+<Description>
+  - コンテンツが1つもない場合、HeroCarouselは表示されません
+</Description>

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.tsx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.tsx
@@ -1,0 +1,107 @@
+import React, { FC } from 'react';
+import ChevronLeftBold from '../Icon/ChevronLeftBold';
+import ChevronRightBold from '../Icon/ChevronRightBold';
+import Pause from '../Icon/Pause';
+import PlayFill from '../Icon/PlayFill';
+import type { CarouselItem } from './HeroCarouselItem';
+import HeroCarouselItem from './HeroCarouselItem';
+import { useAutoPlayCarousel } from './hooks/useAutoPlayCarousel';
+
+type Props = {
+  carouselList: CarouselItem[];
+};
+
+const BLOCK_NAME = 'spui-HeroCarousel';
+const ITEM_LINK_CLASS_NAME = 'js-auto-play-carousel-item-link';
+
+export const HeroCarousel: FC<Props> = React.memo(function HeroCarousel({
+  carouselList,
+}) {
+  if (carouselList.length === 0) {
+    return null;
+  }
+
+  const {
+    handleSlideToPrev,
+    handleSlideToNext,
+    handleMouseEnter,
+    handleMouseDown,
+    handleMouseLeave,
+    handleTouchStart,
+    handleTransitionEnd,
+    isAutoPlaying,
+    isLinkClicked,
+    itemsToRender,
+    listRef,
+    listStyles,
+    toggleAutoPlay,
+    handleFocus,
+    handleBlur,
+  } = useAutoPlayCarousel({
+    items: carouselList,
+    itemLinkClassName: ITEM_LINK_CLASS_NAME,
+  });
+
+  return (
+    <div>
+      <div
+        className={`${BLOCK_NAME}-container`}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        onMouseDown={handleMouseDown}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onTouchStart={handleTouchStart}
+        onTransitionEnd={handleTransitionEnd}
+      >
+        <ul
+          aria-roledescription="カルーセル"
+          className={`${BLOCK_NAME}-list`}
+          ref={listRef}
+          role="group"
+          style={listStyles}
+        >
+          {itemsToRender.map((item: CarouselItem, index: number) => (
+            <HeroCarouselItem
+              carouselItem={item}
+              isLinkClicked={isLinkClicked}
+              itemLinkClassName={ITEM_LINK_CLASS_NAME}
+              key={`hero-carousel-${index}`}
+            />
+          ))}
+        </ul>
+      </div>
+
+      <div className={`${BLOCK_NAME}-controls`}>
+        <button
+          aria-label="1つ前のアイテムに移動"
+          className={`${BLOCK_NAME}-control ${BLOCK_NAME}-control--prev`}
+          type="button"
+          onClick={handleSlideToPrev}
+        >
+          <ChevronLeftBold aria-hidden={true} />
+        </button>
+        <button
+          aria-label={isAutoPlaying ? 'スライドを停止' : 'スライドを再生'}
+          className={`${BLOCK_NAME}-control`}
+          type="button"
+          onClick={toggleAutoPlay}
+        >
+          {isAutoPlaying ? (
+            <Pause aria-hidden={true} />
+          ) : (
+            <PlayFill aria-hidden={true} />
+          )}
+        </button>
+        <button
+          aria-label="1つ後ろのアイテムに移動"
+          className={`${BLOCK_NAME}-control ${BLOCK_NAME}-control--next`}
+          type="button"
+          onClick={handleSlideToNext}
+        >
+          <ChevronRightBold aria-hidden={true} />
+        </button>
+      </div>
+    </div>
+  );
+});

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.css
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.css
@@ -1,0 +1,88 @@
+/*
+ * HeroCarouselItem
+ * NOTE: Styles can be overridden with "--HeroCarouselItem-*" variables
+*/
+:root {
+  --HeroCarouselItem-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
+    0 0 0 3px var(--color-focus-clarity);
+}
+.spui-HeroCarouselItem-listItem {
+  list-style: none;
+  padding: 0 0.44em;
+  width: 100%;
+}
+
+.spui-HeroCarouselItem-link {
+  border: 1px solid var(--color-border-low-emphasis);
+  border-radius: 12px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 12em;
+  text-decoration: none;
+}
+
+.spui-HeroCarouselItem-link:focus {
+  box-shadow: var(--HeroCarouselItem-onFocus-boxShadow);
+  outline: none;
+}
+
+.spui-HeroCarouselItem-link:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.spui-HeroCarouselItem-imageBlock {
+  align-items: center;
+  border-bottom: 1px solid var(--color-border-low-emphasis);
+  border-radius: 12px 12px 0 0;
+  display: flex;
+  height: 9.5em;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.spui-HeroCarouselItem-image {
+  height: 100%;
+}
+
+.spui-HeroCarouselItem-titleContainer {
+  align-items: center;
+  box-sizing: border-box;
+  display: flex;
+  height: 2.89em;
+  justify-content: center;
+  padding: 0 0.5em;
+}
+
+.spui-HeroCarouselItem-title {
+  color: var(--color-text-high-emphasis);
+  font-size: 0.9375em;
+  font-weight: bold;
+  margin: 0;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media screen and (min-width: 768px) {
+  .spui-HeroCarouselItem-listItem {
+    padding: 0 0.75em;
+  }
+
+  .spui-HeroCarouselItem-link {
+    height: 13.8em;
+  }
+
+  .spui-HeroCarouselItem-titleContainer {
+    height: 3.3em;
+  }
+
+  .spui-HeroCarouselItem-title {
+    font-size: 1em;
+  }
+
+  .spui-HeroCarouselItem-imageBlock {
+    height: 10.9em;
+  }
+}

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.tsx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, FC } from 'react';
+import './HeroCarouselItem.css';
+
+export type CarouselItem = {
+  imageUrl: string;
+  link: string;
+  title: string;
+};
+
+type Props = {
+  carouselItem: CarouselItem;
+  isLinkClicked: boolean;
+  itemLinkClassName: string;
+};
+
+const BLOCK_NAME = 'spui-HeroCarouselItem';
+
+export const HeroCarouselItem: FC<Props> = React.memo(
+  function HeroCarouselItem({
+    carouselItem,
+    isLinkClicked,
+    itemLinkClassName,
+  }) {
+    const handleLinkClick = useCallback(
+      (e: React.KeyboardEvent | React.MouseEvent) => {
+        if (!isLinkClicked) {
+          e.preventDefault();
+        }
+      },
+      [isLinkClicked],
+    );
+
+    return (
+      <li className={`${BLOCK_NAME}-listItem`}>
+        <a
+          className={`${itemLinkClassName} ${BLOCK_NAME}-link`}
+          href={carouselItem.link}
+          onClick={handleLinkClick}
+        >
+          <span className={`${BLOCK_NAME}-imageBlock`}>
+            <img
+              alt=""
+              className={`${BLOCK_NAME}-image`}
+              src={carouselItem.imageUrl}
+            />
+          </span>
+          <div className={`${BLOCK_NAME}-titleContainer`}>
+            <p className={`${BLOCK_NAME}-title`}>{carouselItem.title}</p>
+          </div>
+        </a>
+      </li>
+    );
+  },
+  (prevProps, nextProps) =>
+    prevProps.isLinkClicked === nextProps.isLinkClicked &&
+    prevProps.itemLinkClassName === nextProps.itemLinkClassName &&
+    prevProps.carouselItem.title === nextProps.carouselItem.title &&
+    prevProps.carouselItem.link === nextProps.carouselItem.link &&
+    prevProps.carouselItem.imageUrl === nextProps.carouselItem.imageUrl,
+);
+
+export default HeroCarouselItem;

--- a/packages/spindle-ui/src/HeroCarousel/hooks/useAutoPlayCarousel.ts
+++ b/packages/spindle-ui/src/HeroCarousel/hooks/useAutoPlayCarousel.ts
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAutoSlide } from './useAutoSlide';
+import { useCarouselFocus } from './useCarouselFocus';
+import { useSliderMoveEvent } from './useSliderMoveEvent';
+import { useSliderTransition } from './useSliderTransition';
+import { useValueRef } from './useValueRef';
+
+type Payload<Item> = {
+  items: Item[];
+  itemLinkClassName: string;
+};
+
+const COPY_COUNT = 5;
+const SWIPE_THRESHOLD_X = 20;
+
+export function useAutoPlayCarousel<Item>({
+  items,
+  itemLinkClassName,
+}: Payload<Item>) {
+  const {
+    diffXRef,
+    diffYRef,
+    setDiffX,
+    setDiffY,
+    setStartX,
+    setStartY,
+  } = useSliderMoveEvent();
+  const [focusOffset, setFocusOffset] = useState(0);
+  const [isHovering, setIsHovering] = useState(false);
+  const [isLinkClicked, setIsLinkClicked] = useState(false);
+  const isHoveringRef = useValueRef(isHovering);
+  const slideToNextRef = useValueRef(() => slideToNext());
+  const itemCount = useMemo(() => items.length, [items]);
+  const getIsCopiedItem = useCallback(
+    (index: number) => {
+      return index < COPY_COUNT || index >= itemCount + COPY_COUNT;
+    },
+    [itemCount],
+  );
+  const {
+    isAutoPlaying,
+    setIsAutoPlaying,
+    resetAutoSlide,
+    resetTimeOut,
+    toggleAutoPlay,
+  } = useAutoSlide({
+    onTimeOut: slideToNextRef.current,
+  });
+  const { linkRefs, listRef } = useCarouselFocus({
+    getIsCopiedItem,
+    itemLinkClassName,
+  });
+  const isAutoPlayingRef = useValueRef(isAutoPlaying);
+  const {
+    currentIndexRef,
+    handleTransitionEnd,
+    listStyles,
+    setCurrentIndex,
+    setDisableAutoFocus,
+    setDisableTransition,
+  } = useSliderTransition({
+    copyCount: COPY_COUNT,
+    itemCount,
+    isAutoPlaying,
+    linkRefs,
+  });
+
+  const itemsToRender = useMemo(
+    // generate copy contents on both ends to make carousel look like looping
+    () => [
+      ...items.slice(-COPY_COUNT),
+      ...items,
+      ...items.slice(0, COPY_COUNT),
+    ],
+    [items],
+  );
+
+  const slideToNext = (ignoreHover = false) => {
+    const shouldSlideToNext =
+      ((!isHoveringRef.current && isAutoPlayingRef.current) || ignoreHover) &&
+      currentIndexRef.current <= itemCount;
+
+    if (shouldSlideToNext) {
+      setDisableTransition(false);
+      setCurrentIndex(currentIndexRef.current + 1);
+    }
+    resetAutoSlide();
+  };
+
+  const slideToPrev = () => {
+    if (currentIndexRef.current >= 0) {
+      setDisableTransition(false);
+      setCurrentIndex(currentIndexRef.current - 1);
+    }
+    resetAutoSlide();
+  };
+
+  const handleMouseEnter = () => setIsHovering(true);
+
+  const handleMouseLeave = () => {
+    setIsHovering(false);
+    resetAutoSlide();
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    resetTimeOut();
+    setStartX(e.clientX);
+    setStartY(e.clientY);
+  };
+
+  const onMouseUp = () => {
+    if (diffXRef.current > SWIPE_THRESHOLD_X) {
+      setIsLinkClicked(false);
+      setIsAutoPlaying(false);
+      slideToPrev();
+    }
+    if (diffXRef.current < -SWIPE_THRESHOLD_X) {
+      setIsLinkClicked(false);
+      setIsAutoPlaying(false);
+      slideToNext(true);
+    }
+    if (diffXRef.current === 0 && diffYRef.current === 0) {
+      setIsLinkClicked(true);
+    }
+
+    setStartX(null);
+    setStartY(null);
+    setDiffX(0);
+    setDiffY(0);
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (!e.touches.length) return;
+
+    const touch = e.touches[0];
+
+    resetTimeOut();
+    handleMouseEnter();
+    setStartX(touch.clientX);
+    setStartY(touch.clientY);
+  };
+
+  const onTouchEnd = () => {
+    setIsHovering(false);
+    onMouseUp();
+  };
+
+  const handleSlideToPrev = () => {
+    resetTimeOut();
+    setIsAutoPlaying(false);
+    slideToPrev();
+  };
+
+  const handleSlideToNext = () => {
+    resetTimeOut();
+    setIsAutoPlaying(false);
+    slideToNext(true);
+  };
+
+  const handleFocus = (e: React.FocusEvent<HTMLDivElement>) => {
+    setIsAutoPlaying(false);
+
+    const { offsetLeft: newFocusOffset } = e.target;
+
+    setFocusOffset(newFocusOffset);
+
+    if (focusOffset === 0) {
+      return;
+    }
+
+    setDisableAutoFocus(true);
+
+    if (isHovering && diffXRef.current === 0 && diffYRef.current === 0) {
+      setIsLinkClicked(true);
+      return;
+    }
+    if (focusOffset > newFocusOffset) {
+      setDisableTransition(false);
+      setCurrentIndex(currentIndexRef.current - 1);
+    }
+    if (focusOffset < newFocusOffset) {
+      setDisableTransition(false);
+      setCurrentIndex(currentIndexRef.current + 1);
+    }
+  };
+
+  const handleBlur = () => {
+    setIsAutoPlaying(true);
+  };
+
+  useEffect(() => {
+    document.body.addEventListener('mouseup', onMouseUp);
+    document.body.addEventListener('touchend', onTouchEnd);
+
+    return () => {
+      document.body.removeEventListener('mouseup', onMouseUp);
+      document.body.removeEventListener('touchend', onTouchEnd);
+    };
+  }, []);
+
+  return {
+    handleSlideToPrev,
+    handleSlideToNext,
+    handleMouseEnter,
+    handleMouseDown,
+    handleMouseLeave,
+    handleTouchStart,
+    handleTransitionEnd,
+    isAutoPlaying,
+    isLinkClicked,
+    itemsToRender,
+    listRef,
+    listStyles,
+    toggleAutoPlay,
+    handleFocus,
+    handleBlur,
+  };
+}

--- a/packages/spindle-ui/src/HeroCarousel/hooks/useAutoSlide.ts
+++ b/packages/spindle-ui/src/HeroCarousel/hooks/useAutoSlide.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const AUTO_SLIDE_SPEED = 4000; // ms
+
+type Payload = {
+  onTimeOut: () => void;
+};
+
+export function useAutoSlide({ onTimeOut }: Payload) {
+  const [isAutoPlaying, setIsAutoPlaying] = useState(true);
+  const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null);
+
+  const resetTimeOut = useCallback(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }, [timeoutId]);
+
+  const activateAutoSlide = () => {
+    resetTimeOut();
+
+    const newTimeoutId = setTimeout(() => {
+      onTimeOut();
+    }, AUTO_SLIDE_SPEED);
+
+    setTimeoutId(newTimeoutId);
+  };
+
+  const resetAutoSlide = () => {
+    if (isAutoPlaying) {
+      activateAutoSlide();
+    }
+  };
+
+  const toggleAutoPlay = () => {
+    resetTimeOut();
+
+    if (!isAutoPlaying) {
+      activateAutoSlide();
+    }
+    setIsAutoPlaying((prev) => !prev);
+  };
+
+  useEffect(() => {
+    activateAutoSlide();
+  }, []);
+
+  return {
+    isAutoPlaying,
+    setIsAutoPlaying,
+    resetAutoSlide,
+    resetTimeOut,
+    toggleAutoPlay,
+  };
+}

--- a/packages/spindle-ui/src/HeroCarousel/hooks/useCarouselFocus.ts
+++ b/packages/spindle-ui/src/HeroCarousel/hooks/useCarouselFocus.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+
+type Payload = {
+  getIsCopiedItem: (index: number) => boolean;
+  itemLinkClassName: string;
+};
+
+export function useCarouselFocus({
+  getIsCopiedItem,
+  itemLinkClassName,
+}: Payload) {
+  const listRef = useRef<HTMLUListElement>(null);
+  const linkRefs = useRef<HTMLLinkElement[]>([]);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+
+    const linkElements = listRef.current.querySelectorAll(
+      `a.${itemLinkClassName}`,
+    );
+
+    if (!linkElements) return;
+
+    // NOTE: use NodeList forEach as IE polyfill
+    Array.prototype.forEach.call(
+      linkElements,
+      (link: HTMLLinkElement, index) => {
+        linkRefs.current.push(link);
+        link.setAttribute('tabindex', getIsCopiedItem(index) ? '-1' : '0');
+        link.setAttribute(
+          'aria-hidden',
+          getIsCopiedItem(index) ? 'true' : 'false',
+        );
+      },
+    );
+  }, [getIsCopiedItem, itemLinkClassName]);
+
+  return {
+    linkRefs,
+    listRef,
+  };
+}

--- a/packages/spindle-ui/src/HeroCarousel/hooks/useSliderMoveEvent.ts
+++ b/packages/spindle-ui/src/HeroCarousel/hooks/useSliderMoveEvent.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { useValueRef } from './useValueRef';
+
+export function useSliderMoveEvent() {
+  const [diffX, setDiffX] = useState(0);
+  const [diffY, setDiffY] = useState(0);
+  const [startX, setStartX] = useState<number | null>(null);
+  const [startY, setStartY] = useState<number | null>(null);
+  const diffXRef = useValueRef(diffX);
+  const diffYRef = useValueRef(diffY);
+  const startXRef = useValueRef(startX);
+  const startYRef = useValueRef(startY);
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (startXRef.current === null || startYRef.current === null) return;
+
+    e.preventDefault();
+
+    setDiffX(e.clientX - startXRef.current);
+    setDiffY(e.clientY - startYRef.current);
+  };
+
+  const onTouchMove = (e: TouchEvent) => {
+    if (
+      startXRef.current === null ||
+      startYRef.current === null ||
+      !e.touches.length
+    ) {
+      return;
+    }
+
+    const touch = e.touches[0];
+
+    setDiffX(touch.clientX - startXRef.current);
+    setDiffY(touch.clientY - startYRef.current);
+  };
+
+  useEffect(() => {
+    document.body.addEventListener('mousemove', onMouseMove);
+    document.body.addEventListener('touchmove', onTouchMove, {
+      passive: true,
+    });
+
+    return () => {
+      document.body.removeEventListener('mousemove', onMouseMove);
+      document.body.removeEventListener('touchmove', onTouchMove);
+    };
+  }, []);
+
+  return {
+    diffXRef,
+    diffYRef,
+    setDiffX,
+    setDiffY,
+    setStartX,
+    setStartY,
+  };
+}

--- a/packages/spindle-ui/src/HeroCarousel/hooks/useSliderTransition.ts
+++ b/packages/spindle-ui/src/HeroCarousel/hooks/useSliderTransition.ts
@@ -1,0 +1,48 @@
+import { useMemo, useState, MutableRefObject } from 'react';
+import { useValueRef } from './useValueRef';
+
+type Payload = {
+  copyCount: number;
+  itemCount: number;
+  linkRefs: MutableRefObject<HTMLLinkElement[]>;
+  isAutoPlaying: boolean;
+};
+
+export function useSliderTransition({
+  copyCount,
+  itemCount,
+  linkRefs,
+  isAutoPlaying,
+}: Payload) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const currentIndexRef = useValueRef(currentIndex);
+  const [disableTransition, setDisableTransition] = useState(false);
+  const [disableAutoFocus, setDisableAutoFocus] = useState(false);
+
+  const listStyles = useMemo(() => {
+    return {
+      transition: disableTransition ? 'none' : '',
+      transform: `translate3d(${
+        -100 * (currentIndex + copyCount)
+      }%, 0, 0) translateX(0)`,
+    };
+  }, [copyCount, currentIndex, disableTransition]);
+
+  const handleTransitionEnd = () => {
+    if (!isAutoPlaying && !disableAutoFocus) {
+      linkRefs.current[currentIndex + copyCount].focus();
+    }
+    // if reach contents end, rewind without transition to make it look like looping
+    setDisableTransition(true);
+    setCurrentIndex((prev) => (prev + itemCount) % itemCount);
+  };
+
+  return {
+    currentIndexRef,
+    handleTransitionEnd,
+    listStyles,
+    setCurrentIndex,
+    setDisableAutoFocus,
+    setDisableTransition,
+  };
+}

--- a/packages/spindle-ui/src/HeroCarousel/hooks/useValueRef.ts
+++ b/packages/spindle-ui/src/HeroCarousel/hooks/useValueRef.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef, MutableRefObject } from 'react';
+
+export function useValueRef<T>(value: T): MutableRefObject<T> {
+  const ref = useRef(value);
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref;
+}

--- a/packages/spindle-ui/src/HeroCarousel/index.ts
+++ b/packages/spindle-ui/src/HeroCarousel/index.ts
@@ -1,0 +1,1 @@
+export { HeroCarousel } from './HeroCarousel';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -3,6 +3,7 @@
 @import './Button/Button.css';
 @import './ButtonGroup/ButtonGroup.css';
 @import './Form/index.css';
+@import './HeroCarousel/HeroCarousel.css';
 @import './IconButton/IconButton.css';
 @import './LinkButton/LinkButton.css';
 @import './Toast/Toast.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -2,9 +2,19 @@ import { Button } from './Button';
 import { ButtonGroup } from './ButtonGroup';
 import * as Form from './Form';
 import * as Icon from './Icon';
+import { HeroCarousel } from './HeroCarousel';
 import { IconButton } from './IconButton';
 import { LinkButton } from './LinkButton';
 import { Toast } from './Toast';
 
 // Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
-export { Button, ButtonGroup, Form, Icon, IconButton, LinkButton, Toast };
+export {
+  Button,
+  ButtonGroup,
+  Form,
+  HeroCarousel,
+  Icon,
+  IconButton,
+  LinkButton,
+  Toast,
+};


### PR DESCRIPTION
# 概要
HeroCarouselコンポーネントを追加しました

<img width="1056" alt="スクリーンショット 2022-02-16 20 02 35" src="https://user-images.githubusercontent.com/42470015/154251949-ea9bb795-bf20-48e1-a63c-08d8a0f206cd.png">

最近Ameba Newsで作られたカルーセルが最も最新かつアクセシビリティ要件も考慮されたものだったので、そちらの実装を(基本的には)丸っと持ってきています

本PRの背景とゴールについてはこちら: https://github.com/openameba/spindle/pull/348#issuecomment-1043701618

## Props
HeroCarouselに渡せるPropsは以下です
- [必須]`carouselList`
    - [必須]`imageUrl`(string)
    - [必須]`link`(string)
    - [必須]`title`(string): 2行以上は省略(全角だと18文字までは表示 / 19文字以降は省略される)

もっと細かく設定できるようにしたいのですが、今回のチームの案件は上記で足りるため一旦ミニマムで行きます！
※ 今後HeroCarouselを使う際に不足あるようでしたら、都度足していければと思います :pray

# 関連リンク
諸々の都合上関連リンクを貼れないため、このPRの作成通知が流れるSlackのスレに貼ります 🙏🏻 

ref: https://github.com/openameba/spindle/discussions/336