### PR TITLE
Feat/update toast

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -9,11 +9,23 @@
       "maxSize": "1.1 kB"
     },
     {
-      "path": "./dist/!(Icon|Modal)/*.mjs",
+      "path": "./dist/!(Icon|Toast|Modal)/*.mjs",
       "maxSize": "1.1 kB"
     },
     {
       "path": "./dist/Modal/*.mjs",
+      "maxSize": "1.5 kB"
+    },
+    {
+      "path": "./dist/!(Modal)/!(index).css",
+      "maxSize": "1.5 kB"
+    },
+    {
+      "path": "./dist/Modal/!(index).css",
+      "maxSize": "2.0 kB"
+    },
+    {
+      "path": "./dist/Toast/*.mjs",
       "maxSize": "1.5 kB"
     },
     {

--- a/packages/spindle-ui/src/Toast/Toast.css
+++ b/packages/spindle-ui/src/Toast/Toast.css
@@ -1,67 +1,161 @@
+@import '../IconButton/IconButton.css';
+
 :root {
   --Toast-z-index: 1;
 }
 
 .spui-Toast {
+  box-sizing: border-box;
   left: 0;
+  padding: 0 12px;
   position: fixed;
   right: 0;
   text-align: center;
   z-index: var(--Toast-z-index);
 }
 
-.spui-Toast--content {
-  background-color: var(--color-surface-accent-primary-light);
-  border-radius: 40px;
-  box-shadow: 0px 4.75px 14.25px rgba(8, 18, 26, 0.12);
+.spui-Toast-content {
+  align-items: center;
+  border-radius: 52px;
+  box-shadow: 0px 11px 28px rgba(8, 18, 26, 0.24);
   box-sizing: border-box;
-  color: var(--color-text-accent-primary);
-  cursor: default;
-  display: inline-block;
-  font-family: inherit;
-  font-size: 16px;
-  font-weight: bold;
+  display: inline-flex;
   margin: 0;
-  padding: 11px 16px;
+  max-width: 360px;
+  min-height: 48px;
+  padding: 0 16px 0 20px;
 }
 
-.spui-Toast-content--error {
-  background-color: var(--color-surface-caution-light);
-  color: var(--color-text-caution);
-  position: relative;
+.spui-Toast-contentInfo {
+  flex-shrink: 0;
+  font-size: 1.375rem;
+  line-height: 0;
+  margin-right: 8px;
 }
 
-.spui-Toast-content--error:before {
-  background-color: var(--color-surface-primary);
-  border-radius: 40px;
-  content: '';
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-  z-index: -1;
+.spui-Toast-contentText {
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: bold;
+  line-height: 1.6;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .spui-Toast--top {
-  top: 16px;
+  top: 0;
+  transform: translateY(
+    calc(var(--Toast--initial-height) - var(--Toast--offset-top))
+  );
 }
 
 .spui-Toast--bottom {
   bottom: 0;
+  transform: translateY(
+    calc((var(--Toast--initial-height) - var(--Toast--offset-bottom)) * -1)
+  );
 }
 
 .spui-Toast--slide {
-  transform: translateY(-100px);
-  transition: transform 0.5s ease;
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.spui-Toast--hidden {
+  visibility: hidden;
 }
 
 .spui-Toast-slide--in {
-  transform: translateY(0);
+  opacity: 1;
+  transition: transform 0.5s ease, opacity 0.5s ease;
+}
+
+.spui-Toast-slide--in.spui-Toast--top {
+  transform: translateY(var(--Toast--order-offset-top));
+}
+
+.spui-Toast-slide--in.spui-Toast--bottom {
+  transform: translateY(var(--Toast--order-offset-bottom));
+}
+
+.spui-Toast-iconButton {
+  /* stylelint-disable-next-line plugin/selector-bem-pattern */
+  --IconButton--neutral-backgroundColor: transparent;
+  margin-left: 12px;
+}
+
+/* === Information === */
+
+.spui-Toast-contentInfo--information {
+  color: var(--color-object-high-emphasis-inverse);
+}
+
+.spui-Toast-content--information {
+  /* TODO: use --color-surface-accent-neutral-high-emphasis */
+  background-color: var(--gray-80);
+  color: var(--color-text-high-emphasis-inverse);
+}
+
+.spui-Toast-iconButton--information {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --IconButton--neutral-onActive-backgroundColor: var(--white-20-alpha);
+  --IconButton--neutral-onHover-backgroundColor: var(--white-20-alpha);
+  --IconButton--neutral-color: var(--color-object-high-emphasis-inverse);
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+/* === Confirmation === */
+
+.spui-Toast-contentInfo--confirmation {
+  color: var(--color-object-accent-primary);
+}
+
+.spui-Toast-content--confirmation {
+  background-color: var(--color-surface-primary);
+  border: 2px solid var(--color-border-low-emphasis);
+  color: var(--color-text-accent-primary);
+}
+
+.spui-Toast-iconButton--confirmation {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --IconButton--neutral-onActive-backgroundColor: var(--gray-20-alpha);
+  --IconButton--neutral-onHover-backgroundColor: var(--gray-20-alpha);
+  --IconButton--neutral-color: var(--color-object-low-emphasis);
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+/* === Error === */
+
+.spui-Toast-contentInfo--error {
+  color: var(--color-object-high-emphasis-inverse);
+}
+
+.spui-Toast-content--error {
+  background-color: var(--color-surface-caution);
+  color: var(--color-text-high-emphasis-inverse);
+}
+
+.spui-Toast-iconButton--error {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --IconButton--neutral-onActive-backgroundColor: var(--white-20-alpha);
+  --IconButton--neutral-onHover-backgroundColor: var(--white-20-alpha);
+  --IconButton--neutral-color: var(--color-object-high-emphasis-inverse);
+  /* stylelint-enable plugin/selector-bem-pattern */
 }
 
 @media (prefers-reduced-motion: reduce) {
   .spui-Toast--slide {
     transition-duration: 0.1ms;
+  }
+
+  .spui-Toast-slide--in {
+    transition-duration: 0.1ms;
+  }
+}
+
+/* max-width equals to the sum of the content's max-width and horizontal padding */
+@media (max-width: 384px) {
+  .spui-Toast-content {
+    max-width: 100%;
   }
 }

--- a/packages/spindle-ui/src/Toast/Toast.stories.mdx
+++ b/packages/spindle-ui/src/Toast/Toast.stories.mdx
@@ -3,6 +3,7 @@ import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { Toast } from './Toast';
 import { Button } from '../Button';
+import { Information, CheckCircleFill, ExclamationmarkCircleFill } from '../Icon';
 
 export const usePoliteAnnouncer = (message) => {
   const announcer = useRef(null);
@@ -18,31 +19,84 @@ export const usePoliteAnnouncer = (message) => {
       announcerContent.textContent = message;
     }
     return () => {
-      if(message) {
+      if (message) {
         announcerContent.textContent = '';
       }
     };
   }, [message]);
 };
 
-export const ActivateButton = ({ hasError }) => {
+export const ActivateButton = ({
+  message: _message,
+  variant,
+  hideInfoIcon,
+  order,
+  icon,
+  position,
+}) => {
   const [message, setMessage] = useState('');
   usePoliteAnnouncer(message);
   return (
     <div>
       <Button
         size="medium"
-        variant={hasError ? 'danger' : 'outlined'}
-        onClick={() => setMessage('Toast Content')}
+        variant={variant === "error" ? 'danger' : 'outlined'}
+        onClick={() => setMessage(_message || 'メッセージが届きました')}
+      >
+        Activate
+      </Button>
+      <div style={{ ["--Toast-z-index"]: 2 }}>
+        <Toast
+          active={!!message}
+          variant={variant}
+          hideInfoIcon={hideInfoIcon}
+          order={order}
+          icon={icon}
+          position={position}
+          onHide={() => setMessage('')}
+        >
+          {message}
+        </Toast>
+      </div>
+    </div>
+  );
+};
+
+export const MultiActivateButton = ({ offset, icon, position }) => {
+  const [message1, setMessage1] = useState('');
+  const [message2, setMessage2] = useState('');
+  usePoliteAnnouncer(message1);
+  return (
+    <div>
+      <Button
+        size="medium"
+        variant={'outlined'}
+        onClick={() => {
+          setMessage1('メッセージが届きました1');
+          setMessage2('メッセージが届きました2');
+        }}
       >
         Activate
       </Button>
       <Toast
-        active={!!message}
-        hasError={hasError}
-        onHide={() => setMessage('')}
+        active={!!message1}
+        offset={offset}
+        order={0}
+        icon={icon}
+        position={position}
+        onHide={() => setMessage1('')}
       >
-        {message}
+        {message1}
+      </Toast>
+      <Toast
+        active={!!message2}
+        offset={offset}
+        order={message1 ? 1 : 0}
+        icon={icon}
+        position={position}
+        onHide={() => setMessage2('')}
+      >
+        {message2}
       </Toast>
     </div>
   );
@@ -55,7 +109,7 @@ export const ActivateButton = ({ hasError }) => {
 ![stability-experiment](https://img.shields.io/badge/stability-experiment-red.svg)
 
 <Description>
-  Toastコンポーネントは、利用者に一時的なお知らせをする際に利用します。画面上には常に一つしか表示できません。Toastは自動で消えてしまうため、見落とされても影響のない「重要ではないお知らせ」に用います。利用する際には、その他により適切な手段がないか必ず確認してください。
+  Toastコンポーネントは、利用者に一時的なお知らせをする際に利用します。画面上に複数表示することができます。Toastは自動で消えてしまうため、見落とされても影響のない「重要ではないお知らせ」に用います。利用する際には、その他により適切な手段がないか必ず確認してください。
 </Description>
 <Description>
   「重要なお知らせ」とは何か、他のnotification系のコンポーネントとの違いは別途まとめる予定です。
@@ -76,17 +130,45 @@ export const ActivateButton = ({ hasError }) => {
   code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Toast/Toast.css">`}
 />
 
-## Normal
+## Information
 
 <Preview withSource="open">
-  <Story name="Normal">
-    <ActivateButton />
+  <Story name="Information">
+    <ActivateButton variant="information" icon={<Information />} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<Toast active={true}>Success Content</Toast>
+<Toast active={true} variant="information" icon={<Information />}>メッセージが届きました</Toast>
+  `}
+/>
+
+## Information without info icon
+
+<Preview withSource="open">
+  <Story name="Information without info icon">
+    <ActivateButton variant="information" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Toast active={true} variant="information" hideInfoIcon>メッセージが届きました</Toast>
+  `}
+/>
+
+## Confirmation
+
+<Preview withSource="open">
+  <Story name="Confirmation">
+    <ActivateButton variant="confirmation" icon={<CheckCircleFill />} />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Toast active={true} variant="confirmation" icon={<CheckCircleFill />}>メッセージが届きました</Toast>
   `}
 />
 
@@ -94,13 +176,74 @@ export const ActivateButton = ({ hasError }) => {
 
 <Preview withSource="open">
   <Story name="Error">
-    <ActivateButton hasError />
+    <ActivateButton variant="error" icon={<ExclamationmarkCircleFill />} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<Toast active={true} hasError>Error Content</Toast>
+<Toast active={true} variant="error" icon={<ExclamationmarkCircleFill />}>メッセージが届きました</Toast>
+  `}
+/>
+
+## Position Bottom
+
+<Preview withSource="open">
+  <Story name="Position Bottom">
+    <ActivateButton icon={<Information />} position="bottom" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Toast active={true} position="bottom" icon={<Information />}>メッセージが届きました</Toast>
+  `}
+/>
+
+## Long Content
+
+<Preview withSource="open">
+  <Story name="Long Content">
+    <ActivateButton
+      message="長いコンテンツは1行で切られるので注意が必要です。"
+      icon={<Information />}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Toast active={true} icon={<Information />}>長いコンテンツは1行で切られるので注意が必要です。</Toast>
+  `}
+/>
+
+## Multiple
+
+<Preview withSource="open">
+  <Story name="Multiple">
+    <MultiActivateButton offset={{ top: 30 }} icon={<Information />} />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Toast active={true} order={0} offset={{ top: 30 }}>メッセージが届きました1</Toast>
+<Toast active={true} order={1} offset={{ top: 30 }}>メッセージが届きました2</Toast>
+  `}
+/>
+
+## Multiple bottom
+
+<Preview withSource="open">
+  <Story name="Multiple bottom">
+    <MultiActivateButton offset={{ bottom: 30 }} position="bottom" icon={<Information />} />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<Toast active={true} order={0} offset={{ bottom: 30 }} position="bottom">メッセージが届きました1</Toast>
+<Toast active={true} order={1} offset={{ bottom: 30 }} position="bottom">メッセージが届きました2</Toast>
   `}
 />
 
@@ -125,8 +268,10 @@ export const ActivateButton = ({ hasError }) => {
   Toastは自動で消えてしまうため、見落とされても影響のない、「重要ではないお知らせ」に用います
 </Description>
 <Description>
-  -
-  もし「重要なお知らせ」に用いる場合、時間制限を外し、閉じるボタンを設置します（**※未実装**）
+  - アイコンの設定は利用者に委ねられていますが、基本的には設定します。**`information`のみアイコンを外すことができます。**
+</Description>
+<Description>
+  - `z-index`はdefaultでは`1`になっていますが、必要に応じて`--Toast-z-index`を設定してください
 </Description>
 <Description>
   -

--- a/packages/spindle-ui/src/Toast/Toast.test.tsx
+++ b/packages/spindle-ui/src/Toast/Toast.test.tsx
@@ -4,6 +4,8 @@ import { jest } from '@jest/globals';
 
 import { Toast, BLOCK_NAME, ANIMATION_DURATION } from './Toast';
 
+const DURATION = 4000;
+
 describe('<Toast />', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -18,20 +20,21 @@ describe('<Toast />', () => {
     const testAnimation = () => {
       onHide.mockReset();
 
-      expect(screen.getByText(/content/).parentElement).toHaveClass(
-        `${BLOCK_NAME}-slide--in`,
-      );
+      expect(
+        screen.getByText(/content/).parentElement?.parentElement,
+      ).toHaveClass(`${BLOCK_NAME}-slide--in`);
 
       act(() => {
-        jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+        jest.advanceTimersByTime(DURATION - ANIMATION_DURATION);
       });
 
-      expect(screen.getByText(/content/).parentElement).not.toHaveClass(
-        `${BLOCK_NAME}-slide--in`,
-      );
+      expect(
+        screen.getByText(/content/).parentElement?.parentElement,
+      ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
 
       act(() => {
-        const parentElement = screen.getByText(/content/).parentElement;
+        const parentElement =
+          screen.getByText(/content/).parentElement?.parentElement;
         expect(parentElement).not.toBeNull();
         if (parentElement) {
           fireEvent.transitionEnd(parentElement);
@@ -42,9 +45,8 @@ describe('<Toast />', () => {
     };
 
     const onHide = jest.fn();
-    const duration = 5000;
     const { rerender } = render(
-      <Toast active onHide={onHide} duration={duration}>
+      <Toast active onHide={onHide}>
         content
       </Toast>,
     );
@@ -54,18 +56,18 @@ describe('<Toast />', () => {
     /* === The following code check if timeoutID is null === */
 
     rerender(
-      <Toast active={false} onHide={onHide} duration={duration}>
+      <Toast active={false} onHide={onHide}>
         content
       </Toast>,
     );
 
-    expect(screen.getByText(/content/).parentElement).not.toHaveClass(
-      `${BLOCK_NAME}-slide--in`,
-    );
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
 
     // If timeoutID is not null, Toast animation is not invoked again.
     rerender(
-      <Toast active onHide={onHide} duration={duration}>
+      <Toast active onHide={onHide}>
         content
       </Toast>,
     );
@@ -75,9 +77,8 @@ describe('<Toast />', () => {
 
   test('When it is hovered, duration should be reset', () => {
     const onHide = jest.fn();
-    const duration = 4000;
     render(
-      <Toast active onHide={onHide} duration={duration}>
+      <Toast active onHide={onHide}>
         content
       </Toast>,
     );
@@ -85,25 +86,26 @@ describe('<Toast />', () => {
     fireEvent.mouseOver(screen.getByText(/content/));
 
     act(() => {
-      jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+      jest.advanceTimersByTime(DURATION - ANIMATION_DURATION);
     });
 
-    expect(screen.getByText(/content/).parentElement).toHaveClass(
-      `${BLOCK_NAME}-slide--in`,
-    );
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).toHaveClass(`${BLOCK_NAME}-slide--in`);
 
     fireEvent.mouseOut(screen.getByText(/content/));
 
     act(() => {
-      jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+      jest.advanceTimersByTime(DURATION - ANIMATION_DURATION);
     });
 
-    expect(screen.getByText(/content/).parentElement).not.toHaveClass(
-      `${BLOCK_NAME}-slide--in`,
-    );
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
 
     act(() => {
-      const parentElement = screen.getByText(/content/).parentElement;
+      const parentElement =
+        screen.getByText(/content/).parentElement?.parentElement;
       expect(parentElement).not.toBeNull();
       if (parentElement) {
         fireEvent.transitionEnd(parentElement);
@@ -114,36 +116,75 @@ describe('<Toast />', () => {
   });
 
   test('When it is focused, duration should be reset', () => {
+    const handleCloseButtonEvent = (evtName: 'focus' | 'blur') => {
+      const parentElement = screen.getByLabelText(/閉じる/).parentElement;
+      if (parentElement) {
+        fireEvent[evtName](parentElement);
+      }
+    };
     const onHide = jest.fn();
-    const duration = 4000;
     render(
-      <Toast active onHide={onHide} duration={duration}>
+      <Toast active onHide={onHide}>
         content
       </Toast>,
     );
 
-    fireEvent.focus(screen.getByText(/content/));
+    handleCloseButtonEvent('focus');
 
     act(() => {
-      jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+      jest.advanceTimersByTime(DURATION - ANIMATION_DURATION);
     });
 
-    expect(screen.getByText(/content/).parentElement).toHaveClass(
-      `${BLOCK_NAME}-slide--in`,
-    );
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).toHaveClass(`${BLOCK_NAME}-slide--in`);
 
-    fireEvent.blur(screen.getByText(/content/));
+    handleCloseButtonEvent('blur');
 
     act(() => {
-      jest.advanceTimersByTime(duration - ANIMATION_DURATION);
+      jest.advanceTimersByTime(DURATION - ANIMATION_DURATION);
     });
 
-    expect(screen.getByText(/content/).parentElement).not.toHaveClass(
-      `${BLOCK_NAME}-slide--in`,
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+    act(() => {
+      const parentElement =
+        screen.getByText(/content/).parentElement?.parentElement;
+      expect(parentElement).not.toBeNull();
+      if (parentElement) {
+        fireEvent.transitionEnd(parentElement);
+      }
+    });
+
+    expect(onHide).toBeCalledTimes(1);
+  });
+
+  test('it should close when close button is clicked', () => {
+    const onHide = jest.fn();
+    render(
+      <Toast active onHide={onHide}>
+        content
+      </Toast>,
     );
 
     act(() => {
-      const parentElement = screen.getByText(/content/).parentElement;
+      // Get button element outer of 閉じる icon.
+      const parentElement = screen.getByLabelText(/閉じる/).parentElement;
+      expect(parentElement).not.toBeNull();
+      if (parentElement) {
+        fireEvent.click(parentElement);
+      }
+    });
+
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+    act(() => {
+      const parentElement =
+        screen.getByText(/content/).parentElement?.parentElement;
       expect(parentElement).not.toBeNull();
       if (parentElement) {
         fireEvent.transitionEnd(parentElement);

--- a/packages/spindle-ui/src/Toast/Toast.tsx
+++ b/packages/spindle-ui/src/Toast/Toast.tsx
@@ -1,65 +1,62 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { CrossBold } from '../Icon';
+import { IconButton } from '../IconButton';
 
 type Position = 'top' | 'bottom';
-type Animation = 'slide' | 'fade';
+type PositionOffset = {
+  [K in Position]?: number;
+};
+
+type Variant = 'information' | 'confirmation' | 'error';
 
 type Props = {
   children?: React.ReactNode;
   active?: boolean;
+  order?: number;
+  offset?: PositionOffset;
   // milliseconds to hide
   duration?: number;
   onHide?: () => void;
   position?: Position;
-  animation?: Animation;
-  hasError?: boolean;
+  icon?: React.ReactNode;
+  variant?: Variant;
 };
 
 export const BLOCK_NAME = 'spui-Toast';
 
 // Duration for css animation.
-export const ANIMATION_DURATION = 500;
+export const ANIMATION_DURATION = 300;
 
-const MIN_DURATION = 4000;
-const MAX_DURATION = 100000;
-
-const getAnimationClassName = (
-  isShow: boolean,
-  animation: Animation,
-): string => {
-  return isShow ? `${BLOCK_NAME}-${animation}--in` : '';
-};
-
-const limitDuration = (duration: number) => {
-  if (duration < MIN_DURATION || duration > MAX_DURATION) {
-    return MIN_DURATION;
-  }
-  return duration;
-};
+const MAX_DURATION = 4000;
+const VERTICAL_GAP = 20;
+const TOTAL_ANIMATION_DURATION = MAX_DURATION - ANIMATION_DURATION;
 
 export const Toast = ({
   children,
   active = false,
-  duration = 4000,
-  animation = 'slide',
   position = 'top',
-  hasError = false,
+  order = 0,
+  offset: _offset = {},
   onHide,
+  icon,
+  variant = 'information',
 }: Props): React.ReactElement => {
   const [isShow, setIsShow] = useState<boolean>(false);
-  const animationClassName = getAnimationClassName(isShow, animation);
-  const errorContentClassName = hasError ? `${BLOCK_NAME}-content--error` : '';
-  const formattedDuration = limitDuration(duration) - ANIMATION_DURATION;
+  const offset: PositionOffset = {
+    top: _offset.top || 24,
+    bottom: _offset.bottom || 24,
+  };
   const timeoutID = useRef<number | null>(null);
-  const transitionElementRef = useRef<HTMLDivElement | null>(null);
+  const [clientHeight, setClientHeight] = useState(0);
 
   const setIsShowWithTimeout = useCallback(() => {
-    // Out animation is executed after `formattedDuration` seconds.
+    // Out animation is executed after `TOTAL_ANIMATION_DURATION` seconds.
     if (timeoutID.current === null && isShow) {
       timeoutID.current = window.setTimeout(() => {
         setIsShow(false);
-      }, formattedDuration);
+      }, TOTAL_ANIMATION_DURATION);
     }
-  }, [isShow, timeoutID, setIsShow, formattedDuration]);
+  }, [isShow, timeoutID, setIsShow]);
 
   const resetTimeout = useCallback(() => {
     if (timeoutID.current) {
@@ -75,6 +72,10 @@ export const Toast = ({
     }
   }, [isShow, setIsShow, onHide]);
 
+  const handleOnClickCloseButton = useCallback(() => {
+    setIsShow(false);
+  }, []);
+
   useEffect(() => {
     // Animation is not stopped even if `active` props is changed while running animation.
     if (active && timeoutID.current === null) {
@@ -87,38 +88,55 @@ export const Toast = ({
     return resetTimeout;
   }, [setIsShowWithTimeout, resetTimeout]);
 
-  useEffect(() => {
-    const transitionElement = transitionElementRef.current;
-
-    // When out animation is finished, `onHide` method is invoked.
-    if (transitionElement) {
-      transitionElement.addEventListener('transitionend', handleTransitionEnd);
-    }
-
-    return () => {
-      if (transitionElement) {
-        transitionElement.removeEventListener(
-          'transitionend',
-          handleTransitionEnd,
-        );
-      }
-    };
-  }, [transitionElementRef, handleTransitionEnd]);
+  const contentHeight = clientHeight;
+  const offsetPosition = offset[position] || 0;
+  const orderOffset = order * (contentHeight + VERTICAL_GAP) + offsetPosition;
 
   return (
     <div
-      className={`${BLOCK_NAME} ${BLOCK_NAME}--${position} ${BLOCK_NAME}--${animation} ${animationClassName}`}
-      ref={transitionElementRef}
+      style={{
+        ['--Toast--initial-height' as string]: `${
+          orderOffset - contentHeight + offsetPosition
+        }px`,
+        ['--Toast--order-offset-top' as string]: `${orderOffset}px`,
+        ['--Toast--order-offset-bottom' as string]: `${-orderOffset}px`,
+        ['--Toast--offset-top' as string]: `${offset.top}px`,
+        ['--Toast--offset-bottom' as string]: `${offset.bottom}px`,
+      }}
+      className={[
+        BLOCK_NAME,
+        `${BLOCK_NAME}--${position}`,
+        `${BLOCK_NAME}--slide`,
+        isShow && `${BLOCK_NAME}-slide--in`,
+        !active && `${BLOCK_NAME}--hidden`,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-hidden={!active}
+      onTransitionEnd={handleTransitionEnd}
+      ref={(ref) => setClientHeight(ref?.clientHeight || 0)}
     >
       <div
-        className={`${BLOCK_NAME}--content ${errorContentClassName}`}
-        tabIndex={0}
+        className={`${BLOCK_NAME}-content ${BLOCK_NAME}-content--${variant}`}
         onMouseOver={resetTimeout}
         onMouseOut={setIsShowWithTimeout}
         onFocus={resetTimeout}
         onBlur={setIsShowWithTimeout}
       >
-        {children}
+        {icon && <div className={`${BLOCK_NAME}-contentInfo`}>{icon}</div>}
+        <span className={`${BLOCK_NAME}-contentText`}>{children}</span>
+        <div
+          className={`${BLOCK_NAME}-iconButton ${BLOCK_NAME}-iconButton--${variant}`}
+          onTransitionEnd={(e) => e.stopPropagation()}
+        >
+          <IconButton
+            size="exSmall"
+            variant="neutral"
+            onClick={handleOnClickCloseButton}
+          >
+            <CrossBold aria-label="閉じる" />
+          </IconButton>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Toastをアップデートし、以下の要素を追加しました。

- 先頭にinformation iconが表示されるようになりました
  - `variant="information"`の時は非表示できます
- close buttonの追加
- variantの追加(`information`, `confirmation`, `error`)
- 複数表示のサポート

|information|confirmation|error|
|-|-|-|
|![Screen Shot 2022-07-19 at 18 23 36](https://user-images.githubusercontent.com/34934510/179717572-17129332-b93e-44b5-b1c9-6d41bb8986df.png)|![Screen Shot 2022-07-19 at 18 24 07](https://user-images.githubusercontent.com/34934510/179717649-ab9bf8db-7e38-4090-85df-86dffd39db82.png)|![Screen Shot 2022-07-19 at 18 24 23](https://user-images.githubusercontent.com/34934510/179717743-62e07ab3-399f-45cc-91a8-c6b2a31c3a3d.png)|

## TODO

- [ ] approve後にcommitをまとめます
- [ ] 今回のToastをベースにSnack Barを実装します
