### PR TITLE
Feat/add snack bar

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -9,7 +9,7 @@
       "maxSize": "1.1 kB"
     },
     {
-      "path": "./dist/!(Icon|Toast|Modal)/*.mjs",
+      "path": "./dist/!(Icon|Toast|Modal|SnackBar)/*.mjs",
       "maxSize": "1.1 kB"
     },
     {
@@ -17,19 +17,15 @@
       "maxSize": "1.5 kB"
     },
     {
-      "path": "./dist/!(Modal)/!(index).css",
-      "maxSize": "1.5 kB"
-    },
-    {
-      "path": "./dist/Modal/!(index).css",
-      "maxSize": "2.0 kB"
+      "path": "./dist/SnackBar/*.mjs",
+      "maxSize": "1.74 kB"
     },
     {
       "path": "./dist/Toast/*.mjs",
       "maxSize": "1.5 kB"
     },
     {
-      "path": "./dist/!(Modal)/!(index).css",
+      "path": "./dist/!(Modal|SnackBar)/!(index).css",
       "maxSize": "1.5 kB"
     },
     {
@@ -37,8 +33,12 @@
       "maxSize": "2.0 kB"
     },
     {
+      "path": "./dist/SnackBar/!(index).css",
+      "maxSize": "2.0 kB"
+    },
+    {
       "path": "./dist/index.css",
-      "maxSize": "7 kB"
+      "maxSize": "7.2 kB"
     }
   ]
 }

--- a/packages/spindle-ui/src/SnackBar/SnackBar.css
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.css
@@ -1,0 +1,253 @@
+@import '../IconButton/IconButton.css';
+@import '../TextLink/TextLink.css';
+@import '../TextButton/TextButton.css';
+
+:root {
+  --SnackBar-z-index: 1;
+  --SnackBar-onFocus-outlineColor: var(--color-focus-clarity);
+}
+
+.spui-SnackBar {
+  box-sizing: border-box;
+  left: 0;
+  padding: 0 var(--SnackBar--offset-right) 0 var(--SnackBar--offset-left);
+  position: fixed;
+  right: 0;
+  text-align: var(--SnackBar--text-align);
+  z-index: var(--SnackBar-z-index);
+}
+
+.spui-SnackBar-content {
+  align-items: center;
+  border-radius: 16px;
+  box-shadow: 0px 11px 28px rgba(8, 18, 26, 0.24);
+  box-sizing: border-box;
+  display: inline-grid;
+  grid-template: 'Icon Text Button IconButton' auto / auto 1fr auto auto;
+  max-width: 440px;
+  min-height: 52px;
+  min-width: 360px;
+  padding: 14px 16px 14px 20px;
+}
+
+.spui-SnackBar-icon {
+  flex-shrink: 0;
+  font-size: 1.375rem;
+  grid-area: Icon;
+  line-height: 0;
+  margin-right: 12px;
+}
+
+.spui-SnackBar-text {
+  --SnackBar-max-lines: 3;
+
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: bold;
+  grid-area: Text;
+  line-height: 1.6;
+  max-height: calc(1em * 1.6 * var(--SnackBar-max-lines));
+  overflow: hidden;
+  text-align: left;
+}
+
+.spui-SnackBar-button {
+  font-size: 0.875rem;
+  grid-area: Button;
+  margin-left: 16px;
+  margin-right: 13px; /* margin for border + border width */
+  position: relative;
+}
+
+.spui-SnackBar-button::after {
+  bottom: 0;
+  content: '';
+  display: inline-block;
+  position: absolute;
+  right: -12px;
+  top: 0;
+  width: 1px;
+}
+
+.spui-SnackBar--top {
+  top: 0;
+  transform: translateY(
+    calc(var(--SnackBar--initial-height-top) - var(--SnackBar--offset-top))
+  );
+}
+
+.spui-SnackBar--bottom {
+  bottom: 0;
+  transform: translateY(
+    calc(
+      (var(--SnackBar--initial-height-bottom) - var(--SnackBar--offset-bottom)) *
+        -1
+    )
+  );
+}
+
+.spui-SnackBar--slide {
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.spui-SnackBar--hidden {
+  visibility: hidden;
+}
+
+.spui-SnackBar-slide--in {
+  opacity: 1;
+  transition: transform 0.5s ease, opacity 0.5s ease;
+}
+
+.spui-SnackBar-slide--in.spui-SnackBar--top {
+  transform: translateY(var(--SnackBar--order-offset-top));
+}
+
+.spui-SnackBar-slide--in.spui-SnackBar--bottom {
+  transform: translateY(var(--SnackBar--order-offset-bottom));
+}
+
+.spui-SnackBar-iconButton {
+  /* stylelint-disable-next-line plugin/selector-bem-pattern */
+  --IconButton--neutral-backgroundColor: transparent;
+  grid-area: IconButton;
+  margin-left: 12px;
+}
+
+/* === Information === */
+
+.spui-SnackBar-content--information {
+  /* TODO: use --color-surface-accent-neutral-high-emphasis */
+  background-color: var(--gray-80);
+  color: var(--color-text-high-emphasis-inverse);
+}
+
+.spui-SnackBar-iconButton--information {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --IconButton--neutral-onActive-backgroundColor: var(--white-20-alpha);
+  --IconButton--neutral-onHover-backgroundColor: var(--white-20-alpha);
+  --IconButton--neutral-color: var(--color-object-high-emphasis-inverse);
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+.spui-SnackBar-button--information {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --TextLink-color: var(--color-text-high-emphasis-inverse);
+  --TextLink-icon-color: var(--color-object-high-emphasis-inverse);
+  --TextButton-color: var(--color-text-high-emphasis-inverse);
+  --TextButton-icon-color: var(--color-object-high-emphasis-inverse);
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+.spui-SnackBar-button--information::after {
+  /* TODO: use --color-border-low-emphasis-inverse */
+  background: var(--white-20-alpha);
+}
+
+/* === Confirmation === */
+
+.spui-SnackBar-content--confirmation {
+  background-color: var(--color-surface-primary);
+  border: 2px solid var(--color-border-low-emphasis);
+  color: var(--color-text-accent-primary);
+}
+
+.spui-SnackBar-iconButton--confirmation {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --IconButton--neutral-onActive-backgroundColor: var(--gray-20-alpha);
+  --IconButton--neutral-onHover-backgroundColor: var(--gray-20-alpha);
+  --IconButton--neutral-color: var(--color-object-low-emphasis);
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+.spui-SnackBar-button--confirmation {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --TextLink-color: var(--color-text-low-emphasis);
+  --TextLink-icon-color: var(--color-object-low-emphasis);
+  --TextButton-color: var(--color-text-low-emphasis);
+  --TextButton-icon-color: var(--color-object-low-emphasis);
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+.spui-SnackBar-button--confirmation::after {
+  background: var(--color-border-low-emphasis);
+}
+
+/* === Error === */
+
+.spui-SnackBar-content--error {
+  background-color: var(--color-surface-caution);
+  color: var(--color-text-high-emphasis-inverse);
+}
+
+.spui-SnackBar-iconButton--error {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --IconButton--neutral-onActive-backgroundColor: var(--white-20-alpha);
+  --IconButton--neutral-onHover-backgroundColor: var(--white-20-alpha);
+  --IconButton--neutral-color: var(--color-object-high-emphasis-inverse);
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+.spui-SnackBar-button--error {
+  /* stylelint-disable plugin/selector-bem-pattern */
+  --TextLink-color: var(--color-text-high-emphasis-inverse);
+  --TextLink-icon-color: var(--color-object-high-emphasis-inverse);
+  --TextButton-color: var(--color-text-high-emphasis-inverse);
+  --TextButton-icon-color: var(--color-object-high-emphasis-inverse);
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+.spui-SnackBar-button--error::after {
+  /* TODO: use --color-border-low-emphasis-inverse */
+  background: var(--white-20-alpha);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spui-SnackBar--slide {
+    transition-duration: 0.1ms;
+  }
+
+  .spui-SnackBar-slide--in {
+    transition-duration: 0.1ms;
+  }
+}
+
+/* `max-width` for the SnackBar is set to 440px and horizontal margin is 12px on the desktop. */
+/* Therefore, breakpoint is 464px that is the sum of the max-width and horizontal margin. */
+@media (max-width: 464px) {
+  .spui-SnackBar {
+    padding: 0 12px;
+    text-align: center;
+
+    /* On mobile device, the snack bar position is fixed at the bottom */
+    /* stylelint-disable-next-line order/properties-alphabetical-order */
+    bottom: 0;
+    top: unset;
+    transform: translateY(
+      calc(
+        (
+            var(--SnackBar--initial-height-bottom) -
+              var(--SnackBar--offset-bottom)
+          ) * -1
+      )
+    );
+  }
+
+  .spui-SnackBar-slide--in.spui-SnackBar--top {
+    transform: translateY(var(--SnackBar--order-offset-bottom));
+  }
+
+  .spui-SnackBar-content {
+    border-radius: 82px;
+    max-width: 400px;
+    min-width: calc(100% - 24px);
+    padding: 14px 16px 14px 20px;
+  }
+}
+
+@media (max-width: 320px) {
+  .spui-SnackBar-text {
+    --SnackBar-max-lines: 4;
+  }
+}

--- a/packages/spindle-ui/src/SnackBar/SnackBar.stories.mdx
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.stories.mdx
@@ -1,0 +1,534 @@
+import { useState, useEffect, useRef, forwardRef } from 'react';
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { actions } from '@storybook/addon-actions';
+import { SnackBar } from './SnackBar';
+import { Button } from '../Button';
+import { Information, CheckCircleFill, Openblank, ExclamationmarkCircleFill } from '../Icon';
+
+export const usePoliteAnnouncer = (message) => {
+  const announcer = useRef(null);
+  useEffect(() => {
+    announcer.current = document.getElementById('polite-announcer');
+    return () => {
+      announcer.current = null;
+    };
+  }, []);
+  useEffect(() => {
+    const announcerContent = announcer.current;
+    if (announcerContent && message) {
+      announcerContent.textContent = message;
+    }
+    return () => {
+      if (message) {
+        announcerContent.textContent = '';
+      }
+    };
+  }, [message]);
+};
+
+export const ActivateButton = ({
+  message: _message,
+  label,
+  isLink,
+  variant,
+  hideInfoIcon,
+  order,
+  icon,
+  position,
+  buttonIcon,
+}) => {
+  const [message, setMessage] = useState('');
+  usePoliteAnnouncer(message);
+  return (
+    <div>
+      <Button
+        size="medium"
+        variant={variant === 'error' ? 'danger' : 'outlined'}
+        onClick={() => setMessage(_message || 'メッセージが届きました')}
+      >
+        Activate
+      </Button>
+      <SnackBar.Frame
+        active={!!message}
+        variant={variant}
+        hideInfoIcon={hideInfoIcon}
+        order={order}
+        position={position}
+        onHide={() => setMessage('')}
+      >
+        {icon && <SnackBar.Icon>{icon}</SnackBar.Icon>}
+        <SnackBar.Text>{message}</SnackBar.Text>
+        {label &&
+          (!isLink ? (
+            <SnackBar.TextButton icon={buttonIcon} {...actions("onClick")}>{label}</SnackBar.TextButton>
+          ) : (
+            <SnackBar.TextLink icon={buttonIcon} href="https://example.com/" {...actions("onClick")}>{label}</SnackBar.TextLink>
+          ))}
+      </SnackBar.Frame>
+    </div>
+  );
+};
+
+export const MultiActivateButton = ({ offset, icon, position }) => {
+  const [message1, setMessage1] = useState('');
+  const [message2, setMessage2] = useState('');
+  usePoliteAnnouncer(message1);
+  return (
+    <div>
+      <Button
+        size="medium"
+        variant={'outlined'}
+        onClick={() => {
+          setMessage1('メッセージが届きました1');
+          setMessage2('メッセージが届きました2');
+        }}
+      >
+        Activate
+      </Button>
+      <SnackBar.Frame
+        active={!!message1}
+        offset={offset}
+        order={0}
+        position={position}
+        onHide={() => setMessage1('')}
+      >
+        {icon && <SnackBar.Icon>{icon}</SnackBar.Icon>}
+        <SnackBar.Text>{message1}</SnackBar.Text>
+      </SnackBar.Frame>
+      <SnackBar.Frame
+        active={!!message2}
+        offset={offset}
+        order={message1 ? 1 : 0}
+        position={position}
+        onHide={() => setMessage2('')}
+      >
+        {icon && <SnackBar.Icon>{icon}</SnackBar.Icon>}
+        <SnackBar.Text>{message2}</SnackBar.Text>
+      </SnackBar.Frame>
+    </div>
+  );
+};
+
+# SnackBar
+
+<Meta title="SnackBar" component={SnackBar} />
+
+![stability-experiment](https://img.shields.io/badge/stability-experiment-red.svg)
+
+SnackBarコンポーネントは、利用者に一時的なお知らせをする際に利用します。画面上に複数表示できます。SnackBarは自動で消えてしまうため、見落とされても影響のない「重要ではないお知らせ」に用います。利用する際には、その他により適切な手段がないか必ず確認してください。
+
+「重要なお知らせ」とは何か、他のnotification系のコンポーネントとの違いは別途まとめる予定です。
+
+<Source
+  language="javascript"
+  code={`import { SnackBar } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language="css"
+  code={`@import './node_modules/@openameba/spindle-ui/SnackBar/SnackBar.css'`}
+/>
+
+<Source
+  language="html"
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/SnackBar/SnackBar.css">`}
+/>
+
+## Information
+
+<Preview withSource="open">
+  <Story name="Information">
+    <ActivateButton variant="information" icon={<Information />} label="取り消し" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true}>
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+  <SnackBar.TextButton>取り消し</SnackBar.TextButton>
+</SnackBar.Frame>
+  `}
+/>
+
+## Information without info icon
+
+<Preview withSource="open">
+  <Story name="Information without info icon">
+    <ActivateButton variant="information" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true}>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+</SnackBar.Frame>
+  `}
+/>
+
+## Confirmation
+
+<Preview withSource="open">
+  <Story name="Confirmation">
+    <ActivateButton variant="confirmation" icon={<CheckCircleFill />} label="取り消し" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} variant="confirmation">
+  <SnackBar.Icon><CheckCircleFill /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+  <SnackBar.TextButton>取り消し</SnackBar.TextButton>
+</SnackBar.Frame>
+  `}
+/>
+
+## Error
+
+<Preview withSource="open">
+  <Story name="Error">
+    <ActivateButton variant="error" icon={<ExclamationmarkCircleFill />} label="取り消し" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} variant="error">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+  <SnackBar.TextButton>取り消し</SnackBar.TextButton>
+</SnackBar.Frame>
+  `}
+/>
+
+## Position Top Left
+
+<Preview withSource="open">
+  <Story name="Position Top Left">
+    <ActivateButton icon={<Information />} position="topLeft" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} position="topLeft">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+</SnackBar.Frame>
+  `}
+/>
+
+## Position Top Right
+
+<Preview withSource="open">
+  <Story name="Position Top Right">
+    <ActivateButton icon={<Information />} position="topRight" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} position="topRight">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+</SnackBar.Frame>
+  `}
+/>
+
+## Position Bottom Left
+
+<Preview withSource="open">
+  <Story name="Position Bottom Left">
+    <ActivateButton icon={<Information />} position="bottomLeft" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} position="bottomLeft">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+</SnackBar.Frame>
+  `}
+/>
+
+## Position Bottom Right
+
+<Preview withSource="open">
+  <Story name="Position Bottom Right">
+    <ActivateButton icon={<Information />} position="bottomRight" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} position="bottomRight">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+</SnackBar.Frame>
+  `}
+/>
+
+## Position Bottom Center
+
+<Preview withSource="open">
+  <Story name="Position Bottom Center">
+    <ActivateButton icon={<Information />} position="bottomCenter" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} position="bottomCenter">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+</SnackBar.Frame>
+  `}
+/>
+
+## Long Content
+
+<Preview withSource="open">
+  <Story name="Long Content">
+    <ActivateButton
+      message="長いメッセージが入る長いメッセージが入る長いメッセージが入る長いメッセージが入る長いメッセージが入る長いメッセージが入る長いメッセージ"
+      icon={<Information />}
+      label="取り消し"
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true}>
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>長いメッセージが入る長いメッセージが入る長いメッセージが入る長いメッセージが入る長いメッセージが入る長いメッセージが入る長いメッセージ</SnackBar.Text>
+  <SnackBar.TextButton>取り消し</SnackBar.TextButton>
+</SnackBar.Frame>
+  `}
+/>
+
+## Multiple
+
+<Preview withSource="open">
+  <Story name="Multiple">
+    <MultiActivateButton offset={{ top: 30 }} icon={<Information />} />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} order={0} offset={{ top: 30 }} position="bottomCenter">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました1</SnackBar.Text>
+</SnackBar.Frame>
+<SnackBar.Frame active={true} order={1} offset={{ top: 30 }} position="bottomCenter">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました2</SnackBar.Text>
+</SnackBar.Frame>
+  `}
+/>
+
+## Multiple bottom
+
+<Preview withSource="open">
+  <Story name="Multiple bottom">
+    <MultiActivateButton
+      offset={{ bottom: 30 }}
+      position="bottomCenter"
+      icon={<Information />}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} order={0} offset={{ bottom: 30 }} position="bottomCenter">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました1</SnackBar.Text>
+</SnackBar.Frame>
+<SnackBar.Frame active={true} order={1} offset={{ bottom: 30 }} position="bottomCenter">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました2</SnackBar.Text>
+</SnackBar.Frame>
+  `}
+/>
+
+## Custom button with icon
+
+<Preview withSource="open">
+  <Story name="Custom button with icon">
+    <ActivateButton
+      icon={<Information />}
+      buttonIcon={<Openblank />}
+      message="メッセージが届きました"
+      label="取り消し"
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true}>
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+  <SnackBar.TextLink icon={<Openblank />}>詳細</SnackBar.TextLink>
+</SnackBar.Frame>
+  `}
+/>
+
+## Custom link with information
+
+<Preview withSource="open">
+  <Story name="Custom link with information">
+    <ActivateButton
+      icon={<Information />}
+      message="メッセージが届きました"
+      label="取り消し"
+      isLink
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true}>
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+  <SnackBar.TextLink>取り消し</SnackBar.TextLink>
+</SnackBar.Frame>
+  `}
+/>
+
+## Custom link with confirmation
+
+<Preview withSource="open">
+  <Story name="Custom link with confirmation">
+    <ActivateButton
+      icon={<CheckCircleFill />}
+      message="メッセージが届きました"
+      label="取り消し"
+      variant="confirmation"
+      isLink
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} variant="confirmation">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+  <SnackBar.TextLink>取り消し</SnackBar.TextLink>
+</SnackBar.Frame>
+  `}
+/>
+
+## Custom link with error
+
+<Preview withSource="open">
+  <Story name="Custom link with error">
+    <ActivateButton
+      icon={<ExclamationmarkCircleFill />}
+      message="メッセージが届きました"
+      label="取り消し"
+      variant="error"
+      isLink
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<SnackBar.Frame active={true} variant="error">
+  <SnackBar.Icon><Information /></SnackBar.Icon>
+  <SnackBar.Text>メッセージが届きました</SnackBar.Text>
+  <SnackBar.TextLink>取り消し</SnackBar.TextLink>
+</SnackBar.Frame>
+  `}
+/>
+
+## このコンポーネントでやっていること
+
+- reduced motionが指定された時に、トランジッションを短くします
+- hover、focusされている時には、時間制限を停止します。フォーカスが離れたのち、再度0秒から計測します
+- モードを奪うことになるため、自動的にfocusはしません
+- デバイスのorientationに追従して表示位置・サイズを変更します
+
+## Toastとの違い
+
+- Toastは1行しかメッセージをいれられないのに対して、Snack Barは複数行入れることができます。
+- Toastは4秒で消えるのに対して、Snack Barは10秒で消えます。
+- Toastは画面上下の中央にしか配置できなかったのに対し、Snack Barは画面上下の左・右・中央に配置できます。
+  - NOTE: SPはcenter-bottom固定
+- Snack Barには1つだけ任意のボタンを置くことができます
+  - NOTE: 5文字以上のボタンは設置できません
+- Toastよりは消えるタイミングが遅いため、Toastと比べるとやや優先度が高いです。またボタンやテキスト量など表示できる情報も多いです。
+
+## 利用時に注意してほしいこと
+
+- SnackBarは自動で消えてしまうため、見落とされても影響のない、「重要ではないお知らせ」に用います
+- アイコンの設定は利用者に委ねられていますが、基本的には設定します。**`information`のみアイコンを外すことができます。**
+- 任意のボタンを設定できます。システム上では制御しませんが、5文字以上設定してはいけません。またボタンは1つ以上追加しないでください。
+- SnackBarでは最大3行まで表示されます。320px以下の画面では4行まで表示されます。超える部分は切られます。
+- モバイル表示ではbottom-center固定になるので注意してください。
+- このコンポーネントでは関与しませんが、ライブリージョンをアプリケーションで実装してください（参考：[実装方法 - 4.1.3 コンテンツの変更をユーザーに知らせる - Ameba Accessibility Guidelines](https://a11y-guidelines.ameba.design/4/1/3/#%E5%AE%9F%E8%A3%85%E6%96%B9%E6%B3%95)）
+- ライブリージョンは次のように実装します。 `html` 側に `aria-live="polite"` 及び `role="status"` を持つ要素を予め埋め込んでおき、この要素にコンテンツを動的に挿入することで、スクリーンリーダーが自動でコンテンツを読み上げてくれます。
+
+<Source
+  code={`
+<html>
+  <body>
+    ...
+    <div
+      aria-live="polite"
+      id="polite-announcer"
+      role="status"
+      class="visually-hidden"
+    ></div>
+    ...
+  </body>
+</html>
+  `}
+/>
+
+<Source
+  code={`
+const usePoliteAnnouncer = (message) => {
+  const announcer = useRef(null);
+  useEffect(() => {
+    announcer.current = document.getElementById('polite-announcer');
+    return () => {
+      announcer.current = null;
+    };
+  }, []);
+  useEffect(() => {
+    const announcerContent = announcer.current;
+    if (announcerContent && message) {
+      announcerContent.textContent = message;
+    }
+    return () => {
+      if(message) {
+        announcerContent.textContent = '';
+      }
+    };
+  }, [message]);
+};
+  `}
+/>
+
+<Source
+  code={`
+  .visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  clip: rect(1px, 1px, 1px, 1px);
+}
+  `}
+/>

--- a/packages/spindle-ui/src/SnackBar/SnackBar.test.tsx
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+import {
+  SnackBar,
+  BLOCK_NAME,
+  ANIMATION_DURATION,
+  MAX_DURATION,
+} from './SnackBar';
+
+describe('<SnackBar />', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('Inner isShow state should be changed by timer', () => {
+    const testAnimation = () => {
+      onHide.mockReset();
+
+      expect(
+        screen.getByText(/content/).parentElement?.parentElement,
+      ).toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+      act(() => {
+        jest.advanceTimersByTime(MAX_DURATION - ANIMATION_DURATION);
+      });
+
+      expect(
+        screen.getByText(/content/).parentElement?.parentElement,
+      ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+      act(() => {
+        const parentElement =
+          screen.getByText(/content/).parentElement?.parentElement;
+        expect(parentElement).not.toBeNull();
+        if (parentElement) {
+          fireEvent.transitionEnd(parentElement);
+        }
+      });
+
+      expect(onHide).toBeCalledTimes(1);
+    };
+
+    const onHide = jest.fn();
+    const { rerender } = render(
+      <SnackBar.Frame active onHide={onHide}>
+        <SnackBar.Text>content</SnackBar.Text>
+      </SnackBar.Frame>,
+    );
+
+    testAnimation();
+
+    /* === The following code check if timeoutID is null === */
+
+    rerender(
+      <SnackBar.Frame active={false} onHide={onHide}>
+        <SnackBar.Text>content</SnackBar.Text>
+      </SnackBar.Frame>,
+    );
+
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+    // If timeoutID is not null, SnackBar animation is not invoked again.
+    rerender(
+      <SnackBar.Frame active onHide={onHide}>
+        <SnackBar.Text>content</SnackBar.Text>
+      </SnackBar.Frame>,
+    );
+
+    testAnimation();
+  });
+
+  test('When it is hovered, duration should be reset', () => {
+    const onHide = jest.fn();
+    render(
+      <SnackBar.Frame active onHide={onHide}>
+        <SnackBar.Text>content</SnackBar.Text>
+      </SnackBar.Frame>,
+    );
+
+    fireEvent.mouseOver(screen.getByText(/content/));
+
+    act(() => {
+      jest.advanceTimersByTime(MAX_DURATION - ANIMATION_DURATION);
+    });
+
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+    fireEvent.mouseOut(screen.getByText(/content/));
+
+    act(() => {
+      jest.advanceTimersByTime(MAX_DURATION - ANIMATION_DURATION);
+    });
+
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+    act(() => {
+      const parentElement =
+        screen.getByText(/content/).parentElement?.parentElement;
+      expect(parentElement).not.toBeNull();
+      if (parentElement) {
+        fireEvent.transitionEnd(parentElement);
+      }
+    });
+
+    expect(onHide).toBeCalledTimes(1);
+  });
+
+  test('When it is focused, duration should be reset', () => {
+    const handleCloseButtonEvent = (evtName: 'focus' | 'blur') => {
+      const parentElement = screen.getByLabelText(/閉じる/).parentElement;
+      if (parentElement) {
+        fireEvent[evtName](parentElement);
+      }
+    };
+    const onHide = jest.fn();
+    render(
+      <SnackBar.Frame active onHide={onHide}>
+        <SnackBar.Text>content</SnackBar.Text>
+      </SnackBar.Frame>,
+    );
+
+    handleCloseButtonEvent('focus');
+
+    act(() => {
+      jest.advanceTimersByTime(MAX_DURATION - ANIMATION_DURATION);
+    });
+
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+    handleCloseButtonEvent('blur');
+
+    act(() => {
+      jest.advanceTimersByTime(MAX_DURATION - ANIMATION_DURATION);
+    });
+
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+    act(() => {
+      const parentElement =
+        screen.getByText(/content/).parentElement?.parentElement;
+      expect(parentElement).not.toBeNull();
+      if (parentElement) {
+        fireEvent.transitionEnd(parentElement);
+      }
+    });
+
+    expect(onHide).toBeCalledTimes(1);
+  });
+
+  test('it should close when close button is clicked', () => {
+    const onHide = jest.fn();
+    render(
+      <SnackBar.Frame active onHide={onHide}>
+        <SnackBar.Text>content</SnackBar.Text>
+      </SnackBar.Frame>,
+    );
+
+    act(() => {
+      // Get button element outer of 閉じる icon.
+      const parentElement = screen.getByLabelText(/閉じる/).parentElement;
+      expect(parentElement).not.toBeNull();
+      if (parentElement) {
+        fireEvent.click(parentElement);
+      }
+    });
+
+    expect(
+      screen.getByText(/content/).parentElement?.parentElement,
+    ).not.toHaveClass(`${BLOCK_NAME}-slide--in`);
+
+    act(() => {
+      const parentElement =
+        screen.getByText(/content/).parentElement?.parentElement;
+      expect(parentElement).not.toBeNull();
+      if (parentElement) {
+        fireEvent.transitionEnd(parentElement);
+      }
+    });
+
+    expect(onHide).toBeCalledTimes(1);
+  });
+});

--- a/packages/spindle-ui/src/SnackBar/SnackBar.tsx
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.tsx
@@ -1,0 +1,252 @@
+import React, {
+  Children,
+  cloneElement,
+  Dispatch,
+  FC,
+  HTMLAttributes,
+  MouseEventHandler,
+  ReactNode,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { CrossBold } from '../Icon';
+import { IconButton } from '../IconButton';
+import { TextLink as SpindleTextLink } from '../TextLink/TextLink';
+import { TextButton as SpindleTextButton } from '../TextButton/TextButton';
+
+type Position = `${'top' | 'bottom'}${'Left' | 'Center' | 'Right'}`;
+
+type PositionOffset = {
+  top: number;
+  right: number;
+  left: number;
+  bottom: number;
+};
+
+type Variant = 'information' | 'confirmation' | 'error';
+
+type Props = {
+  children?: React.ReactElement;
+  active?: boolean;
+  order?: number;
+  offset?: { [K in keyof PositionOffset]?: PositionOffset[K] };
+  // milliseconds to hide
+  duration?: number;
+  onHide?: () => void;
+  position?: Position;
+  variant?: Variant;
+};
+
+export const BLOCK_NAME = 'spui-SnackBar';
+
+// Duration for css animation.
+export const ANIMATION_DURATION = 300;
+
+export const MAX_DURATION = 10000;
+const VERTICAL_GAP = 20;
+const DEFAULT_VARIANT = 'information';
+
+type InternalChildProps = {
+  setIsShow?: Dispatch<SetStateAction<boolean>>;
+  variant?: Variant;
+};
+
+const Frame = ({
+  children,
+  active = false,
+  position = 'topCenter',
+  order = 0,
+  offset: _offset = {},
+  onHide,
+  variant = DEFAULT_VARIANT,
+}: Props): React.ReactElement => {
+  const [isShow, setIsShow] = useState(false);
+  const offset: PositionOffset = {
+    top: _offset.top || 24,
+    // If position is top or bottom, then horizontal offset is not needed.
+    left: position.endsWith('Left') ? _offset.left || 32 : 0,
+    right: position.endsWith('Right') ? _offset.right || 32 : 0,
+    bottom: _offset.bottom || 24,
+  };
+  const formattedDuration = MAX_DURATION - ANIMATION_DURATION;
+  const timeoutID = useRef<number | null>(null);
+  const [clientHeight, setClientHeight] = useState(0);
+
+  const setIsShowWithTimeout = useCallback(() => {
+    // Out animation is executed after `formattedDuration` seconds.
+    if (timeoutID.current === null && isShow) {
+      timeoutID.current = window.setTimeout(() => {
+        setIsShow(false);
+      }, formattedDuration);
+    }
+  }, [isShow, timeoutID, setIsShow, formattedDuration]);
+
+  const resetTimeout = useCallback(() => {
+    if (timeoutID.current) {
+      window.clearTimeout(timeoutID.current);
+      timeoutID.current = null;
+    }
+  }, [timeoutID]);
+
+  const handleTransitionEnd = useCallback(() => {
+    if (onHide && !isShow) {
+      onHide();
+      timeoutID.current = null;
+    }
+  }, [isShow, setIsShow, onHide]);
+
+  const handleOnClickCloseButton = useCallback(() => {
+    setIsShow(false);
+  }, []);
+
+  useEffect(() => {
+    // Animation is not stopped even if `active` props is changed while running animation.
+    if (active && timeoutID.current === null) {
+      setIsShow(true);
+    }
+  }, [active]);
+
+  useEffect(() => {
+    setIsShowWithTimeout();
+    return resetTimeout;
+  }, [setIsShowWithTimeout, resetTimeout]);
+
+  const contentHeight = clientHeight;
+  const positionPrefix = position.startsWith('top') ? 'top' : 'bottom';
+  const positionSuffix = position.slice(positionPrefix.length).toLowerCase() as
+    | 'left'
+    | 'center'
+    | 'right';
+  const orderOffsetTop = order * (contentHeight + VERTICAL_GAP) + offset.top;
+  const orderOffsetBottom =
+    order * (contentHeight + VERTICAL_GAP) + offset.bottom;
+
+  return (
+    <div
+      style={{
+        ['--SnackBar--initial-height-top' as string]: `${
+          orderOffsetTop - contentHeight + offset.top
+        }px`,
+        ['--SnackBar--initial-height-bottom' as string]: `${
+          orderOffsetBottom - contentHeight + offset.bottom
+        }px`,
+        ['--SnackBar--order-offset-top' as string]: `${orderOffsetTop}px`,
+        ['--SnackBar--order-offset-bottom' as string]: `${-orderOffsetBottom}px`,
+        ['--SnackBar--offset-top' as string]: `${offset.top}px`,
+        ['--SnackBar--offset-bottom' as string]: `${offset.bottom}px`,
+        ['--SnackBar--offset-left' as string]: `${offset.left}px`,
+        ['--SnackBar--offset-right' as string]: `${offset.right}px`,
+        ['--SnackBar--text-align' as string]: positionSuffix,
+      }}
+      className={[
+        BLOCK_NAME,
+        `${BLOCK_NAME}--${positionPrefix}`,
+        `${BLOCK_NAME}--slide`,
+        isShow && `${BLOCK_NAME}-slide--in`,
+        !active && `${BLOCK_NAME}--hidden`,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-hidden={!active}
+      onTransitionEnd={handleTransitionEnd}
+      ref={(ref) => setClientHeight(ref?.clientHeight || 0)}
+    >
+      <div
+        className={`${BLOCK_NAME}-content ${BLOCK_NAME}-content--${variant}`}
+        onMouseOver={resetTimeout}
+        onMouseOut={setIsShowWithTimeout}
+        onFocus={resetTimeout}
+        onBlur={setIsShowWithTimeout}
+      >
+        {Children.map(children, (child) =>
+          child ? cloneElement(child, { variant, setIsShow }) : child,
+        )}
+        <div
+          className={`${BLOCK_NAME}-iconButton ${BLOCK_NAME}-iconButton--${variant}`}
+          onTransitionEnd={(e) => e.stopPropagation()}
+        >
+          <IconButton
+            size="exSmall"
+            variant="neutral"
+            onClick={handleOnClickCloseButton}
+          >
+            <CrossBold aria-label="閉じる" />
+          </IconButton>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const getInternalChildProps = (
+  props: Record<string, any>,
+): InternalChildProps => {
+  const hasInternalChildProps = (
+    props: Record<string, any>,
+  ): props is InternalChildProps =>
+    ({}.hasOwnProperty.call(props, 'setIsShow') ||
+    {}.hasOwnProperty.call(props, 'variant'));
+
+  if (hasInternalChildProps(props)) {
+    return {
+      setIsShow: props.setIsShow,
+      variant: props.variant,
+    };
+  }
+  return {};
+};
+
+const Icon: FC<{ children: ReactNode }> = ({ children }) => (
+  <div className={`${BLOCK_NAME}-icon`}>{children}</div>
+);
+const Text: FC<{ children: ReactNode }> = ({ children }) => (
+  <span className={`${BLOCK_NAME}-text`}>{children}</span>
+);
+const TextButton: FC<
+  { icon?: ReactNode; children: ReactNode } & HTMLAttributes<HTMLButtonElement>
+> = ({ icon, children, onClick, ...rest }) => {
+  const internalProps = useMemo(() => getInternalChildProps(rest), []);
+  const variant = internalProps.variant || DEFAULT_VARIANT;
+  const setIsShow = internalProps.setIsShow;
+  const handleOnClick: MouseEventHandler<HTMLButtonElement> = (e) => {
+    onClick?.(e);
+    setIsShow?.(false);
+  };
+  return (
+    <div className={`${BLOCK_NAME}-button ${BLOCK_NAME}-button--${variant}`}>
+      <SpindleTextButton icon={icon} onClick={handleOnClick} {...rest}>
+        {children}
+      </SpindleTextButton>
+    </div>
+  );
+};
+const TextLink: FC<
+  { icon?: ReactNode; children: ReactNode } & HTMLAttributes<HTMLAnchorElement>
+> = ({ icon, children, onClick, ...rest }) => {
+  const internalProps = useMemo(() => getInternalChildProps(rest), []);
+  const variant = internalProps.variant || DEFAULT_VARIANT;
+  const setIsShow = internalProps.setIsShow;
+  const handleOnClick: MouseEventHandler<HTMLAnchorElement> = (e) => {
+    onClick?.(e);
+    setIsShow?.(false);
+  };
+  return (
+    <div className={`${BLOCK_NAME}-button ${BLOCK_NAME}-button--${variant}`}>
+      <SpindleTextLink icon={icon} onClick={handleOnClick} {...rest}>
+        {children}
+      </SpindleTextLink>
+    </div>
+  );
+};
+
+export const SnackBar = {
+  Frame,
+  Icon,
+  Text,
+  TextButton,
+  TextLink,
+};

--- a/packages/spindle-ui/src/SnackBar/index.ts
+++ b/packages/spindle-ui/src/SnackBar/index.ts
@@ -1,0 +1,1 @@
+export { SnackBar } from './SnackBar';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -13,4 +13,5 @@
 @import './TextButton/TextButton.css';
 @import './TextLink/TextLink.css';
 @import './Toast/Toast.css';
+@import './SnackBar/SnackBar.css';
 @import './List/index.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -9,6 +9,7 @@ import { IconButton } from './IconButton';
 import { LinkButton } from './LinkButton';
 import { TextButton } from './TextButton';
 import { Toast } from './Toast';
+import { SnackBar } from './SnackBar';
 
 // Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
 export {
@@ -24,4 +25,5 @@ export {
   LinkButton,
   TextButton,
   Toast,
+  SnackBar,
 };


### PR DESCRIPTION
SnackBarを追加しました。

SnackBarはToastとは以下の点が異なります。

- 10秒後に自動で消えます
- 任意のボタンを一つ追加できます
- 複数行表示できますが、最大3行で、320px以下では4行になります

|information|confirmation|error|
|-|-|-|
|<img width="638" alt="Screen Shot 2022-07-26 at 14 06 13" src="https://user-images.githubusercontent.com/34934510/180930453-c28b1350-da92-43a0-9037-7e6f08b5be53.png">|<img width="638" alt="Screen Shot 2022-07-26 at 14 06 30" src="https://user-images.githubusercontent.com/34934510/180930464-0d4ecea6-3cfc-43df-87ef-aff3a5d881e6.png">|<img width="638" alt="Screen Shot 2022-07-26 at 14 06 46" src="https://user-images.githubusercontent.com/34934510/180930477-3b0c0b26-3678-4dd5-be78-ae8098574866.png">|

## Context

- Toastとほとんど同じコードなので共通化できそうではありますが、微妙なスタイリングの違いがあり、共通化するのも難しそうなので一旦別定義にしています。
- ロジック部分はほとんどToastと同じであるため、別PRでCustom Hooksとして切り出します

## TODO

- [ ] approve後にcommitをまとめます
- [ ] 最後にbundlesize調整します
- [ ] Contextでの管理は別で実装します
