### PR TITLE
build(spindle-icons): set tsconfig to build

### DIFF
--- a/packages/spindle-icons/tsconfig.json
+++ b/packages/spindle-icons/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
[アイコンのビルドが失敗](https://github.com/openameba/spindle/actions/runs/2661459157)していたので対応しました。[ts-node実行時](https://github.com/openameba/spindle/blob/4714a55f45348a04ef5468f3eba255eaa04f0f18/packages/spindle-icons/package.json#L8)に型エラーが出てたので共通のconfigを読み込むようにしてみました(前は参照できてたんだろか？[-Tオプション](https://typestrong.org/ts-node/docs/options#transpileonly)でもいいですがconfigはあってよさそうなため〜)。

その結果[ジョブは成功するようになりました](https://github.com/herablog/spindle/runs/7317222029?check_suite_focus=true)。

_より良い解決方法があればそりでいきたいです！_
