### PR TITLE
Add polite announcer css example to storybook docs

### DIFF
--- a/packages/spindle-ui/src/Toast/Toast.stories.mdx
+++ b/packages/spindle-ui/src/Toast/Toast.stories.mdx
@@ -178,3 +178,16 @@ const usePoliteAnnouncer = (message) => {
 };
   `}
 />
+
+<Source
+  code={`
+  .visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  clip: rect(1px, 1px, 1px, 1px);
+}
+  `}
+/>


### PR DESCRIPTION

[アクセシビリティガイドライン](https://a11y-guidelines.ameba.design/1/1/1/#web)の「不可視のテキスト要素を用意し、支援技術にはアイコン自体を無視させる方法」を参考にして CSS の推奨されるコード例を storybook の docs に追加しました。