### PR TITLE
Feat/add stack

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -9,7 +9,7 @@
       "maxSize": "1.1 kB"
     },
     {
-      "path": "./dist/!(Icon|Toast|Modal|SnackBar)/*.mjs",
+      "path": "./dist/!(Icon|Toast|Modal|SnackBar|StackNotificationManager)/*.mjs",
       "maxSize": "1.1 kB"
     },
     {
@@ -18,11 +18,15 @@
     },
     {
       "path": "./dist/SnackBar/*.mjs",
-      "maxSize": "1.74 kB"
+      "maxSize": "2 kB"
     },
     {
       "path": "./dist/Toast/*.mjs",
       "maxSize": "1.5 kB"
+    },
+    {
+      "path": "./dist/StackNotificationManager/*.mjs",
+      "maxSize": "1.8 kB"
     },
     {
       "path": "./dist/!(Modal|SnackBar)/!(index).css",
@@ -34,7 +38,7 @@
     },
     {
       "path": "./dist/SnackBar/!(index).css",
-      "maxSize": "2.0 kB"
+      "maxSize": "2.1 kB"
     },
     {
       "path": "./dist/index.css",

--- a/packages/spindle-ui/src/SnackBar/SnackBar.css
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.css
@@ -10,7 +10,9 @@
 .spui-SnackBar {
   box-sizing: border-box;
   left: 0;
+  opacity: 0;
   padding: 0 var(--SnackBar--offset-right) 0 var(--SnackBar--offset-left);
+  pointer-events: none;
   position: fixed;
   right: 0;
   text-align: var(--SnackBar--text-align);
@@ -28,6 +30,7 @@
   min-height: 52px;
   min-width: 360px;
   padding: 14px 16px 14px 20px;
+  pointer-events: auto;
 }
 
 .spui-SnackBar-icon {
@@ -87,7 +90,6 @@
 }
 
 .spui-SnackBar--slide {
-  opacity: 0;
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
 

--- a/packages/spindle-ui/src/SnackBar/SnackBar.stories.mdx
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.stories.mdx
@@ -32,7 +32,6 @@ export const ActivateButton = ({
   isLink,
   variant,
   hideInfoIcon,
-  order,
   icon,
   position,
   buttonIcon,
@@ -52,7 +51,6 @@ export const ActivateButton = ({
         active={!!message}
         variant={variant}
         hideInfoIcon={hideInfoIcon}
-        order={order}
         position={position}
         onHide={() => setMessage('')}
       >
@@ -72,6 +70,7 @@ export const ActivateButton = ({
 export const MultiActivateButton = ({ offset, icon, position }) => {
   const [message1, setMessage1] = useState('');
   const [message2, setMessage2] = useState('');
+  const [stackPosition, setStackPosition] = useState(0);
   usePoliteAnnouncer(message1);
   return (
     <div>
@@ -79,8 +78,8 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
         size="medium"
         variant={'outlined'}
         onClick={() => {
-          setMessage1('メッセージが届きました1');
-          setMessage2('メッセージが届きました2');
+          setMessage1('メッセージが届きましたメッセージが届きましたメッセージが届きましたメッセージが届きましたメッセージが届きましたメッセージが届きました');
+          setMessage2('メッセージが届きました');
         }}
       >
         Activate
@@ -88,7 +87,7 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
       <SnackBar.Frame
         active={!!message1}
         offset={offset}
-        order={0}
+        setContentHeight={setStackPosition}
         position={position}
         onHide={() => setMessage1('')}
       >
@@ -98,7 +97,7 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
       <SnackBar.Frame
         active={!!message2}
         offset={offset}
-        order={message1 ? 1 : 0}
+        stackPosition={message1 ? stackPosition : 0}
         position={position}
         onHide={() => setMessage2('')}
       >
@@ -321,11 +320,11 @@ SnackBarコンポーネントは、利用者に一時的なお知らせをする
 
 <Source
   code={`
-<SnackBar.Frame active={true} order={0} offset={{ top: 30 }} position="bottomCenter">
+<SnackBar.Frame active={true} offset={{ top: 30 }} position="bottomCenter">
   <SnackBar.Icon><Information /></SnackBar.Icon>
   <SnackBar.Text>メッセージが届きました1</SnackBar.Text>
 </SnackBar.Frame>
-<SnackBar.Frame active={true} order={1} offset={{ top: 30 }} position="bottomCenter">
+<SnackBar.Frame active={true} offset={{ top: 30 }} position="bottomCenter">
   <SnackBar.Icon><Information /></SnackBar.Icon>
   <SnackBar.Text>メッセージが届きました2</SnackBar.Text>
 </SnackBar.Frame>
@@ -346,11 +345,11 @@ SnackBarコンポーネントは、利用者に一時的なお知らせをする
 
 <Source
   code={`
-<SnackBar.Frame active={true} order={0} offset={{ bottom: 30 }} position="bottomCenter">
+<SnackBar.Frame active={true} offset={{ bottom: 30 }} position="bottomCenter">
   <SnackBar.Icon><Information /></SnackBar.Icon>
   <SnackBar.Text>メッセージが届きました1</SnackBar.Text>
 </SnackBar.Frame>
-<SnackBar.Frame active={true} order={1} offset={{ bottom: 30 }} position="bottomCenter">
+<SnackBar.Frame active={true} offset={{ bottom: 30 }} position="bottomCenter">
   <SnackBar.Icon><Information /></SnackBar.Icon>
   <SnackBar.Text>メッセージが届きました2</SnackBar.Text>
 </SnackBar.Frame>
@@ -532,3 +531,8 @@ const usePoliteAnnouncer = (message) => {
 }
   `}
 />
+
+## スタック機能
+
+StackNotificationManager を使用することで Toast や SnackBar をスタックして複数表示することができます。
+詳しくは[StackNotificationManager のドキュメント](/docs/stacknotificationmanager--normal)を参照してください。

--- a/packages/spindle-ui/src/StackNotificationManager/StackNotificationManager.stories.example.tsx
+++ b/packages/spindle-ui/src/StackNotificationManager/StackNotificationManager.stories.example.tsx
@@ -1,0 +1,115 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { SnackBar } from '../SnackBar';
+import { useStackNotificationManager } from '.';
+import {
+  StackNotificationManagerProvider,
+  StackPosition,
+} from './StackNotificationManager';
+import { Button } from '../Button';
+import { Information } from '../Icon';
+import { useRepeatedStackItem } from './hooks';
+
+const usePoliteAnnouncer = (active: boolean, message: string) => {
+  const announcer = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    announcer.current = document.getElementById('polite-announcer');
+    return () => {
+      announcer.current = null;
+    };
+  }, []);
+  useEffect(() => {
+    const announcerContent = announcer.current;
+    if (message && announcerContent && active) {
+      announcerContent.textContent = message;
+    }
+    return () => {
+      if (announcerContent && active) {
+        announcerContent.textContent = '';
+      }
+    };
+  }, [message, active]);
+};
+
+const SnackBarExample: React.FC<
+  Omit<React.ComponentProps<typeof SnackBar.Frame>, 'onHide'> & {
+    id: string;
+    position: StackPosition;
+    text: string;
+    icon?: React.ReactElement;
+    onHide: (id: string) => void;
+  }
+> = ({ id, position, icon, text, variant, onHide, ...rest }) => {
+  const { stackProps } = useStackNotificationManager({
+    id,
+    position,
+  });
+
+  const handleOnHide = useCallback(() => {
+    onHide(id);
+  }, [onHide]);
+
+  usePoliteAnnouncer(!!stackProps.active, text);
+
+  return (
+    <>
+      <SnackBar.Frame
+        variant={variant}
+        onHide={handleOnHide}
+        {...rest}
+        {...stackProps}
+      >
+        {icon && <SnackBar.Icon>{icon}</SnackBar.Icon>}
+        <SnackBar.Text>{text}</SnackBar.Text>
+        <SnackBar.TextButton>取り消し</SnackBar.TextButton>
+      </SnackBar.Frame>
+    </>
+  );
+};
+
+const SnackBarWithButtonExample: React.FC<
+  React.ComponentProps<typeof SnackBar.Frame> & {
+    id: string;
+    position: StackPosition;
+    text: string;
+    icon?: React.ReactElement;
+  }
+> = ({ id, position, text, variant, ...rest }) => {
+  const { idList, append, onHide } = useRepeatedStackItem({ id, position });
+
+  return (
+    <>
+      <Button size="medium" variant="outlined" onClick={append}>
+        メッセージを送信する
+      </Button>
+      {idList.map((id) => (
+        <SnackBarExample
+          key={id}
+          id={id}
+          variant={variant}
+          position={position}
+          text={text}
+          onHide={onHide}
+          {...rest}
+        />
+      ))}
+    </>
+  );
+};
+
+const StackNotificationManagerExamplePresenter = () => (
+  <div>
+    <SnackBarWithButtonExample
+      id="toast-topCenter"
+      position="topCenter"
+      text="メッセージを送信しました"
+      variant="information"
+      icon={<Information />}
+    />
+  </div>
+);
+
+export const StackNotificationManagerExample = () => (
+  <StackNotificationManagerProvider>
+    <StackNotificationManagerExamplePresenter />
+  </StackNotificationManagerProvider>
+);

--- a/packages/spindle-ui/src/StackNotificationManager/StackNotificationManager.stories.mdx
+++ b/packages/spindle-ui/src/StackNotificationManager/StackNotificationManager.stories.mdx
@@ -1,0 +1,219 @@
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { StackNotificationManagerExample } from './StackNotificationManager.stories.example';
+import { StackNotificationManager } from '.';
+
+# StackNotificationManager
+
+<Meta title="StackNotificationManager" component={StackNotificationManager} />
+
+![stability-experiment](https://img.shields.io/badge/stability-experiment-red.svg)
+
+StackNotificationManager コンポーネントは、利用者に一時的なお知らせをする際に利用します。画面上に複数表示できます。StackNotificationManager は自動で消えてしまうため、見落とされても影響のない「重要ではないお知らせ」に用います。利用する際には、その他により適切な手段がないか必ず確認してください。
+
+「重要なお知らせ」とは何か、他の notification 系のコンポーネントとの違いは別途まとめる予定です。
+
+基本的にNotification系のコンポーネントを使用する際にはStackNotificationManagerを一緒に使用する必要があります。
+Notificationは処理が終了したことに対する通知なので該当の処理が複数回実行される可能性があれば、StackNotificationManagerを使用して複数表示をサポートする必要があります。
+
+<Source
+  language="javascript"
+  code={`import { StackNotificationManager } from '@openameba/spindle-ui'`}
+/>
+
+## Normal
+
+<Preview withSource="open">
+  <Story name="Normal">
+    <StackNotificationManagerExample />
+  </Story>
+</Preview>
+
+<Source
+  language="javascript"
+  code={`
+const SnackBarExample = ({ id, position, icon, text, variant, onHide, ...rest }) => {
+  const { stackProps } = useStackNotificationManager({
+    id,
+    position,
+  });
+  const handleOnHide = useCallback(() => {
+    onHide(id);
+  }, [onHide]);
+  usePoliteAnnouncer(!!stackProps.active, text);
+  return (
+    <>
+      {stackProps.active && (
+        <SnackBar.Frame
+          variant={variant}
+          onHide={handleOnHide}
+          {...rest}
+          {...stackProps}
+        >
+          {icon && <SnackBar.Icon>{icon}</SnackBar.Icon>}
+          <SnackBar.Text>{text}</SnackBar.Text>
+          <SnackBar.TextButton>取り消し</SnackBar.TextButton>
+        </SnackBar.Frame>
+      )}
+    </>
+  );
+};
+const SnackBarWithButtonExample = ({ id, position, text, variant, ...rest }) => {
+  const { idList, append, onHide } = useRepeatedStackItem({ id, position });
+  return (
+    <>
+      <Button size="medium" variant="outlined" onClick={handleOnClick}>
+        {text}を開く(連続で開きます)
+      </Button>
+      {idList.map((id) => (
+        <SnackBarExample
+          key={id}
+          id={id}
+          variant={variant}
+          position={position}
+          text={text}
+          onHide={handleOnHide}
+          {...rest}
+        />
+      ))}
+    </>
+  );
+};
+render(<StackNotificationManagerProvider>
+  <SnackBarContainer
+    id="snackbar-id"
+    position="topCenter"
+    text="メッセージが届きました"
+  />
+</StackNotificationManagerProvider>);
+`}
+/>
+
+## このコンポーネントでやっていること
+
+- Toast または Snack Bar どちらにも使用できます
+- 複数の Toast や Snack Bar を表示したいときに、表示数や表示順序などを管理するためのコンポーネントです
+
+## 利用時に注意してほしいこと
+
+- スタック機能はあくまで補足的な用途で使い、stack 自体がメインになるような使い方はしません。
+- 最大スタック数は PC では 4 つまでで、SP では 3 つまでです。これをこえる場合は古い要素が自動で消えます。
+- このコンポーネントでは関与しませんが、ライブリージョンをアプリケーションで実装してください（参考：[実装方法 - 4.1.3 コンテンツの変更をユーザーに知らせる - Ameba Accessibility Guidelines](https://a11y-guidelines.ameba.design/4/1/3/#%E5%AE%9F%E8%A3%85%E6%96%B9%E6%B3%95)）
+- ライブリージョンは次のように実装します。 `html` 側に `aria-live="polite"` 及び `role="status"` を持つ要素を予め埋め込んでおき、この要素にコンテンツを動的に挿入することで、スクリーンリーダーが自動でコンテンツを読み上げてくれます。
+  - `aria-live`を指定した要素に複数の要素を追加すると重複して読み上げられてしまうので、最新の通知で上書きします。
+
+<Source
+  language="html"
+  code={`
+<html>
+  <body>
+    ...
+    <div
+      aria-live="polite"
+      id="polite-announcer"
+      role="status"
+      class="visually-hidden"
+    ></div>
+    ...
+  </body>
+</html>
+  `}
+/>
+
+<Source
+  language="javascript"
+  code={`
+const usePoliteAnnouncer = (message) => {
+  const announcer = useRef(null);
+  useEffect(() => {
+    announcer.current = document.getElementById('polite-announcer');
+    return () => {
+      announcer.current = null;
+    };
+  }, []);
+  useEffect(() => {
+    const announcerContent = announcer.current;
+    if (announcerContent && message) {
+      announcerContent.textContent = message;
+    }
+    return () => {
+      if(message) {
+        announcerContent.textContent = '';
+      }
+    };
+  }, [message]);
+};
+  `}
+/>
+
+<Source
+  language="css"
+  code={`
+  .visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  clip: rect(1px, 1px, 1px, 1px);
+}
+  `}
+/>
+
+## Hooks
+
+以下の Hooks をあわせて使用します。
+
+- useStackNotificationManager ... 一意の ID と position を指定することで、スタックを管理するための Hook です。
+- useRepeatedStackItem ... 同じ要素が何度もスタックする場合に必要な処理をまとめた Hook です。
+- useStackInteraction ... 直接 ID と position を指定して active や offset を操作したい時に使用します。
+
+### useStackNotificationManager
+
+引数には以下を指定します。
+
+- `id`: `string` ... スタックに追加する要素の ID です。
+- `position`: `${'top' | 'bottom'}${'Left' | 'Center' | 'Right'}` ... 要素を表示する位置を指定します。
+
+返り値は以下の通りです。
+
+- `stackProps`: `object` ... 基本的には`<Toast {...stackProps}/>`のようにして`Toast`や`SnackBar`に渡します。
+- `setActive`: `(active: boolean) => void` ... スタックに追加している要素をアクティブにするための関数です。
+- `setOffset`: `(offset: { top: number, bottom: number, right: number, left: number ] }) => void` ... スタックに追加している要素の offset を変更するための関数です。
+
+```ts
+const { stackProps } = useStackNotificationManager({
+  id,
+  position,
+});
+```
+
+### useRepeatedStackItem
+
+引数には以下を指定します。
+
+- `id`: `string` ... スタックに追加する要素の ID です。
+- `position`: `${'top' | 'bottom'}${'Left' | 'Center' | 'Right'}` ... 要素を表示する位置を指定します。
+
+返り値は以下の通りです。
+
+- `idList`: `string[]` ... スタックされている同一要素のIDです。
+- `append`: `() => void` ... 同一要素をスタックに追加したい時に呼び出すとIdListに新しいidが追加されます。
+- `onHide`: `(id: string) => void` ... スタックされている同一要素を非表示にするための関数です。
+
+```ts
+const { idList, append, onHide } = useRepeatedStackItem({ id, position });
+```
+
+### useStackInteraction
+
+引数には何も指定しません。
+
+返り値は以下の通りです。
+
+- `setActive`: `({ id: string; active: boolean; position: StackPosition }) => void` ... 明示的にIDとpositionを指定して要素をアクティブにするための関数です。
+- `setOffset`: `({ offset: StackOffset; position: StackPosition }) => void` ... 明示的にIDとpositionを指定してoffsetを設定するための関数です。
+- `setContentHeight`: `({ id: string; height: number; position: StackPosition; }) => void` ... 明示的にIDとpositionを指定してスタックの高さを設定するための関数です。
+
+```ts
+const { setActive, setOffset, setContentHeight } = useStackInteraction();
+```

--- a/packages/spindle-ui/src/StackNotificationManager/StackNotificationManager.tsx
+++ b/packages/spindle-ui/src/StackNotificationManager/StackNotificationManager.tsx
@@ -1,0 +1,89 @@
+import React, {
+  createContext,
+  Dispatch,
+  FC,
+  MutableRefObject,
+  ReactNode,
+  SetStateAction,
+  useCallback,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
+
+export type ManagedStackItem = {
+  id: string;
+  active: boolean;
+  order: number;
+  isPreservingInternalActive: boolean;
+  contentHeight: number;
+};
+
+export type StackPosition = `${'top' | 'bottom'}${'Left' | 'Center' | 'Right'}`;
+
+export type ManagedStack<P extends StackPosition = StackPosition> = {
+  [K in P]?: ManagedStackItem[];
+};
+
+type OffsetPosition = 'top' | 'bottom' | 'right' | 'left';
+
+export type StackPositionOffset<P extends OffsetPosition = OffsetPosition> = {
+  [K in P]: number;
+};
+
+export type StackOffset<P extends StackPosition = StackPosition> = {
+  [K in P]?: {
+    [K in keyof StackPositionOffset]?: StackPositionOffset[K];
+  };
+};
+
+type StackNotificationManagerContextValue<
+  P extends StackPosition = StackPosition,
+> = {
+  stackRef: MutableRefObject<ManagedStack<P>>;
+  setStack: (cb: (prev: ManagedStack) => ManagedStack) => void;
+  offset: StackOffset<P>;
+  setOffset: Dispatch<SetStateAction<StackOffset<P>>>;
+};
+
+const StackNotificationManagerContext =
+  createContext<StackNotificationManagerContextValue | null>(null);
+
+export const useStackNotificationManagerContext = () => {
+  const context = React.useContext(StackNotificationManagerContext);
+  if (context === null) {
+    throw new Error(
+      'useStackNotificationManagerContext must be used within a StackNotificationManagerProvider',
+    );
+  }
+  return context;
+};
+
+type StackNotificationManagerProviderProps = {
+  children: ReactNode;
+};
+
+export const StackNotificationManagerProvider: FC<
+  StackNotificationManagerProviderProps
+> = ({ children }) => {
+  // To clear unnecessary stack items in unmount process, we need to use useRef.
+  const [, forceRender] = useReducer(() => ({}), {});
+  const stackRef = useRef<ManagedStack>({});
+  const setStack = useCallback(
+    (cb: (prev: ManagedStack) => ManagedStack) => {
+      stackRef.current = cb(stackRef.current);
+      forceRender();
+    },
+    [forceRender],
+  );
+
+  const [offset, setOffset] = useState<StackOffset>({});
+
+  return (
+    <StackNotificationManagerContext.Provider
+      value={{ stackRef, setStack, offset, setOffset }}
+    >
+      {children}
+    </StackNotificationManagerContext.Provider>
+  );
+};

--- a/packages/spindle-ui/src/StackNotificationManager/hooks.test.tsx
+++ b/packages/spindle-ui/src/StackNotificationManager/hooks.test.tsx
@@ -1,0 +1,676 @@
+import React from 'react';
+import { act, renderHook as _renderHook } from '@testing-library/react-hooks';
+import {
+  StackNotificationManagerProvider,
+  useStackNotificationManager,
+  StackOffset,
+  useStackInteraction,
+  useRepeatedStackItem,
+} from '.';
+import { useStackNotificationManagerContext } from './StackNotificationManager';
+
+const renderHook: typeof _renderHook = (cb, ops) =>
+  _renderHook(cb, {
+    ...ops,
+    wrapper: ({ children }) => (
+      <StackNotificationManagerProvider>
+        {children}
+      </StackNotificationManagerProvider>
+    ),
+  });
+
+const testStackProps = (
+  stackProps: ReturnType<typeof useStackNotificationManager>['stackProps'],
+  {
+    id,
+    active,
+    order,
+    offset,
+    position,
+    isPreservingInternalActive,
+  }: {
+    id: string;
+    active: boolean;
+    order: number;
+    offset: StackOffset[keyof StackOffset] | undefined;
+    position: string;
+    isPreservingInternalActive?: boolean;
+  },
+) => {
+  expect(stackProps.id).toBe(id);
+  expect(stackProps.active).toBe(active);
+  expect(stackProps.order).toBe(order);
+  expect(stackProps.offset).toEqual(offset);
+  expect(stackProps.position).toBe(position);
+  if (isPreservingInternalActive !== undefined) {
+    expect(stackProps.isPreservingInternalActive).toBe(
+      isPreservingInternalActive,
+    );
+  }
+};
+
+describe('useStackNotificationManager()', () => {
+  it('should add one stack item', () => {
+    const id = 'test-id';
+    const position = 'topLeft';
+    const { result } = renderHook(() =>
+      useStackNotificationManager({ id, position }),
+    );
+
+    testStackProps(result.current.stackProps, {
+      id,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+
+    act(() => {
+      result.current.setActive(true);
+    });
+
+    testStackProps(result.current.stackProps, {
+      id,
+      active: true,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+  });
+
+  it('should increment or decrement order when add multiple stack items', () => {
+    const id1 = 'test-id-1';
+    const id2 = 'test-id-2';
+    const id3 = 'test-id-3';
+    const position = 'topLeft';
+    const { result } = renderHook(() => {
+      const val1 = useStackNotificationManager({ id: id1, position });
+      const val2 = useStackNotificationManager({ id: id2, position });
+      const val3 = useStackNotificationManager({ id: id3, position });
+
+      return {
+        val1,
+        val2,
+        val3,
+      };
+    });
+
+    // check initial value
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+
+    // When activate result1, others should not be changed.
+    act(() => {
+      result.current.val1.setActive(true);
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true, // changed
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+
+    // When activate result3, others should not be changed.
+    // And result3's order should be incremented.
+    act(() => {
+      result.current.val3.setActive(true);
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: true, // changed
+      order: 1, // changed
+      offset: undefined,
+      position,
+    });
+
+    // When activate result2, others should not be changed.
+    // And result2's order should be incremented.
+    act(() => {
+      result.current.val2.setActive(true);
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: true, // changed
+      order: 2, // changed
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: true,
+      order: 1,
+      offset: undefined,
+      position,
+    });
+
+    // When deactivate result2, other's order should not be decremented.
+    act(() => {
+      result.current.val2.setActive(false);
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: false, // changed
+      order: 2,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: true,
+      order: 1,
+      offset: undefined,
+      position,
+    });
+
+    // Reset. reactivate result2 then order should not be incremented.
+    act(() => {
+      result.current.val2.setActive(true);
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: true, // changed
+      order: 2,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: true,
+      order: 1,
+      offset: undefined,
+      position,
+    });
+
+    // When deactivate result3, other's order should be decremented.
+    act(() => {
+      result.current.val3.setActive(false);
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: true,
+      order: 1, // changed
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: false, // changed
+      order: 1,
+      offset: undefined,
+      position,
+    });
+  });
+
+  it('should not change order when other position stack is changed', () => {
+    const id1 = 'test-id-1';
+    const position1 = 'topLeft';
+    const id2 = 'test-id-2';
+    const position2 = 'bottomRight';
+    const { result } = renderHook(() => {
+      const val1 = useStackNotificationManager({
+        id: id1,
+        position: position1,
+      });
+      const val2 = useStackNotificationManager({
+        id: id2,
+        position: position2,
+      });
+      return {
+        val1,
+        val2,
+      };
+    });
+
+    // check initial value
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position: position1,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position: position2,
+    });
+
+    act(() => {
+      result.current.val1.setActive(true);
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true, // changed
+      order: 0,
+      offset: undefined,
+      position: position1,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position: position2,
+    });
+
+    act(() => {
+      result.current.val2.setActive(true);
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true,
+      order: 0,
+      offset: undefined,
+      position: position1,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: true, // changed
+      order: 0, // should not be changed
+      offset: undefined,
+      position: position2,
+    });
+  });
+
+  it('should change offset when invoke setOffset', () => {
+    const id1 = 'test-id-1';
+    const position1 = 'topLeft';
+    const id2 = 'test-id-2';
+    const position2 = 'bottomRight';
+    const { result } = renderHook(() => {
+      const val1 = useStackNotificationManager({
+        id: id1,
+        position: position1,
+      });
+      const val2 = useStackNotificationManager({
+        id: id2,
+        position: position2,
+      });
+      return {
+        val1,
+        val2,
+      };
+    });
+
+    // check initial value
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position: position1,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: false,
+      order: 0,
+      offset: undefined,
+      position: position2,
+    });
+
+    act(() => {
+      result.current.val1.setOffset({ left: 30 });
+    });
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: false,
+      order: 0,
+      offset: { left: 30 }, // changed
+      position: position1,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: false,
+      order: 0,
+      offset: undefined, // should not be changed
+      position: position2,
+    });
+  });
+
+  it('should hide when stack items are over number of max stack items', () => {
+    const id1 = 'test-id-1';
+    const position = 'topLeft';
+    const id2 = 'test-id-2';
+    const id3 = 'test-id-3';
+    const id4 = 'test-id-4';
+    const id5 = 'test-id-5';
+    const { result } = renderHook(() => {
+      const val1 = useStackNotificationManager({ id: id1, position });
+      const val2 = useStackNotificationManager({ id: id2, position });
+      const val3 = useStackNotificationManager({ id: id3, position });
+      const val4 = useStackNotificationManager({ id: id4, position });
+      const val5 = useStackNotificationManager({ id: id5, position });
+      return {
+        val1,
+        val2,
+        val3,
+        val4,
+        val5,
+      };
+    });
+
+    act(() => {
+      result.current.val1.setActive(true);
+      result.current.val2.setActive(true);
+      result.current.val3.setActive(true);
+      result.current.val4.setActive(true);
+    });
+
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: true,
+      order: 0,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: true,
+      order: 1,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: true,
+      order: 2,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val4.stackProps, {
+      id: id4,
+      active: true,
+      order: 3,
+      offset: undefined,
+      position,
+    });
+
+    act(() => {
+      result.current.val5.setActive(true);
+    });
+
+    testStackProps(result.current.val1.stackProps, {
+      id: id1,
+      active: false, // first item will be hidden
+      order: 0,
+      offset: undefined,
+      position,
+      isPreservingInternalActive: true, // preserve active state internally
+    });
+    testStackProps(result.current.val2.stackProps, {
+      id: id2,
+      active: true,
+      order: 1,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val3.stackProps, {
+      id: id3,
+      active: true,
+      order: 2,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val4.stackProps, {
+      id: id4,
+      active: true,
+      order: 3,
+      offset: undefined,
+      position,
+    });
+    testStackProps(result.current.val5.stackProps, {
+      id: id5,
+      active: true,
+      order: 4,
+      offset: undefined,
+      position,
+    });
+  });
+
+  it('should get stack position when stack item is displayed', () => {
+    const id1 = 'test-id-1';
+    const position = 'topLeft';
+    const id2 = 'test-id-2';
+    const id3 = 'test-id-3';
+    const id4 = 'test-id-4';
+    const id5 = 'test-id-5';
+    const { result } = renderHook(() => {
+      const val1 = useStackNotificationManager({ id: id1, position });
+      const val2 = useStackNotificationManager({ id: id2, position });
+      const val3 = useStackNotificationManager({ id: id3, position });
+      const val4 = useStackNotificationManager({ id: id4, position });
+      const val5 = useStackNotificationManager({ id: id5, position });
+      return {
+        val1: {
+          ...val1,
+          setContentHeight: useStackInteraction().setContentHeight,
+        },
+        val2: {
+          ...val2,
+          setContentHeight: useStackInteraction().setContentHeight,
+        },
+        val3: {
+          ...val3,
+          setContentHeight: useStackInteraction().setContentHeight,
+        },
+        val4: {
+          ...val4,
+          setContentHeight: useStackInteraction().setContentHeight,
+        },
+        val5: {
+          ...val5,
+          setContentHeight: useStackInteraction().setContentHeight,
+        },
+      };
+    });
+
+    act(() => {
+      result.current.val1.setActive(true);
+      result.current.val2.setActive(true);
+      result.current.val3.setActive(true);
+      result.current.val4.setActive(true);
+      result.current.val5.setActive(true);
+    });
+
+    act(() => {
+      result.current.val1.setContentHeight({ id: id1, position, height: 1 });
+      result.current.val2.setContentHeight({ id: id2, position, height: 1 });
+      result.current.val3.setContentHeight({ id: id3, position, height: 1 });
+      result.current.val5.setContentHeight({ id: id5, position, height: 1 });
+    });
+
+    expect(result.current.val1.stackProps.stackPosition).toBe(0);
+    // max stack items is 4 so val1 is deactivated but val1 still has the height
+    expect(
+      result.current.val1.stackProps.isPreservingInternalActive,
+    ).toBeTruthy();
+    expect(result.current.val1.stackProps.active).toBeFalsy();
+
+    expect(result.current.val2.stackProps.stackPosition).toBe(1);
+    expect(result.current.val2.stackProps.active).toBeTruthy();
+    expect(result.current.val3.stackProps.stackPosition).toBe(2);
+    expect(result.current.val3.stackProps.active).toBeTruthy();
+    expect(result.current.val4.stackProps.stackPosition).toBe(3);
+    expect(result.current.val4.stackProps.active).toBeTruthy();
+    expect(result.current.val5.stackProps.stackPosition).toBe(3);
+    expect(result.current.val5.stackProps.active).toBeTruthy();
+  });
+
+  it('should remove unnecessary item when unmounting', () => {
+    const id = 'test-id';
+    const position = 'topLeft';
+    const { result, unmount } = renderHook(() => {
+      // create stack
+      useStackNotificationManager({ id, position });
+      return useStackNotificationManagerContext();
+    });
+
+    // check initial value
+    expect(
+      result.current.stackRef.current[position]?.find((item) => item.id === id),
+    ).toBeDefined();
+
+    act(() => {
+      unmount();
+    });
+
+    expect(
+      result.current.stackRef.current[position]?.find((item) => item.id === id),
+    ).toBeUndefined();
+  });
+});
+
+describe('useStackInteraction()', () => {
+  it('should add one stack item', () => {
+    const id1 = 'test-id';
+    const id2 = 'test-id-2';
+    const position = 'topLeft';
+
+    const { result } = renderHook(() => {
+      return {
+        ...useStackInteraction(),
+        context: useStackNotificationManagerContext(),
+      };
+    });
+
+    expect(result.current.context.stackRef.current[position]).toBeUndefined();
+
+    act(() => {
+      result.current.setActive({ id: id1, position, active: true });
+      result.current.setActive({ id: id2, position, active: true });
+    });
+
+    expect(result.current.context.stackRef.current[position]).toEqual([
+      {
+        id: id1,
+        active: true,
+        order: 0,
+        isPreservingInternalActive: false,
+        contentHeight: 0,
+      },
+      {
+        id: id2,
+        active: true,
+        order: 1,
+        isPreservingInternalActive: false,
+        contentHeight: 0,
+      },
+    ]);
+  });
+});
+
+describe('useRepeatedStackItem()', () => {
+  it('should add and hide stack item', () => {
+    const id = 'test-id';
+    const position = 'topLeft';
+
+    const { result } = renderHook(() => useRepeatedStackItem({ id, position }));
+
+    expect(result.current.idList).toEqual([]);
+
+    act(() => {
+      result.current.append();
+      result.current.append();
+      result.current.append();
+    });
+    expect(result.current.idList).toEqual([`${id}-0`, `${id}-1`, `${id}-2`]);
+
+    act(() => {
+      result.current.onHide(`${id}-1`);
+    });
+    expect(result.current.idList).toEqual([`${id}-0`, `${id}-2`]);
+
+    act(() => {
+      result.current.onHide(`${id}-2`);
+    });
+    expect(result.current.idList).toEqual([`${id}-0`]);
+
+    act(() => {
+      result.current.onHide(`${id}-0`);
+    });
+    expect(result.current.idList).toEqual([]);
+
+    act(() => {
+      result.current.append();
+    });
+    expect(result.current.idList).toEqual([`${id}-3`]);
+  });
+});

--- a/packages/spindle-ui/src/StackNotificationManager/hooks.ts
+++ b/packages/spindle-ui/src/StackNotificationManager/hooks.ts
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ManagedStack,
+  StackOffset,
+  StackPosition,
+  useStackNotificationManagerContext,
+} from './StackNotificationManager';
+
+const MAX_STACK_SIZE_DESKTOP = 4;
+const MAX_STACK_SIZE_MOBILE = 3;
+
+/**
+ * Fallback for `MediaQueryList.onchange`
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/matches
+ */
+function addMQListener(
+  mq: MediaQueryList,
+  callback: (evt: MediaQueryListEvent) => void,
+) {
+  if (mq.addEventListener) {
+    mq.addEventListener('change', callback);
+  } else {
+    mq.addListener(callback);
+  }
+}
+
+/**
+ * Fallback for `MediaQueryList.onchange`
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/matches
+ */
+function removeMQListener(
+  mq: MediaQueryList,
+  callback: (evt: MediaQueryListEvent) => void,
+) {
+  if (mq.removeEventListener) {
+    mq.removeEventListener('change', callback);
+  } else {
+    mq.removeListener(callback);
+  }
+}
+
+const useBreakpoint = (breakpoint: string): boolean => {
+  const mql = useRef(
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia(breakpoint)
+      : undefined,
+  );
+  const [matches, setMatches] = useState(() =>
+    mql.current ? mql.current.matches : false,
+  );
+
+  const handleSetMatches = useCallback(
+    (e: MediaQueryListEvent) => setMatches(e.matches),
+    [],
+  );
+
+  useEffect(() => {
+    const current = mql.current;
+    if (current) {
+      addMQListener(current, handleSetMatches);
+    }
+    return () => {
+      if (current) {
+        removeMQListener(current, handleSetMatches);
+      }
+    };
+  }, []);
+
+  return matches;
+};
+
+const useMaxStackSize = () => {
+  const isMobile = useBreakpoint('(max-width: 464px)');
+  return isMobile ? MAX_STACK_SIZE_MOBILE : MAX_STACK_SIZE_DESKTOP;
+};
+
+export const useStackInteraction = <
+  P extends StackPosition = StackPosition,
+>() => {
+  const { setStack, setOffset: _setOffset } =
+    useStackNotificationManagerContext();
+  const maxStackSize = useMaxStackSize();
+
+  const setActive = useCallback(
+    ({
+      id,
+      active,
+      position,
+    }: {
+      id: string;
+      active: boolean;
+      position: P;
+    }) => {
+      setStack((prev) => {
+        const _stack: ManagedStack[keyof ManagedStack] = prev[position] || [];
+        const stack = [..._stack];
+        let specifiedItem = stack.find((item) => item.id === id);
+        if (!specifiedItem) {
+          specifiedItem = {
+            id,
+            active: false,
+            order: 0,
+            isPreservingInternalActive: false,
+            contentHeight: 0,
+          };
+          stack.push(specifiedItem);
+        }
+
+        const shouldUpdate =
+          specifiedItem?.active !== active ||
+          specifiedItem?.isPreservingInternalActive;
+
+        if (!shouldUpdate) {
+          return prev;
+        }
+
+        const totalActiveItems = stack.reduce(
+          (res, v) =>
+            v.active || v.isPreservingInternalActive ? res + 1 : res,
+          0,
+        );
+        const isOverMaxStackSize = totalActiveItems >= maxStackSize;
+
+        if (active && isOverMaxStackSize) {
+          stack
+            .sort((a, b) => (a.order > b.order ? 1 : -1))
+            .find((item) => {
+              if (item.active && !item.isPreservingInternalActive) {
+                item.active = false;
+                item.isPreservingInternalActive = true;
+                return true;
+              }
+              return false;
+            });
+        }
+
+        return {
+          ...prev,
+          [position]: stack.map((s) => {
+            const next = { ...s };
+            if (next.id === id) {
+              next.active = active;
+              next.isPreservingInternalActive = false;
+            }
+
+            if (
+              next.id !== id &&
+              !active &&
+              (specifiedItem?.order || 0) <= next.order
+            ) {
+              next.order = Math.max(next.order - 1, 0);
+            }
+            if (next.id === id && active) {
+              next.order = totalActiveItems;
+            }
+            return next;
+          }),
+        };
+      });
+    },
+    [],
+  );
+
+  const setOffset = ({
+    offset,
+    position,
+  }: {
+    offset: StackOffset<P>[keyof StackOffset<P>];
+    position: P;
+  }) => {
+    _setOffset((prev) => ({ ...prev, [position]: offset }));
+  };
+
+  const setContentHeight = ({
+    id,
+    height,
+    position,
+  }: {
+    id: string;
+    height: number;
+    position: P;
+  }) => {
+    setStack((prev) => {
+      const _stack: ManagedStack[keyof ManagedStack] = prev[position] || [];
+      const stack = [..._stack];
+      const specifiedItem = stack.find((item) => item.id === id);
+      if (!specifiedItem) {
+        return prev;
+      }
+
+      const next = { ...specifiedItem };
+      next.contentHeight = height;
+
+      return {
+        ...prev,
+        [position]: stack.map((s) => (s.id === id ? next : s)),
+      };
+    });
+  };
+
+  return {
+    setActive,
+    setOffset,
+    setContentHeight,
+  };
+};
+
+export const useStackNotificationManager = <
+  P extends StackPosition = StackPosition,
+>({
+  id,
+  position,
+}: {
+  id: string;
+  position: P;
+}) => {
+  const { stackRef, setStack, offset } = useStackNotificationManagerContext();
+  const stack = stackRef.current;
+  const {
+    setActive: _setActive,
+    setOffset: _setOffset,
+    setContentHeight: _setContentHeight,
+  } = useStackInteraction<P>();
+
+  const setActive = useCallback(
+    (active: boolean) => {
+      _setActive({ id, active, position });
+    },
+    [id, position],
+  );
+
+  const setOffset = useCallback(
+    (offset: StackOffset[keyof StackOffset]) => {
+      _setOffset({ position, offset });
+    },
+    [position],
+  );
+
+  const setContentHeight = useCallback(
+    (height: number) => {
+      _setContentHeight({ id, position, height });
+    },
+    [position],
+  );
+
+  useEffect(() => {
+    setStack((prev) => {
+      const stack: ManagedStack[keyof ManagedStack] = prev[position] || [];
+      const item = stack?.find((s) => s.id === id);
+      if (item) {
+        return prev;
+      }
+
+      // If stack item does not find, create stack item.
+      return {
+        ...prev,
+        [position]: [
+          ...stack,
+          {
+            id,
+            active: false,
+            order: 0,
+            contentHeight: 0,
+          },
+        ],
+      };
+    });
+
+    return () => {
+      setStack((prev) => {
+        return {
+          ...prev,
+          [position]: [...(prev[position]?.filter((s) => s.id !== id) || [])],
+        };
+      });
+    };
+  }, []);
+
+  const item = useMemo(
+    () => stack[position]?.find((s) => s.id === id),
+    [stack, id, position],
+  );
+
+  const stackPosition = useMemo(() => {
+    const _stackItem: ManagedStack[keyof ManagedStack] = stack[position] || [];
+    const stackItem = [..._stackItem];
+    return stackItem
+      .sort((a, b) => (a.order > b.order ? 1 : -1))
+      .reduce(
+        (res, v) =>
+          (v.active || v.isPreservingInternalActive) &&
+          v.order < (item?.order || 0)
+            ? res + v.contentHeight
+            : res,
+        0,
+      );
+  }, [stack]);
+
+  return {
+    stackProps: {
+      ...(item || {}),
+      position,
+      offset: offset[position],
+      stackPosition,
+      setContentHeight,
+    },
+    setActive,
+    setOffset,
+  };
+};
+
+export const useRepeatedStackItem = <P extends StackPosition = StackPosition>({
+  id,
+  position,
+}: {
+  id: string;
+  position: P;
+}) => {
+  const [idList, setIdList] = useState<string[]>([]);
+  const lastIndex = useRef(0);
+  const { setActive } = useStackInteraction();
+  const append = useCallback(() => {
+    const nextId = `${id}-${lastIndex.current}`;
+    lastIndex.current += 1;
+    setActive({ id: nextId, position, active: true });
+    setIdList((prev) => [...prev, nextId]);
+  }, [id, position, idList]);
+  const onHide = useCallback(
+    (id) => {
+      setActive({ id, position, active: false });
+      setIdList((prev) => prev.filter((item) => item !== id));
+    },
+    [position],
+  );
+
+  return {
+    idList,
+    append,
+    onHide,
+  };
+};

--- a/packages/spindle-ui/src/StackNotificationManager/index.ts
+++ b/packages/spindle-ui/src/StackNotificationManager/index.ts
@@ -1,0 +1,12 @@
+export {
+  StackNotificationManagerProvider,
+  StackPosition,
+  StackOffset,
+  StackPositionOffset,
+  ManagedStack,
+} from './StackNotificationManager';
+export {
+  useStackNotificationManager,
+  useStackInteraction,
+  useRepeatedStackItem,
+} from './hooks';

--- a/packages/spindle-ui/src/Toast/Toast.css
+++ b/packages/spindle-ui/src/Toast/Toast.css
@@ -7,7 +7,9 @@
 .spui-Toast {
   box-sizing: border-box;
   left: 0;
+  opacity: 0;
   padding: 0 12px;
+  pointer-events: none;
   position: fixed;
   right: 0;
   text-align: center;
@@ -24,6 +26,7 @@
   max-width: 360px;
   min-height: 48px;
   padding: 0 16px 0 20px;
+  pointer-events: auto;
 }
 
 .spui-Toast-contentInfo {
@@ -57,7 +60,6 @@
 }
 
 .spui-Toast--slide {
-  opacity: 0;
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
 

--- a/packages/spindle-ui/src/Toast/Toast.stories.mdx
+++ b/packages/spindle-ui/src/Toast/Toast.stories.mdx
@@ -30,7 +30,6 @@ export const ActivateButton = ({
   message: _message,
   variant,
   hideInfoIcon,
-  order,
   icon,
   position,
 }) => {
@@ -50,7 +49,6 @@ export const ActivateButton = ({
           active={!!message}
           variant={variant}
           hideInfoIcon={hideInfoIcon}
-          order={order}
           icon={icon}
           position={position}
           onHide={() => setMessage('')}
@@ -65,6 +63,7 @@ export const ActivateButton = ({
 export const MultiActivateButton = ({ offset, icon, position }) => {
   const [message1, setMessage1] = useState('');
   const [message2, setMessage2] = useState('');
+  const [stackPosition, setStackPosition] = useState(0);
   usePoliteAnnouncer(message1);
   return (
     <div>
@@ -78,26 +77,30 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
       >
         Activate
       </Button>
-      <Toast
-        active={!!message1}
-        offset={offset}
-        order={0}
-        icon={icon}
-        position={position}
-        onHide={() => setMessage1('')}
-      >
-        {message1}
-      </Toast>
-      <Toast
-        active={!!message2}
-        offset={offset}
-        order={message1 ? 1 : 0}
-        icon={icon}
-        position={position}
-        onHide={() => setMessage2('')}
-      >
-        {message2}
-      </Toast>
+      <div style={{ ["--Toast-z-index"]: 2 }}>
+        <Toast
+          active={!!message1}
+          offset={offset}
+          icon={icon}
+          setContentHeight={setStackPosition}
+          position={position}
+          onHide={() => setMessage1('')}
+        >
+          {message1}
+        </Toast>
+      </div>
+      <div style={{ ["--Toast-z-index"]: 2 }}>
+        <Toast
+          active={!!message2}
+          offset={offset}
+          icon={icon}
+          stackPosition={message1 ? stackPosition : 0}
+          position={position}
+          onHide={() => setMessage2('')}
+        >
+          {message2}
+        </Toast>
+      </div>
     </div>
   );
 };
@@ -190,13 +193,13 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
 
 <Preview withSource="open">
   <Story name="Position Bottom">
-    <ActivateButton icon={<Information />} position="bottom" />
+    <ActivateButton icon={<Information />} position="bottomCenter" />
   </Story>
 </Preview>
 
 <Source
   code={`
-<Toast active={true} position="bottom" icon={<Information />}>メッセージが届きました</Toast>
+<Toast active={true} position="bottomCenter" icon={<Information />}>メッセージが届きました</Toast>
   `}
 />
 
@@ -227,8 +230,8 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
 
 <Source
   code={`
-<Toast active={true} order={0} offset={{ top: 30 }}>メッセージが届きました1</Toast>
-<Toast active={true} order={1} offset={{ top: 30 }}>メッセージが届きました2</Toast>
+<Toast active={true} offset={{ top: 30 }}>メッセージが届きました1</Toast>
+<Toast active={true} offset={{ top: 30 }}>メッセージが届きました2</Toast>
   `}
 />
 
@@ -236,14 +239,14 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
 
 <Preview withSource="open">
   <Story name="Multiple bottom">
-    <MultiActivateButton offset={{ bottom: 30 }} position="bottom" icon={<Information />} />
+    <MultiActivateButton offset={{ bottom: 30 }} position="bottomCenter" icon={<Information />} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<Toast active={true} order={0} offset={{ bottom: 30 }} position="bottom">メッセージが届きました1</Toast>
-<Toast active={true} order={1} offset={{ bottom: 30 }} position="bottom">メッセージが届きました2</Toast>
+<Toast active={true} offset={{ bottom: 30 }} position="bottomCenter">メッセージが届きました1</Toast>
+<Toast active={true} offset={{ bottom: 30 }} position="bottomCenter">メッセージが届きました2</Toast>
   `}
 />
 
@@ -336,3 +339,8 @@ const usePoliteAnnouncer = (message) => {
 }
   `}
 />
+
+## スタック機能
+
+StackNotificationManager を使用することで Toast や SnackBar をスタックして複数表示することができます。
+詳しくは[StackNotificationManager のドキュメント](/docs/stacknotificationmanager--normal)を参照してください。

--- a/packages/spindle-ui/src/Toast/Toast.tsx
+++ b/packages/spindle-ui/src/Toast/Toast.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { ManagedStack, StackPositionOffset } from '../StackNotificationManager';
 import { CrossBold } from '../Icon';
 import { IconButton } from '../IconButton';
 
-type Position = 'top' | 'bottom';
+type Position = keyof Pick<ManagedStack, 'topCenter' | 'bottomCenter'>;
 type PositionOffset = {
-  [K in Position]?: number;
+  [K in keyof StackPositionOffset<'top' | 'bottom'>]?: StackPositionOffset[K];
 };
 
 type Variant = 'information' | 'confirmation' | 'error';
@@ -12,7 +13,6 @@ type Variant = 'information' | 'confirmation' | 'error';
 type Props = {
   children?: React.ReactNode;
   active?: boolean;
-  order?: number;
   offset?: PositionOffset;
   // milliseconds to hide
   duration?: number;
@@ -20,6 +20,8 @@ type Props = {
   position?: Position;
   icon?: React.ReactNode;
   variant?: Variant;
+  setContentHeight?: (height: number) => void;
+  stackPosition?: number;
 };
 
 export const BLOCK_NAME = 'spui-Toast';
@@ -31,23 +33,26 @@ const MAX_DURATION = 4000;
 const VERTICAL_GAP = 20;
 const TOTAL_ANIMATION_DURATION = MAX_DURATION - ANIMATION_DURATION;
 
-export const Toast = ({
+export const Toast: FC<Props> = ({
   children,
-  active = false,
-  position = 'top',
-  order = 0,
+  active: _active,
+  position = 'topCenter',
   offset: _offset = {},
   onHide,
   icon,
   variant = 'information',
-}: Props): React.ReactElement => {
+  stackPosition = 0,
+  setContentHeight,
+}) => {
   const [isShow, setIsShow] = useState<boolean>(false);
   const offset: PositionOffset = {
-    top: _offset.top || 24,
-    bottom: _offset.bottom || 24,
+    top: _offset.top ?? 24,
+    bottom: _offset.bottom ?? 24,
   };
   const timeoutID = useRef<number | null>(null);
   const [clientHeight, setClientHeight] = useState(0);
+  const [shouldAnimation, setShouldAnimation] = useState(false);
+  const [active, setActive] = useState(false);
 
   const setIsShowWithTimeout = useCallback(() => {
     // Out animation is executed after `TOTAL_ANIMATION_DURATION` seconds.
@@ -68,6 +73,7 @@ export const Toast = ({
   const handleTransitionEnd = useCallback(() => {
     if (onHide && !isShow) {
       onHide();
+      setActive(false);
       timeoutID.current = null;
     }
   }, [isShow, setIsShow, onHide]);
@@ -84,19 +90,41 @@ export const Toast = ({
   }, [active]);
 
   useEffect(() => {
+    if (isShow) {
+      setShouldAnimation(true);
+    }
+    if (!active) {
+      setShouldAnimation(false);
+    }
+  }, [active, isShow]);
+
+  useEffect(() => {
     setIsShowWithTimeout();
     return resetTimeout;
   }, [setIsShowWithTimeout, resetTimeout]);
 
-  const contentHeight = clientHeight;
-  const offsetPosition = offset[position] || 0;
-  const orderOffset = order * (contentHeight + VERTICAL_GAP) + offsetPosition;
+  useEffect(() => {
+    if (_active) {
+      setActive(true);
+    }
+    if (!_active && isShow) {
+      setIsShow(false);
+    }
+  }, [_active, isShow]);
+
+  useEffect(() => {
+    setContentHeight?.(clientHeight + VERTICAL_GAP);
+  }, [clientHeight]);
+
+  const positionPrefix = position.startsWith('top') ? 'top' : 'bottom';
+  const offsetPosition = offset[positionPrefix] || 0;
+  const orderOffset = stackPosition + offsetPosition;
 
   return (
     <div
       style={{
         ['--Toast--initial-height' as string]: `${
-          orderOffset - contentHeight + offsetPosition
+          orderOffset - clientHeight + offsetPosition
         }px`,
         ['--Toast--order-offset-top' as string]: `${orderOffset}px`,
         ['--Toast--order-offset-bottom' as string]: `${-orderOffset}px`,
@@ -105,8 +133,8 @@ export const Toast = ({
       }}
       className={[
         BLOCK_NAME,
-        `${BLOCK_NAME}--${position}`,
-        `${BLOCK_NAME}--slide`,
+        `${BLOCK_NAME}--${positionPrefix}`,
+        shouldAnimation && `${BLOCK_NAME}--slide`,
         isShow && `${BLOCK_NAME}-slide--in`,
         !active && `${BLOCK_NAME}--hidden`,
       ]


### PR DESCRIPTION
ToastやSnackBarの複数表示を管理するStackManagerを追加しました。
現状の実装だと複数のToastやSnackBarを表示する際に利用側で管理する必要がありましたが、この部分は実装が複雑な上にデザイン状の仕様も複雑なためSpindleでコンポーネントを提供します。

https://user-images.githubusercontent.com/34934510/182985986-314e98bb-3751-4f13-860c-e6241879b2d7.mov

## 確認事項

- [ ] StorybookのStackManagerにて正しく動作すること
- [ ] Docsがわかりやすいかどうか

## ざっくり仕様

- 最大スタック数: PC=4、SP=3
- 新しい要素は下に追加される
- live regionは利用側で管理
- offsetは任意のタイミングで変更可能

##  TODO

- [ ] commitをまとめます
- [ ] 最後にbundlesize調整します