### PR TITLE
chore(spindle-ui): check ESM file size

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -1,15 +1,15 @@
 {
   "files": [
     {
-      "path": "./dist/Icon/@(OnedariFill|Peta|Amebapick).js",
+      "path": "./dist/Icon/@(OnedariFill|Peta|Amebapick).mjs",
       "maxSize": "2.12 kB"
     },
     {
-      "path": "./dist/Icon/!(index|OnedariFill|Peta|Amebapick).js",
+      "path": "./dist/Icon/!(index|OnedariFill|Peta|Amebapick).mjs",
       "maxSize": "1.5 kB"
     },
     {
-      "path": "./dist/!(Icon)/*.js",
+      "path": "./dist/!(Icon)/*.mjs",
       "maxSize": "1.5 kB"
     },
     {

--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -1,16 +1,16 @@
 {
   "files": [
     {
-      "path": "./dist/Icon/@(OnedariFill|Peta|Amebapick).mjs",
-      "maxSize": "2.12 kB"
+      "path": "./dist/Icon/@(OnedariFill|Peta).mjs",
+      "maxSize": "2 kB"
     },
     {
-      "path": "./dist/Icon/!(index|OnedariFill|Peta|Amebapick).mjs",
-      "maxSize": "1.5 kB"
+      "path": "./dist/Icon/!(index|OnedariFill|Peta).mjs",
+      "maxSize": "1.1 kB"
     },
     {
       "path": "./dist/!(Icon)/*.mjs",
-      "maxSize": "1.5 kB"
+      "maxSize": "1.1 kB"
     },
     {
       "path": "./dist/**/!(index).css",


### PR DESCRIPTION
Spindle UIとしてはESM版をプライマリとして提供している(お気持ち)ので、サイズチェックをそちらのスクリプトベースでするように変更しました。同時に今のサイズに合わせてバジェットを更新しています。
