### PR TITLE
feat(spindle-ui): add Breadcrumb component

### DIFF
--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -43,8 +43,8 @@
 .spui-Breadcrumb a[href]::before {
   border-radius: 4px;
   content: '';
-  height: 56px;
   left: 0;
+  min-height: 56px;
   position: absolute;
   top: -50%;
   width: 100%;
@@ -98,7 +98,7 @@
   }
 
   .spui-Breadcrumb a[href]::before {
-    height: 40px;
+    min-height: 40px;
   }
   /* stylelint-enable plugin/selector-bem-pattern */
 

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -5,7 +5,8 @@
   background: var(--color-surface-secondary);
   border-radius: 70px;
   display: inline-block;
-  padding: 0 12px;
+  overflow: hidden;
+  padding: 0 16px;
 }
 
 .spui-Breadcrumb-list {
@@ -19,6 +20,7 @@
 .spui-Breadcrumb-item {
   align-items: center;
   display: flex;
+  min-height: 56px;
 }
 
 /* stylelint-disable plugin/selector-bem-pattern */
@@ -27,14 +29,25 @@
   display: flex;
   letter-spacing: 0.1em;
   line-height: 1.3;
-  min-height: 56px;
-  padding: 0 12px;
+  padding: 4px 8px;
+  position: relative;
 }
 
 .spui-Breadcrumb a[href] {
+  border-radius: 4px;
   color: var(--color-text-accent-primary);
   font-weight: bold;
   text-decoration: none;
+}
+
+.spui-Breadcrumb a[href]::before {
+  border-radius: 4px;
+  content: '';
+  height: 56px;
+  left: 0;
+  position: absolute;
+  top: -50%;
+  width: 100%;
 }
 
 .spui-Breadcrumb a[href]:hover {
@@ -45,11 +58,22 @@
   color: var(--color-text-low-emphasis);
   font-weight: normal;
 }
+
+.spui-Breadcrumb a:focus {
+  box-shadow: 0 0 0 1px var(--color-surface-secondary),
+    0 0 0 3px var(--color-focus-clarity);
+  outline: none;
+}
+
+.spui-Breadcrumb a:focus:not(:focus-visible) {
+  box-shadow: none;
+}
 /* stylelint-enable plugin/selector-bem-pattern */
 
 .spui-Breadcrumb-chevron {
   color: var(--color-object-low-emphasis);
   height: 16px;
+  padding: 0 4px;
   width: 16px;
 }
 
@@ -60,19 +84,27 @@
 
 @media screen and (max-width: 375px) {
   .spui-Breadcrumb {
-    padding: 0 12px;
+    padding: 0 14px;
+  }
+
+  .spui-Breadcrumb-item {
+    min-height: 40px;
   }
 
   /* stylelint-disable plugin/selector-bem-pattern */
   .spui-Breadcrumb a {
     font-size: 0.8125em;
-    min-height: 40px;
-    padding: 0 8px;
+    padding: 2px 6px;
+  }
+
+  .spui-Breadcrumb a[href]::before {
+    height: 40px;
   }
   /* stylelint-enable plugin/selector-bem-pattern */
 
   .spui-Breadcrumb-chevron {
     height: 12px;
+    padding: 0 2px;
     width: 12px;
   }
 }

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -1,0 +1,78 @@
+/*
+ * Breadcrumb
+*/
+.spui-Breadcrumb {
+  background: var(--color-surface-secondary);
+  border-radius: 70px;
+  display: inline-block;
+  padding: 0 12px;
+}
+
+.spui-Breadcrumb-list {
+  align-items: center;
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.spui-Breadcrumb-item {
+  align-items: center;
+  display: flex;
+}
+
+/* stylelint-disable plugin/selector-bem-pattern */
+.spui-Breadcrumb a {
+  align-items: center;
+  display: flex;
+  letter-spacing: 0.1em;
+  line-height: 1.3;
+  min-height: 56px;
+  padding: 0 12px;
+}
+
+.spui-Breadcrumb a[href] {
+  color: var(--color-text-accent-primary);
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.spui-Breadcrumb a[href]:hover {
+  text-decoration: underline;
+}
+
+.spui-Breadcrumb a:not([href]) {
+  color: var(--color-text-low-emphasis);
+  font-weight: normal;
+}
+/* stylelint-enable plugin/selector-bem-pattern */
+
+.spui-Breadcrumb-chevron {
+  color: var(--color-object-low-emphasis);
+  height: 16px;
+  width: 16px;
+}
+
+.spui-Breadcrumb-item:last-of-type > .spui-Breadcrumb-chevron {
+  display: none;
+  padding: 0;
+}
+
+@media screen and (max-width: 375px) {
+  .spui-Breadcrumb {
+    padding: 0 12px;
+  }
+
+  /* stylelint-disable plugin/selector-bem-pattern */
+  .spui-Breadcrumb a {
+    font-size: 0.8125em;
+    min-height: 40px;
+    padding: 0 8px;
+  }
+  /* stylelint-enable plugin/selector-bem-pattern */
+
+  .spui-Breadcrumb-chevron {
+    height: 12px;
+    width: 12px;
+  }
+}

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -26,21 +26,26 @@
 /* stylelint-disable plugin/selector-bem-pattern */
 .spui-Breadcrumb a {
   align-items: center;
+  border-radius: 4px;
   display: flex;
   letter-spacing: 0.1em;
   line-height: 1.3;
   padding: 4px 8px;
   position: relative;
-}
-
-.spui-Breadcrumb a[href] {
-  border-radius: 4px;
-  color: var(--color-text-accent-primary);
-  font-weight: bold;
   text-decoration: none;
 }
 
-.spui-Breadcrumb a[href]::before {
+.spui-Breadcrumb a:not([aria-current]) {
+  color: var(--color-text-accent-primary);
+  font-weight: bold;
+}
+
+.spui-Breadcrumb a[aria-current] {
+  color: var(--color-text-low-emphasis);
+  font-weight: normal;
+}
+
+.spui-Breadcrumb a::before {
   border-radius: 4px;
   content: '';
   left: 0;
@@ -50,13 +55,8 @@
   width: 100%;
 }
 
-.spui-Breadcrumb a[href]:hover {
+.spui-Breadcrumb a:hover {
   text-decoration: underline;
-}
-
-.spui-Breadcrumb a:not([href]) {
-  color: var(--color-text-low-emphasis);
-  font-weight: normal;
 }
 
 .spui-Breadcrumb a:focus {
@@ -97,7 +97,7 @@
     padding: 2px 6px;
   }
 
-  .spui-Breadcrumb a[href]::before {
+  .spui-Breadcrumb a:not([aria-current])::before {
     min-height: 40px;
   }
   /* stylelint-enable plugin/selector-bem-pattern */

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
@@ -31,19 +31,19 @@ import { BreadcrumbItem } from './BreadcrumbItem';
     <BreadcrumbList>
       <BreadcrumbItem href="#">Top</BreadcrumbItem>
       <BreadcrumbItem href="#">Team</BreadcrumbItem>
-      <BreadcrumbItem>Amebaとは</BreadcrumbItem>
+      <BreadcrumbItem href="#" current>Amebaとは</BreadcrumbItem>
     </BreadcrumbList>
   </Story>
 </Preview>
 
-通常は`<BreadcrumbItem>`と一緒に使います。`href`を指定しないリンクは現在地扱いになります。
+通常は`<BreadcrumbItem>`と一緒に使います。現在地のリンクには`current`を指定します。
 
 <Source
   code={`
 <BreadcrumbList>
   <BreadcrumbItem href="#">Top</BreadcrumbItem>
   <BreadcrumbItem href="#">Team</BreadcrumbItem>
-  <BreadcrumbItem>Amebaとは</BreadcrumbItem>
+  <BreadcrumbItem href="#" current>Amebaとは</BreadcrumbItem>
 </BreadcrumbList>
   `}
 />
@@ -55,7 +55,7 @@ import { BreadcrumbItem } from './BreadcrumbItem';
   <ol class="spui-Breadcrumb-list">
     <li class="spui-Breadcrumb-item"><a href="/top">Top</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>
     <li class="spui-Breadcrumb-item"><a href="/team">Team</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>
-    <li class="spui-Breadcrumb-item"><a aria-current="page">Amebaとは</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>
+    <li class="spui-Breadcrumb-item"><a href="#" aria-current="page">Amebaとは</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>
   </ol>
 </nav>
   `}
@@ -68,19 +68,19 @@ import { BreadcrumbItem } from './BreadcrumbItem';
     <BreadcrumbList>
       <a href="#">Top</a>
       <a href="#">Team</a>
-      <a aria-current="page">Amebaとは</a>
+      <a href="#" aria-current="page">Amebaとは</a>
     </BreadcrumbList>
   </Story>
 </Preview>
 
-`<BreadcrumbItem>`を使わず、直接`<a>`要素を指定することもできます。`<Link>`も同様に指定できます。
+`<BreadcrumbItem>`を使わず、直接`<a>`要素を指定することもできます。`<Link>`も同様に指定できます。その際には、現在地となるa要素にaria-current属性を付与してください。
 
 <Source
   code={`
 <BreadcrumbList>
   <a href="#">Top</a>
   <a href="#">Team</a>
-  <a>Amebaとは</a>
+  <a href="#" aria-current="page">Amebaとは</a>
 </BreadcrumbList>
   `}
 />

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
@@ -1,0 +1,86 @@
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { actions } from '@storybook/addon-actions';
+import { BreadcrumbList } from './BreadcrumbList';
+import { BreadcrumbItem } from './BreadcrumbItem';
+
+# Breadcrumb
+
+<Meta title="Breadcrumb" component={BreadcrumbList} />
+
+![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
+
+<Source
+  language='javascript'
+  code={`import { BreadcrumbList } from '@openameba/spindle-ui/Breadcrumb'`}
+/>
+
+<Source
+  language='css'
+  code={`@import './node_modules/@openameba/spindle-ui/BreadcrumbList.css'`}
+/>
+
+<Source
+  language='html'
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/BreadcrumbList.css">`}
+/>
+
+## BreadcrumbList
+
+<Preview withSource="open">
+  <Story name="BreadcrumbList">
+    <BreadcrumbList>
+      <BreadcrumbItem href="#">Top</BreadcrumbItem>
+      <BreadcrumbItem href="#">Team</BreadcrumbItem>
+      <BreadcrumbItem>Amebaとは</BreadcrumbItem>
+    </BreadcrumbList>
+  </Story>
+</Preview>
+
+通常は`<BreadcrumbItem>`と一緒に使います。`href`を指定しないリンクは現在地扱いになります。
+
+<Source
+  code={`
+<BreadcrumbList>
+  <BreadcrumbItem href="#">Top</BreadcrumbItem>
+  <BreadcrumbItem href="#">Team</BreadcrumbItem>
+  <BreadcrumbItem>Amebaとは</BreadcrumbItem>
+</BreadcrumbList>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<nav class="spui-Breadcrumb" aria-label="パンくずリスト" role="navigation">
+  <ol class="spui-Breadcrumb-list">
+    <li class="spui-Breadcrumb-item"><a href="/top">Top</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>
+    <li class="spui-Breadcrumb-item"><a href="/team">Team</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>
+    <li class="spui-Breadcrumb-item"><a aria-current="page">Amebaとは</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>
+  </ol>
+</nav>
+  `}
+/>
+
+## BreadcrumbList without BreadcrumbItem
+
+<Preview withSource="open">
+  <Story name="BreadcrumbList Without BreadcrumbItem">
+    <BreadcrumbList>
+      <a href="#">Top</a>
+      <a href="#">Team</a>
+      <a aria-current="page">Amebaとは</a>
+    </BreadcrumbList>
+  </Story>
+</Preview>
+
+`<BreadcrumbItem>`を使わず、直接`<a>`要素を指定することもできます。`<Link>`も同様に指定できます。
+
+<Source
+  code={`
+<BreadcrumbList>
+  <a href="#">Top</a>
+  <a href="#">Team</a>
+  <a>Amebaとは</a>
+</BreadcrumbList>
+  `}
+/>

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
@@ -51,7 +51,7 @@ import { BreadcrumbItem } from './BreadcrumbItem';
 <Source
   language='html'
   code={`
-<nav class="spui-Breadcrumb" aria-label="パンくずリスト" role="navigation">
+<nav class="spui-Breadcrumb" aria-label="パンくずリスト">
   <ol class="spui-Breadcrumb-list">
     <li class="spui-Breadcrumb-item"><a href="/top">Top</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>
     <li class="spui-Breadcrumb-item"><a href="/team">Team</a><svg class="spui-Breadcrumb-chevron" role="img" aria-hidden="true"></svg></li>

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbItem.tsx
@@ -2,19 +2,20 @@ import React, { forwardRef } from 'react';
 
 interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   children?: React.ReactNode;
+  current?: boolean;
 }
 
 export const BreadcrumbItem = forwardRef<HTMLAnchorElement, Props>(
-  function Item({ children, href, ...rest }: Props, ref) {
-    if (href) {
+  function Item({ children, current, ...rest }: Props, ref) {
+    if (current) {
       return (
-        <a href={href} ref={ref} {...rest}>
+        <a ref={ref} aria-current="page" {...rest}>
           {children}
         </a>
       );
     }
     return (
-      <a ref={ref} aria-current="page" {...rest}>
+      <a ref={ref} {...rest}>
         {children}
       </a>
     );

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbItem.tsx
@@ -1,0 +1,22 @@
+import React, { forwardRef } from 'react';
+
+interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  children?: React.ReactNode;
+}
+
+export const BreadcrumbItem = forwardRef<HTMLAnchorElement, Props>(
+  function Item({ children, href, ...rest }: Props, ref) {
+    if (href) {
+      return (
+        <a href={href} ref={ref} {...rest}>
+          {children}
+        </a>
+      );
+    }
+    return (
+      <a ref={ref} aria-current="page" {...rest}>
+        {children}
+      </a>
+    );
+  },
+);

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import ChevronRightBold from '../Icon/ChevronRightBold';
+
+interface Props extends React.HTMLAttributes<HTMLElement> {
+  children?: React.ReactNode;
+}
+
+const BLOCK_NAME = 'spui-Breadcrumb';
+
+export const BreadcrumbList = (props: Props) => {
+  const { children, className, ...rest } = props;
+  return (
+    <nav
+      aria-label="パンくずリスト"
+      className={[BLOCK_NAME, className].join(' ').trim()}
+      role="navigation"
+      {...rest}
+    >
+      <ol className={`${BLOCK_NAME}-list`}>
+        {React.Children.map(children, (child) => {
+          return React.isValidElement(child) ? (
+            <li className={`${BLOCK_NAME}-item`}>
+              {child}
+              <ChevronRightBold
+                aria-hidden="true"
+                className={`${BLOCK_NAME}-chevron`}
+                role="img"
+              />
+            </li>
+          ) : null;
+        })}
+      </ol>
+    </nav>
+  );
+};

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
@@ -13,7 +13,6 @@ export const BreadcrumbList = (props: Props) => {
     <nav
       aria-label="パンくずリスト"
       className={[BLOCK_NAME, className].join(' ').trim()}
-      role="navigation"
       {...rest}
     >
       <ol className={`${BLOCK_NAME}-list`}>

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
@@ -23,7 +23,6 @@ export const BreadcrumbList = (props: Props) => {
               <ChevronRightBold
                 aria-hidden="true"
                 className={`${BLOCK_NAME}-chevron`}
-                role="img"
               />
             </li>
           ) : null;

--- a/packages/spindle-ui/src/Breadcrumb/index.ts
+++ b/packages/spindle-ui/src/Breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export { BreadcrumbList } from './BreadcrumbList';
+export { BreadcrumbItem } from './BreadcrumbItem';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -1,5 +1,6 @@
 /* stylelint-disable plugin/selector-bem-pattern */
 @import 'ameba-color-palette.css';
+@import './Breadcrumb/Breadcrumb.css';
 @import './Button/Button.css';
 @import './ButtonGroup/ButtonGroup.css';
 @import './Form/index.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -1,3 +1,4 @@
+import { BreadcrumbItem, BreadcrumbList } from './Breadcrumb';
 import { Button } from './Button';
 import { ButtonGroup } from './ButtonGroup';
 import * as Form from './Form';
@@ -9,6 +10,8 @@ import { Toast } from './Toast';
 
 // Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
 export {
+  BreadcrumbItem,
+  BreadcrumbList,
   Button,
   ButtonGroup,
   Form,


### PR DESCRIPTION
[Amebaのサイト](https://about.ameba.jp/contents/ed88wdx61mf1/)を元にパンくずリスト(Breadcrumb)を作成しました。今後新たなスタイルが出てきた場合にはvariantを追加する予定です (@MasatoHonda 相談済み)。

Storybook: https://ameba-spindle--pr361-feat-breadcrumb-4o86l7i2.web.app/?path=/story/breadcrumb--breadcrumb-list

## 使用例
anchorの要素がサービスによって異なりそうなので、ブランドサイトと違い子コンポーネントを受け取る形にしようと思います。

詳しくは https://raw.githubusercontent.com/openameba/spindle/feat/breadcrumb/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx

```js
<BreadcrumbList>
  <BreadcrumbItem href="#">Top</BreadcrumbItem>
  <BreadcrumbItem href="#">Team</BreadcrumbItem>
  <BreadcrumbItem>Amebaとは</BreadcrumbItem>
</BreadcrumbList>
```

※ ListとItemは一緒に利用する可能性が高いので、`Breadcrumb.List`, `Breadcrumb.Item`でのexportを考えていましたが、List単体でも利用できるかつ、利用側で`Breadcrumb.Item`をバンドルから外しにくなってしまうため、それぞれexportするようにしました。
※ 厳密なスタイル定義もあまり意味のないかつスタイルを書き換えられる可能性もあまりないコンポーネントなのでclassNameは受け取れるようにしようかと考えています。

ref: https://reactjs.org/docs/jsx-in-depth.html#using-dot-notation-for-jsx-type

本コンポーネントは375pxを起点に表示サイズが変わります。

![localhost_6006_iframe html_id=breadcrumb--breadcrumb-list-without-breadcrumb-item viewMode=story (3)](https://user-images.githubusercontent.com/869023/158116608-097c1ba9-957d-42a6-b819-164b523540e4.png)
![localhost_6006_iframe html_id=breadcrumb--breadcrumb-list-without-breadcrumb-item viewMode=story (2)](https://user-images.githubusercontent.com/869023/158116615-58a3769f-94bd-40a7-8d01-ae478a91480a.png)

## Design Tokens
- -color-surface-secondary: 背景色
- -color-text-accent-primary: リンク色
- -color-text-low-emphasis: 現在地テキスト色
- -color-object-low-emphasis: 矢印の色
- -color-focus-clarity: フォーカルリングの色

## アクセシビリティ
フォントサイズが200%になっても表示自体はできます。(文字数によっては横スクロールが出てしまいます)
![localhost_6006_iframe html_id=breadcrumb--breadcrumb-list-without-breadcrumb-item viewMode=story](https://user-images.githubusercontent.com/869023/158117266-d517becc-760c-4b37-9db8-178c722385fe.png)

タップ領域をできるだけ大きく取れるように実装を少し変えています。がfocusのスタイルは未確定です。
<img width="310" alt="" src="https://user-images.githubusercontent.com/869023/158117674-58e6673e-c01c-47b4-953b-bab21e75e000.png">

確定しました。

![focus,tap](https://user-images.githubusercontent.com/869023/158155560-976166c7-c711-46e6-9c3b-4d409fa37fea.png)


Spindleのデザイントークンを利用して、適切なカラーコントラスト比を担保します。

さらに詳しくはNotionのDesign Docを参照してください。