### PR TITLE
refactor(spindle-ui): improve margin style

### DIFF
--- a/packages/spindle-ui/src/ButtonGroup/ButtonGroup.css
+++ b/packages/spindle-ui/src/ButtonGroup/ButtonGroup.css
@@ -14,55 +14,29 @@
   flex-direction: column;
 }
 
-/* Size */
-
 /* NOTE: gap property should be used in the near future */
 
 /* stylelint-disable plugin/selector-bem-pattern */
-.spui-ButtonGroup--large.spui-ButtonGroup--row > * {
-  margin-right: 16px;
+.spui-ButtonGroup--large.spui-ButtonGroup--row > *:not(:first-child) {
+  margin-left: 16px;
 }
 
-.spui-ButtonGroup--large.spui-ButtonGroup--row > *:last-child {
-  margin-right: 0;
+.spui-ButtonGroup--large.spui-ButtonGroup--column > *:not(:first-child) {
+  margin-top: 16px;
 }
 
-.spui-ButtonGroup--large.spui-ButtonGroup--column > * {
-  margin-bottom: 16px;
+.spui-ButtonGroup--medium.spui-ButtonGroup--row > *:not(:first-child) {
+  margin-left: 12px;
 }
 
-.spui-ButtonGroup--large.spui-ButtonGroup--column > *:last-child {
-  margin-bottom: 0;
+.spui-ButtonGroup--medium.spui-ButtonGroup--column > *:not(:first-child) {
+  margin-top: 12px;
 }
 
-.spui-ButtonGroup--medium.spui-ButtonGroup--row > * {
-  margin-right: 12px;
+.spui-ButtonGroup--small.spui-ButtonGroup--row > *:not(:first-child) {
+  margin-left: 8px;
 }
 
-.spui-ButtonGroup--medium.spui-ButtonGroup--row > *:last-child {
-  margin-right: 0;
-}
-
-.spui-ButtonGroup--medium.spui-ButtonGroup--column > * {
-  margin-bottom: 12px;
-}
-
-.spui-ButtonGroup--medium.spui-ButtonGroup--column > *:last-child {
-  margin-bottom: 0;
-}
-
-.spui-ButtonGroup--small.spui-ButtonGroup--row > * {
-  margin-right: 8px;
-}
-
-.spui-ButtonGroup--small.spui-ButtonGroup--row > *:last-child {
-  margin-right: 0;
-}
-
-.spui-ButtonGroup--small.spui-ButtonGroup--column > * {
-  margin-bottom: 12px;
-}
-
-.spui-ButtonGroup--small.spui-ButtonGroup--column > *:last-child {
-  margin-bottom: 0;
+.spui-ButtonGroup--small.spui-ButtonGroup--column > *:not(:first-child) {
+  margin-top: 12px;
 }

--- a/packages/spindle-ui/src/ButtonGroup/ButtonGroup.css
+++ b/packages/spindle-ui/src/ButtonGroup/ButtonGroup.css
@@ -40,3 +40,9 @@
 .spui-ButtonGroup--small.spui-ButtonGroup--column > *:not(:first-child) {
   margin-top: 12px;
 }
+
+/* Override margin for Subtle button */
+:is(.spui-ButtonGroup--large, .spui-ButtonGroup--medium).spui-ButtonGroup--column
+  > .spui-SubtleButton:not(:first-child) {
+  margin-top: 14px;
+}

--- a/packages/spindle-ui/src/ButtonGroup/ButtonGroup.stories.mdx
+++ b/packages/spindle-ui/src/ButtonGroup/ButtonGroup.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { ButtonGroup } from './ButtonGroup';
 import { Button } from '../Button';
+import { SubtleButton } from '../SubtleButton';
 
 # Button Group
 
@@ -199,6 +200,66 @@ import { Button } from '../Button';
 <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--small">
   <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
   <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+</div>
+  `}
+/>
+
+## Column Direction with Large Subtle Button
+
+<Preview withSource="open">
+  <Story name="Column Direction with Large Subtle Button">
+    <ButtonGroup direction="column" size="large">
+      <Button variant="contained">Contained</Button>
+      <SubtleButton size="large">Subtle Button</SubtleButton>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="column" size="large">
+  <Button size="large" variant="contained">Contained</Button>
+  <SubtleButton size="large">Subtle Button</SubtleButton>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--large">
+  <button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
+  <button class="spui-SubtleButton spui-SubtleButton--large">Subtle Button</button>
+</div>
+  `}
+/>
+
+## Column Direction with Small Subtle Button
+
+<Preview withSource="open">
+  <Story name="Column Direction with Small Subtle Button">
+    <ButtonGroup direction="column" size="small">
+      <Button size="small" variant="contained">Contained</Button>
+      <SubtleButton size="small">Subtle Button</SubtleButton>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="column" size="small">
+  <Button size="small" variant="contained">Contained</Button>
+  <SubtleButton size="small">Subtle Button</SubtleButton>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--small">
+  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
+  <button class="spui-SubtleButton spui-SubtleButton--small">Subtle Button</button>
 </div>
   `}
 />

--- a/packages/spindle-ui/src/ButtonGroup/ButtonGroup.stories.mdx
+++ b/packages/spindle-ui/src/ButtonGroup/ButtonGroup.stories.mdx
@@ -234,6 +234,36 @@ import { SubtleButton } from '../SubtleButton';
   `}
 />
 
+## Column Direction with Medium Subtle Button
+
+<Preview withSource="open">
+  <Story name="Column Direction with Medium Subtle Button">
+    <ButtonGroup direction="column" size="medium">
+      <Button size="medium" variant="contained">Contained</Button>
+      <SubtleButton size="medium">Subtle Button</SubtleButton>
+    </ButtonGroup>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<ButtonGroup direction="column" size="medium">
+  <Button size="medium" variant="contained">Contained</Button>
+  <SubtleButton size="medium">Subtle Button</SubtleButton>
+</ButtonGroup>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--medium">
+  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
+  <button class="spui-SubtleButton spui-SubtleButton--medium">Subtle Button</button>
+</div>
+  `}
+/>
+
 ## Column Direction with Small Subtle Button
 
 <Preview withSource="open">


### PR DESCRIPTION
`<ButtonGroup>`をアップデートしました。内容は以下のとおりです。

- 余白指定のリファクタ [462e945](https://github.com/openameba/spindle/pull/408/commits/462e945cda44dd58e635d66af242ec235b1e6bd7) reg-suitで差分出ていないので大丈夫かと思われです
- Subtleボタンを想定したスタイルにアップデート [896c6e5](https://github.com/openameba/spindle/pull/408/commits/896c6e5d8a52e0120d467f18421b9ba4b0502262) Subtleボタンはcolumnレイアウトのときのみスタイルが当たります