### PR TITLE
fix HeroCarousel component 

### DIFF
--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.css
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.css
@@ -10,10 +10,9 @@
 .spui-HeroCarousel-container {
   align-items: center;
   display: flex;
-  height: 11.6em;
+  height: 12.5em;
   justify-content: center;
   overflow: hidden;
-  padding: 0.6rem 0;
 }
 
 .spui-HeroCarousel-list {
@@ -21,7 +20,7 @@
   margin-right: 0.88em;
   padding: 0 0.44em;
   transition: transform 0.5s;
-  width: 16.7em;
+  width: 17.5em;
 }
 
 .spui-HeroCarousel-controls {
@@ -29,8 +28,9 @@
   border: 1px solid var(--color-border-low-emphasis);
   border-radius: 100px;
   display: flex;
+  height: 2.5em;
   margin: 0.88em auto 0;
-  width: fit-content;
+  width: 7.63em;
 }
 
 .spui-HeroCarousel-control {
@@ -38,10 +38,11 @@
   background-color: transparent;
   border: none;
   display: flex;
-  height: 3em;
+  font-size: 1em;
+  height: 100%;
   justify-content: center;
   padding: 0;
-  width: 3em;
+  width: calc(100% / 3);
 }
 
 .spui-HeroCarousel-control:hover {
@@ -75,35 +76,32 @@
 
 @media screen and (min-width: 768px) {
   .spui-HeroCarousel-container {
-    height: 13em;
+    height: 14.3em;
   }
 
   .spui-HeroCarousel-list {
     margin-right: 1.5em;
     padding: 0 0.75em;
-    width: 18.5em;
+    width: 20em;
   }
 
   .spui-HeroCarousel-controls {
+    height: 2.75em;
     margin-top: 1.25em;
-  }
-
-  .spui-HeroCarousel-control {
-    height: 3.3em;
-    width: 3.3em;
+    width: 8.38em;
   }
 }
 
 /* stylelint-disable plugin/selector-bem-pattern */
 .spui-HeroCarousel-control > svg {
   color: var(--color-text-low-emphasis);
-  height: 1.35em;
-  width: 1.35em;
+  height: 1.13em;
+  width: 1.13em;
 }
 
 @media screen and (min-width: 768px) {
   .spui-HeroCarousel-control > svg {
-    height: 1.5em;
-    width: 1.5em;
+    height: 1.25em;
+    width: 1.25em;
   }
 }

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.css
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.css
@@ -20,6 +20,7 @@
   flex-direction: column;
   height: 12em;
   text-decoration: none;
+  width: 17.5em;
 }
 
 .spui-HeroCarouselItem-link:focus {
@@ -72,6 +73,7 @@
 
   .spui-HeroCarouselItem-link {
     height: 13.8em;
+    width: 20em;
   }
 
   .spui-HeroCarouselItem-titleContainer {


### PR DESCRIPTION
# 概要
https://github.com/openameba/spindle/pull/348 で追加したHeroCarouselコンポーネントの軽微な修正です

Storybookで確認する分には上記のPRの実装で問題なかったのですが、使用したいページでいざ読み込んで使おうとしたら微妙にレイアウトが崩れていたので対応しました

主な原因: AmebaNewsからコードを移植してくる際に(Storybookで確認する分には)指定しなくて良さそうなスタイルを消したのですが、実はそれが必要だったっぽいです

## 詳細
1. スライド部分が中心より左にずれる→ 横幅を指定して対応: https://github.com/openameba/spindle/commit/3021f531d9247bb3893fbb4069c1ac35a97b36f5

| before | after |
| -- | -- |
| ![スクリーンショット 2022-02-22 18 18 24](https://user-images.githubusercontent.com/42470015/155107154-0fa2e00b-6bac-4172-bebc-9024cf128664.png) | ![スクリーンショット 2022-02-22 18 51 48](https://user-images.githubusercontent.com/42470015/155107294-e33773a3-2893-4e07-8b49-2d6300a15823.png) |

2. Controlsのサイズが微妙に大きい → 各controlにサイズを当てるのではなく、controls全体にサイズを指定して対応。また、アイコンのサイズが常に一定になるように対応: https://github.com/openameba/spindle/commit/8ab568cd11d97c052638d6dab4d42df24a761c8e

| before | after |
| -- | -- |
| ![スクリーンショット 2022-02-22 18 18 12](https://user-images.githubusercontent.com/42470015/155107913-d8516782-7b72-429a-8c80-51bd1ec6ed6a.png) | ![スクリーンショット 2022-02-22 18 53 32](https://user-images.githubusercontent.com/42470015/155107934-82d141cb-cdb6-402f-885c-c45caf2096d3.png) |

# 確認項目
- [x] Storybook上での表示が修正前後で変わっていないこと
- [x] 使用したいページのリポジトリの`node_modules/@openameba/spindle-ui/HeroCarousel/`を今回の修正内容で直接書き換えた時に、Storybook上の表示と同じこと