### PR TITLE
fix(spindle-ui): do not use CSS import in JS

### DIFF
--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.css
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.css
@@ -1,3 +1,4 @@
+@import './HeroCarouselItem.css';
 /*
  * HeroCarousel
  * NOTE: Styles can be overridden with "--HeroCarousel-*" variables

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.tsx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, FC } from 'react';
-import './HeroCarouselItem.css';
 
 export type CarouselItem = {
   imageUrl: string;


### PR DESCRIPTION
`HeroCarousel`内で利用される`HeroCarouselItem`で JS 内から CSS を import しないようにし、`HeroCarousel.css` の中で読み込むようにしました。

Next.jsで利用する場合に [CSS の読み込みが上手くいかずエラーとなってしまう](https://nextjs.org/docs/messages/css-npm)ため、その修正です。
