### PR TITLE
feat(spindle-ui): create SubtleButton

### DIFF
--- a/packages/spindle-ui/src/SubtleButton/SubtleButton.css
+++ b/packages/spindle-ui/src/SubtleButton/SubtleButton.css
@@ -1,0 +1,54 @@
+/*
+ * SubtleButton
+ * NOTE: Styles can be overridden with "--SubtleButton-*" variables
+*/
+:root {
+  --SubtleButton-tapHighlightColor: var(--white-60-alpha);
+  --SubtleButton-onFocus-outlineColor: var(--color-focus-clarity);
+  --SubtleButton-color: var(--color-text-medium-emphasis);
+}
+
+.spui-SubtleButton {
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--SubtleButton-color);
+  font-family: inherit;
+  font-weight: bold;
+  line-height: 1.3;
+  margin: 0;
+  padding: 0;
+  -webkit-tap-highlight-color: var(--SubtleButton-tapHighlightColor);
+  text-align: center;
+}
+
+.spui-SubtleButton:disabled {
+  opacity: 0.3;
+}
+
+.spui-SubtleButton:focus {
+  outline: 2px solid var(--SubtleButton-onFocus-outlineColor);
+  outline-offset: 1px;
+}
+
+.spui-SubtleButton:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media (hover: hover) {
+  .spui-SubtleButton:not([disabled]):hover {
+    text-decoration: underline;
+  }
+}
+
+/*
+ * Sizes
+*/
+.spui-SubtleButton--large,
+.spui-SubtleButton--medium {
+  font-size: 0.875em;
+}
+
+.spui-SubtleButton--small {
+  font-size: 0.8125em;
+}

--- a/packages/spindle-ui/src/SubtleButton/SubtleButton.stories.mdx
+++ b/packages/spindle-ui/src/SubtleButton/SubtleButton.stories.mdx
@@ -1,0 +1,87 @@
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { actions } from '@storybook/addon-actions';
+import { SubtleButton } from './SubtleButton';
+
+# SubtleButton
+
+<Meta title="SubtleButton" component={SubtleButton} />
+
+![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
+
+<Source
+  language='javascript'
+  code={`import { SubtleButton } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language='css'
+  code={`@import './node_modules/@openameba/spindle-ui/SubtleButton/SubtleButton.css'`}
+/>
+
+<Source
+  language='html'
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/SubtleButton/SubtleButton.css">`}
+/>
+
+## Large
+
+<Preview withSource="open">
+  <Story name="Large">
+    <SubtleButton size="large" {...actions('onClick', 'onMouseOver')}>Subtle Button</SubtleButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SubtleButton size="large">Subtle Button</SubtleButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-SubtleButton spui-SubtleButton--large">Subtle Button</button>
+  `}
+/>
+
+## Medium
+
+<Preview withSource="open">
+  <Story name="Medium">
+    <SubtleButton size="medium" {...actions('onClick', 'onMouseOver')}>Subtle Button</SubtleButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SubtleButton size="medium">Subtle Button</SubtleButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-SubtleButton spui-SubtleButton--medium">Subtle Button</button>
+  `}
+/>
+
+## Small
+
+<Preview withSource="open">
+  <Story name="Small">
+    <SubtleButton size="Small" {...actions('onClick', 'onMouseOver')}>Subtle Button</SubtleButton>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SubtleButton size="small">Subtle Button</SubtleButton>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<button class="spui-SubtleButton spui-SubtleButton--small">Subtle Button</button>
+  `}
+/>

--- a/packages/spindle-ui/src/SubtleButton/SubtleButton.tsx
+++ b/packages/spindle-ui/src/SubtleButton/SubtleButton.tsx
@@ -1,0 +1,25 @@
+import React, { forwardRef } from 'react';
+
+type Size = 'large' | 'medium' | 'small';
+
+interface Props
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'className'> {
+  children?: React.ReactNode;
+  size?: Size;
+}
+
+const BLOCK_NAME = 'spui-SubtleButton';
+
+export const SubtleButton = forwardRef<HTMLButtonElement, Props>(
+  function SubtleButton({ children, size = 'large', ...rest }: Props, ref) {
+    return (
+      <button
+        className={`${BLOCK_NAME} ${BLOCK_NAME}--${size}`}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  },
+);

--- a/packages/spindle-ui/src/SubtleButton/index.ts
+++ b/packages/spindle-ui/src/SubtleButton/index.ts
@@ -1,0 +1,1 @@
+export { SubtleButton } from './SubtleButton';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -7,4 +7,5 @@
 @import './HeroCarousel/HeroCarousel.css';
 @import './IconButton/IconButton.css';
 @import './LinkButton/LinkButton.css';
+@import './SubtleButton/SubtleButton.css';
 @import './Toast/Toast.css';


### PR DESCRIPTION
`<SubtleButton>`をSpindle UIに追加しました。

独立して定義されているため、従来の`<Button>`とは別に定義しました。

[Spindleサイト](https://spindle.ameba.design/components/button/#Subtle-Button)にはまだ反映されていないですが、対象Figmaのスクリーンショットを載せておきます。

![Subtle Button](https://user-images.githubusercontent.com/869023/170401203-d9600561-d3b6-4e46-bd09-cd72f9eaf6cb.png)

![Style State Chart](https://user-images.githubusercontent.com/869023/170401217-e23451ef-6179-4190-930e-1ec5d0407a4b.png)

