### PR TITLE
feat(spindle-ui): add pagination component

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "./dist/index.css",
-      "maxSize": "8.0 kB"
+      "maxSize": "9.0 kB"
     }
   ]
 }

--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -1,0 +1,109 @@
+@import './PaginationItem.css';
+
+/*
+ * Pagination
+*/
+:root {
+  --Pagination-tapHighlightColor: var(--color-tap-highlight-base);
+}
+
+.spui-Pagination {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.spui-Pagination-list {
+  align-items: center;
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.spui-Pagination-item {
+  align-items: center;
+  display: flex;
+  margin: 0 5px;
+}
+
+.spui-Pagination-item--first,
+.spui-Pagination-item--last {
+  margin: 0;
+}
+
+.spui-Pagination-horizontal {
+  color: var(--color-object-low-emphasis);
+}
+
+.spui-Pagination-link {
+  align-items: center;
+  background: none;
+  border: none;
+  border-radius: 12px;
+  box-sizing: border-box;
+  display: flex;
+  font-size: 0.875em;
+  height: 40px;
+  justify-content: center;
+  line-height: 1.3;
+  margin: 0;
+  min-width: 40px;
+  padding: 0 4px;
+  position: relative;
+  -webkit-tap-highlight-color: var(--Pagination-tapHighlightColor);
+  text-decoration: none;
+}
+
+.spui-Pagination-link:not([aria-current]) {
+  background: var(--color-surface-tertiary);
+  color: var(--color-text-medium-emphasis);
+  font-weight: bold;
+}
+
+.spui-Pagination-link:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.spui-Pagination-link[aria-current] {
+  border: solid 1px var(--color-border-low-emphasis);
+  color: var(--color-text-low-emphasis);
+}
+
+.spui-Pagination-link:focus-visible {
+  outline: 2px solid var(--color-focus-clarity);
+  outline-offset: 1px;
+}
+
+@media (hover: hover) {
+  .spui-Pagination-link:not([aria-current]):hover {
+    background-color: var(--color-surface-quaternary);
+  }
+}
+
+.spui-Pagination-count {
+  color: var(--color-text-low-emphasis);
+  font-size: 0.8125em;
+  line-height: 1.3;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.spui-Pagination-horizontal + .spui-Pagination-link,
+.spui-Pagination-link + .spui-Pagination-horizontal {
+  margin-left: 8px;
+}
+
+@media screen and (max-width: 414px) {
+  .spui-Pagination-item:nth-child(4),
+  .spui-Pagination-item:nth-child(6) {
+    display: block;
+  }
+}
+
+@media screen and (max-width: 360px) {
+  .spui-Pagination-item:nth-child(4),
+  .spui-Pagination-item:nth-child(6) {
+    display: none;
+  }
+}

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -1,0 +1,190 @@
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { actions } from '@storybook/addon-actions';
+import { Pagination } from './Pagination';
+
+# Pagination
+
+<Meta title="Pagination" component={Pagination} />
+
+![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
+
+<Source
+  language="javascript"
+  code={`import { Pagination } from '@openameba/spindle-ui/Pagination'`}
+/>
+
+<Source
+  language="css"
+  code={`@import './node_modules/@openameba/spindle-ui/Pagination.css'`}
+/>
+
+<Source
+  language="html"
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Pagination.css">`}
+/>
+
+<Description>Paginationはページの移動を目的として利用します。</Description>
+
+<Description>
+  ページの前後に移動することができます。また、画面幅によりレイアウトが変化します。
+</Description>
+
+<Description>デフォルトではアンカー要素を使用します。</Description>
+
+<Description>
+  `createUrl`に関数を渡すことでURLを任意の形で生成することが可能です。
+</Description>
+
+export const url = '/detail/CURRENT.html';
+export const pageNumber = 1;
+
+## Normal
+
+<Preview withSource="open">
+  <Story name="Normal">
+    <Pagination
+      total={5}
+      current={3}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 8 total 20
+
+<Preview withSource="open">
+  <Story name="current 8 total 20">
+    <Pagination
+      total={20}
+      current={8}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 900 total 999
+
+<Preview withSource="open">
+  <Story name="current 900 total 999">
+    <Pagination
+      total={999}
+      current={900}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={999} current={900} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 10000 total 20000
+
+<Description>
+  上限は設けていないためページ数の値によってリンクの横幅が広がるレイアウトとなっています。
+</Description>
+
+<Preview withSource="open">
+  <Story name="current 10000 total 20000">
+    <Pagination
+      total={20000}
+      current={10000}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20000} current={10000} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## showPrevNext showFirstLast props false
+
+<Description>
+  `showPrevNext`と`showFirstLast`propsは`false`にすることが可能です。
+</Description>
+
+<Description>
+  その場合、ページリンクにて前後と最初最後のリンクを担保します。
+</Description>
+
+<Preview withSource="open">
+  <Story name="showPrevNext showFirstLast props false">
+    <Pagination
+      total={20}
+      current={8}
+      showCount={true}
+      showPrevNext={false}
+      showFirstLast={false}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## create url function
+
+<Preview withSource="open">
+  <Story name="create url function">
+    <Pagination
+      total={20}
+      current={8}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## リンク動作のカスタマイズ
+
+<Description>
+  各サービスでルーティングを利用したい場合は、onPageChangeの第一引数にあるeventを利用してください。
+</Description>
+
+<Source
+  code={`function Component({children, url = '', external, ref, ...rest}) {
+    const handleClick = (event, pageNumber) => {
+      event.preventDefault();
+      router.push(pageNumber);
+    };
+    return (
+      <Pagination onPageChange={(event, pageNumber) => { handleClick(event, pageNumber); }} />
+    );
+  }
+`}
+/>

--- a/packages/spindle-ui/src/Pagination/Pagination.test.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { jest } from '@jest/globals';
+
+import { Pagination } from './Pagination';
+
+describe('<Pagination />', () => {
+  test('click', async () => {
+    const onClick = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <Pagination
+        total={20}
+        current={8}
+        showCount={true}
+        showPrevNext={true}
+        showFirstLast={true}
+        createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+        onPageChange={onClick}
+      />,
+    );
+
+    await user.click(screen.getByText(1));
+    fireEvent.click(screen.getByText(1));
+    expect(onClick).toBeCalled();
+  });
+});

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -1,0 +1,155 @@
+import React, { useCallback } from 'react';
+import MenuHorizontal from '../Icon/MenuHorizontal';
+
+import PaginationItem from './PaginationItem';
+import { useShowItem } from './hooks/useShowItem';
+
+interface Props extends React.HTMLAttributes<HTMLElement> {
+  current: number;
+  total: number;
+  showCount?: boolean;
+  showPrevNext?: boolean;
+  showFirstLast?: boolean;
+  onPageChange: (
+    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+    pageNumber: number,
+  ) => void;
+  createUrl: (pageNumber: number) => string;
+}
+
+const BLOCK_NAME = 'spui-Pagination';
+
+export const Pagination = (props: Props) => {
+  const {
+    current,
+    total,
+    showCount = false,
+    showPrevNext = true,
+    showFirstLast = false,
+    onPageChange,
+    createUrl,
+    className,
+    ...rest
+  } = props;
+
+  const pageItem = 5;
+  const { displayItem, showPrevHorizontal, showNextHorizontal } = useShowItem({
+    current,
+    total,
+    pageItem,
+  });
+
+  const handleClick = useCallback(
+    (
+      event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+      pageNumber: number,
+    ) => {
+      onPageChange?.(event, pageNumber);
+    },
+    [onPageChange],
+  );
+
+  return (
+    <nav
+      aria-label="ページネーション"
+      className={[BLOCK_NAME, className].filter(Boolean).join(' ').trim()}
+      {...rest}
+    >
+      <ul className={`${BLOCK_NAME}-list`}>
+        {showFirstLast && (
+          <li className={`${BLOCK_NAME}-item ${BLOCK_NAME}-item--first`}>
+            <PaginationItem
+              type="first"
+              current={current}
+              total={total}
+              onClick={handleClick}
+              createUrl={createUrl}
+            />
+          </li>
+        )}
+        {showPrevNext && (
+          <li className={`${BLOCK_NAME}-item ${BLOCK_NAME}-item--prev`}>
+            <PaginationItem
+              type="prev"
+              current={current}
+              total={total}
+              onClick={handleClick}
+              createUrl={createUrl}
+            />
+          </li>
+        )}
+        {displayItem.map((pageNumber, index) => {
+          const isCurrent = current === pageNumber;
+          const hasRelAttribute = current === pageNumber + 1;
+
+          return (
+            <li
+              className={`${BLOCK_NAME}-item`}
+              key={`pagination-item-${pageNumber}`}
+            >
+              {index === pageItem - 1 && showNextHorizontal && (
+                <MenuHorizontal
+                  aria-hidden="true"
+                  className={`${BLOCK_NAME}-horizontal`}
+                />
+              )}
+              <a
+                className={`${BLOCK_NAME}-link`}
+                rel={hasRelAttribute ? undefined : 'nofollow'}
+                href={isCurrent ? undefined : createUrl(pageNumber)}
+                aria-current={isCurrent ? 'page' : undefined}
+                aria-disabled={isCurrent ? true : undefined}
+                onClick={
+                  isCurrent
+                    ? undefined
+                    : (e) => {
+                        handleClick(e, pageNumber);
+                      }
+                }
+                aria-label={`${pageNumber}ページ目`}
+              >
+                {pageNumber}
+              </a>
+              {index === 0 && showPrevHorizontal && (
+                <MenuHorizontal
+                  aria-hidden="true"
+                  className={`${BLOCK_NAME}-horizontal`}
+                />
+              )}
+            </li>
+          );
+        })}
+        {showPrevNext && (
+          <li className={`${BLOCK_NAME}-item ${BLOCK_NAME}-item--next`}>
+            <PaginationItem
+              type="next"
+              current={current}
+              total={total}
+              onClick={handleClick}
+              createUrl={createUrl}
+            />
+          </li>
+        )}
+        {showFirstLast && (
+          <li className={`${BLOCK_NAME}-item ${BLOCK_NAME}-item--last`}>
+            <PaginationItem
+              type="last"
+              current={current}
+              total={total}
+              onClick={handleClick}
+              createUrl={createUrl}
+            />
+          </li>
+        )}
+      </ul>
+      {showCount && (
+        <p
+          className={`${BLOCK_NAME}-count`}
+          aria-label={`${total}ページ中の${current}ページ目`}
+        >
+          {current}/{total}ページ
+        </p>
+      )}
+    </nav>
+  );
+};

--- a/packages/spindle-ui/src/Pagination/PaginationItem.css
+++ b/packages/spindle-ui/src/Pagination/PaginationItem.css
@@ -1,0 +1,86 @@
+/*
+ * PaginationItem
+*/
+.spui-PaginationItem-link {
+  align-items: center;
+  background: none;
+  border: none;
+  border-radius: 12px;
+  box-sizing: border-box;
+  color: var(--color-text-medium-emphasis);
+  display: flex;
+  font-size: 0.875em;
+  font-weight: bold;
+  height: 40px;
+  justify-content: center;
+  line-height: 1.3;
+  margin: 0;
+  min-width: 40px;
+  padding: 0;
+  position: relative;
+  -webkit-tap-highlight-color: var(--Pagination-tapHighlightColor);
+  text-decoration: none;
+}
+
+.spui-PaginationItem-link--prev[aria-disabled],
+.spui-PaginationItem-link--next[aria-disabled],
+.spui-PaginationItem-link--first[aria-disabled],
+.spui-PaginationItem-link--last[aria-disabled] {
+  opacity: 0.3;
+}
+
+.spui-PaginationItem-link[aria-disabled]:focus-visible {
+  outline: none;
+}
+
+.spui-PaginationItem-link:not([aria-disabled]):focus-visible {
+  outline: 2px solid var(--color-focus-clarity);
+  outline-offset: 1px;
+}
+
+.spui-PaginationItem-icon {
+  box-sizing: border-box;
+  height: 24px;
+  padding: 0 4px;
+  width: 24px;
+}
+
+.spui-PaginationItem-link--prev {
+  flex-direction: row-reverse;
+}
+
+.spui-PaginationItem-link--prev {
+  padding-right: 8px;
+}
+
+.spui-PaginationItem-link--next {
+  padding-left: 8px;
+}
+
+@media (hover: hover) {
+  .spui-PaginationItem-link:not([aria-disabled]):hover {
+    background: var(--color-surface-tertiary);
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .spui-PaginationItem-label {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 414px) {
+  .spui-PaginationItem-label,
+  .spui-PaginationItem--first,
+  .spui-PaginationItem--last {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 360px) {
+  .spui-PaginationItem-label,
+  .spui-PaginationItem-item--first,
+  .spui-PaginationItem-item--last {
+    display: none;
+  }
+}

--- a/packages/spindle-ui/src/Pagination/PaginationItem.tsx
+++ b/packages/spindle-ui/src/Pagination/PaginationItem.tsx
@@ -1,0 +1,111 @@
+import React, { FC } from 'react';
+import ChevronRightBold from '../Icon/ChevronRightBold';
+import ChevronLeftBold from '../Icon/ChevronLeftBold';
+import TriangleendRightBold from '../Icon/TriangleendRightBold';
+import TriangleendLeftBold from '../Icon/TriangleendLeftBold';
+
+import { useItemPageNumber } from './hooks/useItemPageNumber';
+
+type Props = {
+  type: 'first' | 'last' | 'next' | 'prev';
+  current: number;
+  total: number;
+  onClick: (
+    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+    pageNumber: number,
+  ) => void;
+  createUrl: (pageNumber: number) => string;
+};
+
+const BLOCK_NAME = 'spui-PaginationItem';
+
+export const PaginationItem: FC<Props> = React.memo(
+  function PaginationItem({ type, current, total, onClick, createUrl }) {
+    const isDisabled =
+      type === 'first' || type === 'prev' ? current === 1 : current === total;
+    const isShowLabel = type === 'prev' || type === 'next';
+    const { pageNumber } = useItemPageNumber({
+      type,
+      isDisabled,
+      current,
+      total,
+    });
+
+    const itemPropMap = {
+      first: {
+        label: '最初へ',
+        icon: function iconElement() {
+          return (
+            <TriangleendLeftBold
+              aria-hidden="true"
+              className={`${BLOCK_NAME}-icon`}
+            />
+          );
+        },
+      },
+      prev: {
+        label: '前へ',
+        icon: function iconElement() {
+          return (
+            <ChevronLeftBold
+              aria-hidden="true"
+              className={`${BLOCK_NAME}-icon`}
+            />
+          );
+        },
+      },
+      next: {
+        label: '次へ',
+        icon: function iconElement() {
+          return (
+            <ChevronRightBold
+              aria-hidden="true"
+              className={`${BLOCK_NAME}-icon`}
+            />
+          );
+        },
+      },
+      last: {
+        label: '最後へ',
+        icon: function iconElement() {
+          return (
+            <TriangleendRightBold
+              aria-hidden="true"
+              className={`${BLOCK_NAME}-icon`}
+            />
+          );
+        },
+      },
+    };
+
+    return (
+      <a
+        className={`${BLOCK_NAME}-link ${BLOCK_NAME}-link--${type}`}
+        rel={type === 'next' ? 'nofollow' : undefined}
+        aria-label={itemPropMap[type].label}
+        href={isDisabled ? undefined : createUrl(pageNumber)}
+        aria-disabled={isDisabled ? true : undefined}
+        onClick={
+          isDisabled
+            ? undefined
+            : (e) => {
+                onClick(e, pageNumber);
+              }
+        }
+      >
+        {isShowLabel && (
+          <span className={`${BLOCK_NAME}-label`}>
+            {itemPropMap[type].label}
+          </span>
+        )}
+        {itemPropMap[type].icon()}
+      </a>
+    );
+  },
+  (prevProps, nextProps) =>
+    prevProps.type === nextProps.type &&
+    prevProps.current === nextProps.current &&
+    prevProps.total === nextProps.total,
+);
+
+export default PaginationItem;

--- a/packages/spindle-ui/src/Pagination/hooks/useItemPageNumber.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useItemPageNumber.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useItemPageNumber } from './useItemPageNumber';
+
+describe('useItemPageNumber()', () => {
+  it('should return first page number', () => {
+    const type = 'first';
+    const isDisabled = false;
+    const current = 8;
+    const total = 20;
+
+    const { result } = renderHook(() =>
+      useItemPageNumber({ type, isDisabled, current, total }),
+    );
+
+    expect(result.current.pageNumber).toEqual(1);
+  });
+
+  it('should return prev page number', () => {
+    const type = 'prev';
+    const isDisabled = false;
+    const current = 8;
+    const total = 20;
+
+    const { result } = renderHook(() =>
+      useItemPageNumber({ type, isDisabled, current, total }),
+    );
+
+    expect(result.current.pageNumber).toEqual(current - 1);
+  });
+
+  it('should return next page number', () => {
+    const type = 'next';
+    const isDisabled = false;
+    const current = 8;
+    const total = 20;
+
+    const { result } = renderHook(() =>
+      useItemPageNumber({ type, isDisabled, current, total }),
+    );
+
+    expect(result.current.pageNumber).toEqual(current + 1);
+  });
+
+  it('should return last page number', () => {
+    const type = 'last';
+    const isDisabled = false;
+    const current = 8;
+    const total = 20;
+
+    const { result } = renderHook(() =>
+      useItemPageNumber({ type, isDisabled, current, total }),
+    );
+
+    expect(result.current.pageNumber).toEqual(total);
+  });
+});

--- a/packages/spindle-ui/src/Pagination/hooks/useItemPageNumber.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useItemPageNumber.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+
+type Payload = {
+  type: 'first' | 'last' | 'next' | 'prev';
+  isDisabled: boolean;
+  current: number;
+  total: number;
+};
+
+export function useItemPageNumber({
+  type,
+  isDisabled,
+  current,
+  total,
+}: Payload) {
+  const pageNumber = useMemo(() => {
+    if (type === 'first') {
+      return 1;
+    } else if (type === 'prev') {
+      return !isDisabled ? current - 1 : 1;
+    } else if (type === 'next') {
+      return !isDisabled ? current + 1 : total;
+    } else {
+      return total;
+    }
+  }, [type, isDisabled, current, total]);
+
+  return { pageNumber };
+}

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useShowItem } from './useShowItem';
+
+describe('useShowItem()', () => {
+  it('should return show props', () => {
+    const current = 8;
+    const total = 20;
+    const pageItem = 5;
+
+    const { result } = renderHook(() =>
+      useShowItem({ current, total, pageItem }),
+    );
+
+    expect(result.current.displayItem).toEqual([1, 7, 8, 9, 20]);
+    expect(result.current.showPrevHorizontal).toEqual(true);
+    expect(result.current.showNextHorizontal).toEqual(true);
+  });
+
+  it('should return show props is current first', () => {
+    const current = 1;
+    const total = 20;
+    const pageItem = 5;
+
+    const { result } = renderHook(() =>
+      useShowItem({ current, total, pageItem }),
+    );
+
+    expect(result.current.displayItem).toEqual([1, 2, 3, 4, 20]);
+    expect(result.current.showPrevHorizontal).toEqual(false);
+    expect(result.current.showNextHorizontal).toEqual(true);
+  });
+
+  it('should return show props is current first', () => {
+    const current = 20;
+    const total = 20;
+    const pageItem = 5;
+
+    const { result } = renderHook(() =>
+      useShowItem({ current, total, pageItem }),
+    );
+
+    expect(result.current.displayItem).toEqual([1, 17, 18, 19, 20]);
+    expect(result.current.showPrevHorizontal).toEqual(true);
+    expect(result.current.showNextHorizontal).toEqual(false);
+  });
+});

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+
+type Payload = {
+  current: number;
+  total: number;
+  pageItem: number;
+};
+
+export function useShowItem({ current, total, pageItem = 5 }: Payload) {
+  const displayItem = useMemo(() => {
+    if (current === 1 || current === 2) {
+      // 現在値が1か2の場合は"1,2,3,4,total"とする
+      return [1, 2, 3, 4, total];
+    } else if (current !== total && current !== total - 1) {
+      // "1,current-1,current,current+1,total"とする
+      return [1, current - 1, current, current + 1, total];
+    } else {
+      // 現在値最大値なら"1,total-3,total-2,total-1,total"とする
+      return [1, total - 3, total - 2, total - 1, total];
+    }
+  }, [current, total]);
+
+  // totalは表示数超えている前提で、前から2つ目のアイテムが2より大きいかどうか（最初が連続した数字じゃないことをチェック）
+  const showPrevHorizontal = total > pageItem && 2 < displayItem[1];
+
+  // totalは表示数超えている前提で、後ろから2つ目のアイテムがtotal-1より小さいか（最後が連続した数字じゃないことをチェック）
+  const showNextHorizontal =
+    total > pageItem && displayItem[pageItem - 2] < total - 1;
+
+  return { displayItem, showPrevHorizontal, showNextHorizontal };
+}

--- a/packages/spindle-ui/src/Pagination/index.ts
+++ b/packages/spindle-ui/src/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { Pagination } from './Pagination';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -16,3 +16,4 @@
 @import './SnackBar/SnackBar.css';
 @import './List/index.css';
 @import './DropdownMenu/DropdownMenu.css';
+@import './Pagination/Pagination.css';


### PR DESCRIPTION
### 概要
ページ間の移動を目的として使用されることを想定したページネーションを追加しました。

### デザイン
<img width="475" alt="スクリーンショット 2022-07-25 15 02 34" src="https://user-images.githubusercontent.com/80251820/180708817-035a98fa-2dd0-4d79-984b-ca00045edb41.png">

### パターン
- 現在のページが**1**でページ総数も**1**の場合
- 現在のページが**1**でページ総数が**2**以上ある場合
- 現在のページとページ総数が**同じ**場合
- currntに対して前後いくつのページ番号を表示するかはpageItems（**3** or **5**）で指定することができる default値は**3** に加えて上記のパターンを考慮する

### Props
- url: string;（リンクに渡すURL）
  - urlには必ずPAGA_NUMBER渡しこれが遷移するページ数に変換されます
- current: number;（現在のページ）
- total: number;（ページ総数）
- showCount?: boolean;（現在のページ数と総ページ数のカウントを表示するか否か）
- showPrevNext?: boolean;（前へ次へアイコンを表示するか否か）
- showFirstLast?: boolean;（最初へ最後へアイコンを表示するか否か）
- onPagination?: (event: any, pageNumber: number) => void;
    - ページ番号をクリックした際はそのページ番号を返却
    - 「前へ」ボタンクリック時はcurrnt - 1を返却
    - 「次へ」ボタンクリック時はcurrnt + 1を返却
    - 「最初へ」ボタンクリック時は1を返却
    - 「最後へ」ボタンクリック時はtotal（ページ総数）を返却
- onCreateUrl?: (pageNumber: number) => string;
    - 関数を渡すことでURLを任意の形で生成

### WAI-ARIA
- aria-label
- aria-current