### PR TITLE
fix(spindle-ui): svg icon disappears on iOS

### DIFF
--- a/packages/spindle-ui/src/IconButton/IconButton.css
+++ b/packages/spindle-ui/src/IconButton/IconButton.css
@@ -44,6 +44,7 @@
   display: inline-flex;
   justify-content: center;
   margin: 0;
+  padding: 0;
   -webkit-tap-highlight-color: var(--IconButton-tapHighlightColor);
   text-align: center;
   transition: background-color 0.3s;


### PR DESCRIPTION
IconButtonコンポーネントをiOSで見た時にアイコンが表示されてないバグの修正です。
iOSブラウザだとbuttonタグにpaddingが付与されていたため、中のアイコンが小さくなってしまったようです。

- close #430 

シミュレーターで表示されることを確認しました
![スクリーンショット 2022-06-21 22 15 23](https://user-images.githubusercontent.com/44389443/174808255-fc05f250-6d96-4060-97f4-0a7cef871917.png)