### PR TITLE
chore: use renovate automerge for linter and test

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -10,5 +10,23 @@
     "group:typescript-eslintMonorepo"
   ],
   "reviewers": ["team:spindle-working-group"],
-  "prConcurrentLimit": 0
+  "prConcurrentLimit": 0,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchPackagePatterns": [
+        "eslint",
+        "jest",
+        "^@testing-library",
+        "stylelint",
+        "^bundlesize$",
+        "prettier",
+        "textlint",
+        "acot",
+        "yaml-lint",
+        "reg-suit"
+      ],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
renovateのPRの数が多くて捌ききれないのでlinter系とtest系はautomergeを設定します。
