### PR TITLE
chore: fix renovate config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -9,9 +9,6 @@
     "group:postcss",
     "group:typescript-eslintMonorepo"
   ],
-  "assignees": [
-    "herablog",
-    "sasaplus1",
-    "hiloki"
-  ]
+  "assignees": ["herablog", "sasaplus1"],
+  "prConcurrentLimit": 0
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -9,6 +9,6 @@
     "group:postcss",
     "group:typescript-eslintMonorepo"
   ],
-  "assignees": ["herablog", "sasaplus1"],
+  "reviewers": ["team:openameba/spindle-working-group"],
   "prConcurrentLimit": 0
 }


### PR DESCRIPTION
https://github.com/openameba/spindle/pull/451 で修正したrenovateの問題ですが、`config:base`で`prConcurrentLimit`が10に設定されているのが原因でした。
Spindleは活発に開発され続けるRepositoryなはずなので`prConcurrentLimit`を0にして制限を無くしました。
またassigneeに`@hiloki`さんが入っていたので外しました