### PR TITLE
fix(spindle-ui): fix breadcrumb breakpoint

### DIFF
--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -82,7 +82,7 @@
   padding: 0;
 }
 
-@media screen and (max-width: 375px) {
+@media screen and (max-width: 768px) {
   .spui-Breadcrumb {
     padding: 0 14px;
   }


### PR DESCRIPTION
Breakpointが375pxになっていたので修正しました

memo: 元実装のレスポンシブ対応の時に値が更新されました