### PR TITLE
docs: modify CDN stylesheet link URL

### DIFF
--- a/packages/spindle-ui/src/Modal/AppealModal.stories.mdx
+++ b/packages/spindle-ui/src/Modal/AppealModal.stories.mdx
@@ -20,7 +20,7 @@ import { AppealModalExample, StyleOnly, StyleOnlyMedium, StyleOnlySmall, StyleOn
 
 <Source
   language='html'
-  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Modal/AppealModal/AppealModal.css">`}
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Modal/AppealModal.css">`}
 />
 
 ## Appeal Modal


### PR DESCRIPTION
`AppealModal`のdocsにあるCSSのCDNリンクが正しくなかったため修正しました