### PR TITLE
Style focus with outline

### DIFF
--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -60,13 +60,12 @@
 }
 
 .spui-Breadcrumb a:focus {
-  box-shadow: 0 0 0 1px var(--color-surface-secondary),
-    0 0 0 3px var(--color-focus-clarity);
-  outline: none;
+  outline: 2px solid var(--color-focus-clarity);
+  outline-offset: 1px;
 }
 
 .spui-Breadcrumb a:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline: none;
 }
 /* stylelint-enable plugin/selector-bem-pattern */
 

--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -4,8 +4,7 @@
 */
 :root {
   --Button-tapHighlightColor: var(--gray-5-alpha);
-  --Button-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
-    0 0 0 3px var(--color-focus-clarity);
+  --Button-onFocus-outlineColor: var(--color-focus-clarity);
 
   --Button--contained-backgroundColor: var(--color-surface-accent-primary);
   --Button--contained-color: var(--color-text-high-emphasis-inverse);
@@ -55,12 +54,12 @@
 }
 
 .spui-Button:focus {
-  box-shadow: var(--Button-onFocus-boxShadow);
-  outline: none;
+  outline: 2px solid var(--Button-onFocus-outlineColor);
+  outline-offset: 1px;
 }
 
 .spui-Button:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline: none;
 }
 
 /*

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.css
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.css
@@ -1,13 +1,7 @@
 @import './HeroCarouselItem.css';
 /*
  * HeroCarousel
- * NOTE: Styles can be overridden with "--HeroCarousel-*" variables
 */
-:root {
-  --HeroCarousel-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
-    0 0 0 3px var(--color-focus-clarity);
-}
-
 .spui-HeroCarousel-container {
   align-items: center;
   display: flex;
@@ -51,12 +45,12 @@
 }
 
 .spui-HeroCarousel-control:focus {
-  box-shadow: var(--HeroCarousel-onFocus-boxShadow);
-  outline: none;
+  outline: 2px solid var(--color-focus-clarity);
+  outline-offset: 1px;
 }
 
 .spui-HeroCarousel-control:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline: none;
 }
 
 .spui-HeroCarousel-control--prev {

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.css
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarouselItem.css
@@ -1,11 +1,6 @@
 /*
  * HeroCarouselItem
- * NOTE: Styles can be overridden with "--HeroCarouselItem-*" variables
 */
-:root {
-  --HeroCarouselItem-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
-    0 0 0 3px var(--color-focus-clarity);
-}
 .spui-HeroCarouselItem-listItem {
   list-style: none;
   padding: 0 0.44em;
@@ -24,12 +19,12 @@
 }
 
 .spui-HeroCarouselItem-link:focus {
-  box-shadow: var(--HeroCarouselItem-onFocus-boxShadow);
-  outline: none;
+  outline: 2px solid var(--color-focus-clarity);
+  outline-offset: 1px;
 }
 
 .spui-HeroCarouselItem-link:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline: none;
 }
 
 .spui-HeroCarouselItem-imageBlock {

--- a/packages/spindle-ui/src/IconButton/IconButton.css
+++ b/packages/spindle-ui/src/IconButton/IconButton.css
@@ -4,8 +4,7 @@
 */
 :root {
   --IconButton-tapHighlightColor: var(--gray-5-alpha);
-  --IconButton-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
-    0 0 0 3px var(--color-focus-clarity);
+  --IconButton-onFocus-outlineColor: var(--color-focus-clarity);
 
   --IconButton--contained-backgroundColor: var(--color-surface-accent-primary);
   --IconButton--contained-color: var(--color-object-high-emphasis-inverse);
@@ -55,12 +54,12 @@
 }
 
 .spui-IconButton:focus {
-  box-shadow: var(--IconButton-onFocus-boxShadow);
-  outline: none;
+  outline: 2px solid var(--IconButton-onFocus-outlineColor);
+  outline-offset: 1px;
 }
 
 .spui-IconButton:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline: none;
 }
 
 /*

--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -4,8 +4,7 @@
 */
 :root {
   --LinkButton-tapHighlightColor: var(--gray-5-alpha);
-  --LinkButton-onFocus-boxShadow: 0 0 0 1px var(--color-surface-primary),
-    0 0 0 3px var(--color-focus-clarity);
+  --LinkButton-onFocus-outlineColor: var(--color-focus-clarity);
 
   --LinkButton--contained-backgroundColor: var(--color-surface-accent-primary);
   --LinkButton--contained-color: var(--color-text-high-emphasis-inverse);
@@ -53,12 +52,12 @@
 }
 
 .spui-LinkButton:focus {
-  box-shadow: var(--LinkButton-onFocus-boxShadow);
-  outline: none;
+  outline: 2px solid var(--LinkButton-onFocus-outlineColor);
+  outline-offset: 1px;
 }
 
 .spui-LinkButton:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline: none;
 }
 
 /*


### PR DESCRIPTION
#393 に関連して、今の動作を変えないまま実装を`box-shadow`から`outline`に変更しました。

## Old
```css
box-shadow: 0 0 0 1px var(--color-surface-secondary),
    0 0 0 3px var(--color-focus-clarity);
```

3pxの青い線を敷いてその上に1pxの白乗せてオフセット作ってます。

## New
```css
outline: 2px solid var(--color-focus-clarity);
outline-offset: 1px;
```



Safariは角丸のoutlineに対応していないので四角くなってしまいますが、 @MasatoHonda 認識済みです。

## 確認したいこと
- 対象コンポーネントのfocus動作をStorybookで検証します (Chrome, Firefox, Safari)

close #393