### PR TITLE
add DropdownMenu component

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/index.css",
-      "maxSize": "7.2 kB"
+      "maxSize": "8.0 kB"
     }
   ]
 }

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.css
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.css
@@ -1,0 +1,154 @@
+/*
+ * DropdownMenu
+ * NOTE: Styles can be overridden with "--DropdownMenu-*" variables
+*/
+:root {
+  --DropdownMenu-z-index: 1;
+  --DropdownMenu-onFocus-outlineColor: var(--color-focus-clarity);
+}
+
+.spui-DropdownMenu {
+  position: relative;
+  width: fit-content;
+}
+
+.spui-DropdownMenu-menu {
+  animation: 0.3s spui-DropdownMenu-fade-in;
+  background-color: var(--color-surface-primary);
+  border-radius: 12px;
+  box-shadow: 0px 11px 28px rgba(8, 18, 26, 0.12);
+  box-sizing: border-box;
+  left: -256px;
+  list-style: none;
+  margin: 0;
+  padding: 12px 0;
+  position: absolute;
+  top: 0;
+  width: 256px;
+  z-index: var(--DropdownMenu-z-index);
+}
+
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
+.spui-DropdownMenu-menu.is-fade-out {
+  animation: 0.3s spui-DropdownMenu-fade-out;
+  opacity: 0;
+}
+
+.spui-DropdownMenu-menu--right {
+  left: auto;
+  right: -256px;
+  width: 256px;
+}
+
+.spui-DropdownMenu-menuButton {
+  align-items: center;
+  background-color: var(--color-surface-primary);
+  border: none;
+  display: flex;
+  font-size: 1em;
+  position: relative;
+  transition: background-color 0.3s;
+  width: 100%;
+}
+
+.spui-DropdownMenu-menu--text .spui-DropdownMenu-menuButton,
+.spui-DropdownMenu-menu--textWithIcon .spui-DropdownMenu-menuButton {
+  padding: 10px 16px;
+}
+
+.spui-DropdownMenu-menu--headWithIcon .spui-DropdownMenu-menuButton {
+  padding: 16px;
+}
+
+.spui-DropdownMenu-menu--headWithIconAndCaption .spui-DropdownMenu-menuButton {
+  padding: 14px 16px;
+}
+
+.spui-DropdownMenu-menuButton:hover {
+  background-color: var(--color-surface-secondary);
+}
+
+.spui-DropdownMenu-menuButton:focus-visible {
+  outline: 2px solid var(--DropdownMenu-onFocus-outlineColor);
+  z-index: var(--DropdownMenu-z-index);
+}
+
+.spui-DropdownMenu-menuItem .spui-DropdownMenu-menuButton::before {
+  background-color: var(--color-border-low-emphasis);
+  content: '';
+  height: 1px;
+  position: absolute;
+  top: 0;
+  width: calc(100% - 32px);
+}
+
+.spui-DropdownMenu-menuItem:first-child .spui-DropdownMenu-menuButton::before {
+  height: 0;
+}
+
+.spui-DropdownMenu-iconContainer {
+  color: var(--color-object-high-emphasis);
+  display: flex;
+  font-size: 1.5em;
+  margin-right: 16px;
+}
+
+.spui-DropdownMenu-textContainer {
+  text-align: left;
+}
+
+.spui-DropdownMenu-title {
+  color: var(--color-text-high-emphasis);
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.spui-DropdownMenu-caption {
+  color: var(--color-text-low-emphasis);
+  font-size: 0.75em;
+  line-height: 1.4;
+  margin: 4px 0 0;
+}
+
+@keyframes spui-DropdownMenu-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes spui-DropdownMenu-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .spui-DropdownMenu-menu {
+    left: auto;
+    right: 0;
+    top: auto;
+  }
+
+  .spui-DropdownMenu-menu--right {
+    left: 0;
+    top: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spui-DropdownMenu-menu {
+    animation: 0s spui-DropdownMenu-fade-in;
+  }
+
+  /* stylelint-disable-next-line plugin/selector-bem-pattern */
+  .spui-DropdownMenu-menu.is-fade-out {
+    animation: 0s spui-DropdownMenu-fade-out;
+  }
+}

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.example.tsx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.example.tsx
@@ -1,0 +1,198 @@
+import React, { useState, useRef } from 'react';
+import { actions } from '@storybook/addon-actions';
+
+import { Button } from '../Button';
+import { AllFill } from '../Icon';
+import { DropdownMenu } from './DropdownMenu';
+
+export function Text() {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const onClick = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+  const onClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div style={{ ['--DropdownMenu-z-index']: 2 }}>
+      <DropdownMenu.Frame>
+        <Button
+          aria-controls="dropdown-menu-example1"
+          aria-expanded={open}
+          onClick={onClick}
+          ref={triggerRef}
+          size="medium"
+          variant="neutral"
+        >
+          開く
+        </Button>
+        <DropdownMenu.List
+          id="dropdown-menu-example1"
+          onClose={onClose}
+          open={open}
+          position="right"
+          triggerRef={triggerRef}
+          variant="text"
+        >
+          <DropdownMenu.ListItem {...actions('onClick')}>
+            <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+          </DropdownMenu.ListItem>
+          <DropdownMenu.ListItem {...actions('onClick')}>
+            <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+          </DropdownMenu.ListItem>
+        </DropdownMenu.List>
+      </DropdownMenu.Frame>
+    </div>
+  );
+}
+
+export function TextWithIcon() {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const onClick = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+  const onClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div style={{ ['--DropdownMenu-z-index']: 2 }}>
+      <DropdownMenu.Frame>
+        <Button
+          aria-controls="dropdown-menu-example2"
+          aria-expanded={open}
+          onClick={onClick}
+          ref={triggerRef}
+          size="medium"
+          variant="neutral"
+        >
+          開く
+        </Button>
+        <DropdownMenu.List
+          id="dropdown-menu-example2"
+          onClose={onClose}
+          open={open}
+          position="right"
+          triggerRef={triggerRef}
+          variant="textWithIcon"
+        >
+          <DropdownMenu.ListItem
+            icon={<AllFill aria-hidden="true" />}
+            {...actions('onClick')}
+          >
+            <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+          </DropdownMenu.ListItem>
+          <DropdownMenu.ListItem
+            icon={<AllFill aria-hidden="true" />}
+            {...actions('onClick')}
+          >
+            <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+          </DropdownMenu.ListItem>
+        </DropdownMenu.List>
+      </DropdownMenu.Frame>
+    </div>
+  );
+}
+
+export function HeadWithIcon() {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const onClick = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+  const onClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div style={{ ['--DropdownMenu-z-index']: 2 }}>
+      <DropdownMenu.Frame>
+        <Button
+          aria-controls="dropdown-menu-example3"
+          aria-expanded={open}
+          onClick={onClick}
+          ref={triggerRef}
+          size="medium"
+          variant="neutral"
+        >
+          開く
+        </Button>
+        <DropdownMenu.List
+          id="dropdown-menu-example3"
+          onClose={onClose}
+          open={open}
+          position="right"
+          triggerRef={triggerRef}
+          variant="headWithIcon"
+        >
+          <DropdownMenu.ListItem
+            icon={<AllFill aria-hidden="true" />}
+            {...actions('onClick')}
+          >
+            <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+          </DropdownMenu.ListItem>
+          <DropdownMenu.ListItem
+            icon={<AllFill aria-hidden="true" />}
+            {...actions('onClick')}
+          >
+            <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+          </DropdownMenu.ListItem>
+        </DropdownMenu.List>
+      </DropdownMenu.Frame>
+    </div>
+  );
+}
+
+export function HeadWithIconAndCaption() {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const onClick = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+  const onClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div style={{ ['--DropdownMenu-z-index']: 2 }}>
+      <DropdownMenu.Frame>
+        <Button
+          aria-controls="dropdown-menu-example4"
+          aria-expanded={open}
+          onClick={onClick}
+          ref={triggerRef}
+          size="medium"
+          variant="neutral"
+        >
+          開く
+        </Button>
+        <DropdownMenu.List
+          id="dropdown-menu-example4"
+          onClose={onClose}
+          open={open}
+          position="right"
+          triggerRef={triggerRef}
+          variant="headWithIconAndCaption"
+        >
+          <DropdownMenu.ListItem
+            icon={<AllFill aria-hidden="true" />}
+            {...actions('onClick')}
+          >
+            <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+            <DropdownMenu.Caption>キャプションですよ</DropdownMenu.Caption>
+          </DropdownMenu.ListItem>
+          <DropdownMenu.ListItem
+            icon={<AllFill aria-hidden="true" />}
+            {...actions('onClick')}
+          >
+            <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+            <DropdownMenu.Caption>キャプションですよ</DropdownMenu.Caption>
+          </DropdownMenu.ListItem>
+        </DropdownMenu.List>
+      </DropdownMenu.Frame>
+    </div>
+  );
+}

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.mdx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.mdx
@@ -1,0 +1,271 @@
+import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import { DropdownMenu } from './DropdownMenu';
+import {
+  Text,
+  TextWithIcon,
+  HeadWithIcon,
+  HeadWithIconAndCaption,
+} from './DropdownMenu.stories.example';
+
+# DropdownMenu
+
+<Meta title="DropdownMenu" component={DropdownMenu} />
+
+![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
+
+<Description>
+  - `DropdownMenu.List`は`open`プロパティの値を見て、開閉を行います。`onClick`や`onClose`内で`open`プロパティを変更してください
+</Description>
+<Description>
+  - DropdownMenuをボタンに対して左側に開くか右側に開くかは、`DropdownMenu.List`の`position`プロパティに指定してください。デフォルトは`left`です
+</Description>
+<Description>
+  - DropdownMenuのコンテンツの種類は、`DropdownMenu.List`の`variant`プロパティに指定してください。デフォルトは`text`です
+</Description>
+
+<Source
+  language='javascript'
+  code={`import { DropdownMenu } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language='css'
+  code={`@import './node_modules/@openameba/spindle-ui/DropdownMenu/DropdownMenu.css'`}
+/>
+
+<Source
+  language='html'
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/DropdownMenu/DropdownMenu.css">`}
+/>
+
+## Text
+<Description>テキストのみのDropdownMenuです</Description>
+
+<Preview withSource="open">
+  <Story name="Text">
+    <Text />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+const [open, setOpen] = useState(false);
+const triggerRef = useRef<HTMLButtonElement>(null);
+const onClick = () => {
+  setOpen((prevOpen) => !prevOpen);
+};
+const onClose = () => {
+  setOpen(false);
+};
+return (
+  <>
+    <DropdownMenu.Frame>
+      <Button
+        aria-controls="dropdown-menu-example1"
+        aria-expanded={open}
+        onClick={onClick}
+        ref={triggerRef}
+        size="medium"
+        variant="neutral"
+      >
+        開く
+      </Button>
+      <DropdownMenu.List
+        id="dropdown-menu-example1"
+        onClose={onClose}
+        open={open}
+        position="right"
+        triggerRef={triggerRef}
+        variant="text"
+      >
+        <DropdownMenu.ListItem {...actions('onClick')}>
+          <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+        </DropdownMenu.ListItem>
+        <DropdownMenu.ListItem {...actions('onClick')}>
+          <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+        </DropdownMenu.ListItem>
+      </DropdownMenu.List>
+    </DropdownMenu.Frame>
+  </>
+);
+  `}
+/>
+
+## Text With Icon（1line 44px）
+<Description>各アイテムの高さが44pxのアイコン付きDropdownMenuです</Description>
+
+<Preview withSource="open">
+  <Story name="Text With Icon">
+    <TextWithIcon />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+const [open, setOpen] = useState(false);
+const triggerRef = useRef<HTMLButtonElement>(null);
+const onClick = () => {
+  setOpen((prevOpen) => !prevOpen);
+};
+const onClose = () => {
+  setOpen(false);
+};
+return (
+  <>
+    <DropdownMenu.Frame>
+      <Button
+        aria-controls="dropdown-menu-example2"
+        aria-expanded={open}
+        onClick={onClick}
+        ref={triggerRef}
+        size="medium"
+        variant="neutral"
+      >
+        開く
+      </Button>
+      <DropdownMenu.List
+        id="dropdown-menu-example2"
+        onClose={onClose}
+        open={open}
+        position="right"
+        triggerRef={triggerRef}
+        variant="textWithIcon"
+      >
+        <DropdownMenu.ListItem
+          icon={<AllFill aria-hidden="true" />}
+          {...actions('onClick')}
+        >
+          <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+        </DropdownMenu.ListItem>
+        <DropdownMenu.ListItem
+          icon={<AllFill aria-hidden="true" />}
+          {...actions('onClick')}
+        >
+          <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+        </DropdownMenu.ListItem>
+      </DropdownMenu.List>
+    </DropdownMenu.Frame>
+  </>
+);
+  `}
+/>
+
+## Head With Icon（1line 56px）
+<Description>各アイテムの高さが56pxのアイコン付きDropdownMenuです</Description>
+
+<Preview withSource="open">
+  <Story name="Head With Icon">
+    <HeadWithIcon />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+const [open, setOpen] = useState(false);
+const triggerRef = useRef<HTMLButtonElement>(null);
+const onClick = () => {
+  setOpen((prevOpen) => !prevOpen);
+};
+const onClose = () => {
+  setOpen(false);
+};
+return (
+  <>
+    <DropdownMenu.Frame>
+      <Button
+        aria-controls="dropdown-menu-example3"
+        aria-expanded={open}
+        onClick={onClick}
+        ref={triggerRef}
+        size="medium"
+        variant="neutral"
+      >
+        開く
+      </Button>
+      <DropdownMenu.List
+        id="dropdown-menu-example3"
+        onClose={onClose}
+        open={open}
+        position="right"
+        triggerRef={triggerRef}
+        variant="headWithIcon"
+      >
+        <DropdownMenu.ListItem
+          icon={<AllFill aria-hidden="true" />}
+          {...actions('onClick')}
+        >
+          <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+        </DropdownMenu.ListItem>
+        <DropdownMenu.ListItem
+          icon={<AllFill aria-hidden="true" />}
+          {...actions('onClick')}
+        >
+          <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+        </DropdownMenu.ListItem>
+      </DropdownMenu.List>
+    </DropdownMenu.Frame>
+  </>
+);
+  `}
+/>
+
+## Head With Icon And Caption
+<Description>アイコンとキャプション付きDropdownMenuです</Description>
+
+<Preview withSource="open">
+  <Story name="Head With Icon And Caption">
+    <HeadWithIconAndCaption />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+const [open, setOpen] = useState(false);
+const triggerRef = useRef<HTMLButtonElement>(null);
+const onClick = () => {
+  setOpen((prevOpen) => !prevOpen);
+};
+const onClose = () => {
+  setOpen(false);
+};
+return (
+  <>
+    <DropdownMenu.Frame>
+      <Button
+        aria-controls="dropdown-menu-example4"
+        aria-expanded={open}
+        onClick={onClick}
+        ref={triggerRef}
+        size="medium"
+        variant="neutral"
+      >
+        開く
+      </Button>
+      <DropdownMenu.List
+        id="dropdown-menu-example4"
+        onClose={onClose}
+        open={open}
+        position="right"
+        triggerRef={triggerRef}
+        variant="headWithIconAndCaption"
+      >
+        <DropdownMenu.ListItem
+          icon={<AllFill aria-hidden="true" />}
+          {...actions('onClick')}
+        >
+          <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+          <DropdownMenu.Caption>キャプションですよ</DropdownMenu.Caption>
+        </DropdownMenu.ListItem>
+        <DropdownMenu.ListItem
+          icon={<AllFill aria-hidden="true" />}
+          {...actions('onClick')}
+        >
+          <DropdownMenu.Title>タイトルですよ</DropdownMenu.Title>
+          <DropdownMenu.Caption>キャプションですよ</DropdownMenu.Caption>
+        </DropdownMenu.ListItem>
+      </DropdownMenu.List>
+    </DropdownMenu.Frame>
+  </>
+);
+  `}
+/>

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.test.tsx
@@ -1,0 +1,230 @@
+import React, { createRef, useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import userEvent from '@testing-library/user-event';
+import { jest } from '@jest/globals';
+
+import { Button } from '../Button';
+import { BLOCK_NAME, DropdownMenu } from './DropdownMenu';
+
+const ANIMATION_DURATION = 300;
+const useDropdownMenuOpen = () => {
+  const [open, setOpen] = useState(true);
+  const onClick = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+  const onClose = () => {
+    setOpen(false);
+  };
+  return { open, setOpen, onClick, onClose };
+};
+
+describe('<DropdownMenu />', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('The DropdownMenu should be closed when you click the trigger button', async () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    const onMenuButtonClick = jest.fn();
+    const onClose = jest.fn();
+    const { result } = renderHook(() => useDropdownMenuOpen());
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    expect(result.current.open).toBe(true);
+
+    const { rerender } = render(
+      <>
+        <DropdownMenu.Frame>
+          <Button onClick={result.current.onClick} ref={triggerRef}>
+            triggerButton
+          </Button>
+          <DropdownMenu.List
+            onClose={onClose}
+            open={result.current.open}
+            triggerRef={triggerRef}
+          >
+            <DropdownMenu.ListItem onClick={onMenuButtonClick}>
+              <DropdownMenu.Title>testTitle</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.List>
+        </DropdownMenu.Frame>
+      </>,
+    );
+
+    const button = screen.getByText(/triggerButton/);
+    const menu = button.nextElementSibling;
+    expect(menu).toHaveClass(`${BLOCK_NAME}-menu`);
+    expect(menu).toBeInTheDocument();
+
+    await user.click(button);
+
+    rerender(
+      <>
+        <DropdownMenu.Frame>
+          <Button onClick={result.current.onClick} ref={triggerRef}>
+            triggerButton
+          </Button>
+          <DropdownMenu.List
+            onClose={onClose}
+            open={result.current.open}
+            triggerRef={triggerRef}
+          >
+            <DropdownMenu.ListItem onClick={onMenuButtonClick}>
+              <DropdownMenu.Title>testTitle</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.List>
+        </DropdownMenu.Frame>
+      </>,
+    );
+
+    expect(result.current.open).toBe(false);
+    expect(
+      screen.getByText(/triggerButton/).nextElementSibling,
+    ).not.toBeInTheDocument();
+  });
+
+  test('The DropdownMenu should be closed when you click outside the DropdownMenu', async () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    const onMenuButtonClick = jest.fn();
+    const { result } = renderHook(() => useDropdownMenuOpen());
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    expect(result.current.open).toBe(true);
+
+    const { rerender } = render(
+      <>
+        <DropdownMenu.Frame>
+          <Button onClick={result.current.onClick} ref={triggerRef}>
+            triggerButton
+          </Button>
+          <DropdownMenu.List
+            onClose={result.current.onClose}
+            open={result.current.open}
+            triggerRef={triggerRef}
+          >
+            <DropdownMenu.ListItem onClick={onMenuButtonClick}>
+              <DropdownMenu.Title>testTitle</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.List>
+        </DropdownMenu.Frame>
+        <div>outside</div>
+      </>,
+    );
+
+    const outside = screen.getByText(/outside/);
+    const menu = screen.getByText(/triggerButton/).nextElementSibling;
+    expect(menu).toHaveClass(`${BLOCK_NAME}-menu`);
+    expect(menu).toBeInTheDocument();
+
+    await user.click(outside);
+
+    expect(menu).toHaveClass('is-fade-out');
+
+    act(() => {
+      jest.advanceTimersByTime(ANIMATION_DURATION);
+      if (menu) fireEvent.animationEnd(menu);
+    });
+
+    rerender(
+      <>
+        <DropdownMenu.Frame>
+          <Button onClick={result.current.onClick} ref={triggerRef}>
+            triggerButton
+          </Button>
+          <DropdownMenu.List
+            onClose={result.current.onClose}
+            open={result.current.open}
+            triggerRef={triggerRef}
+          >
+            <DropdownMenu.ListItem onClick={onMenuButtonClick}>
+              <DropdownMenu.Title>testTitle</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.List>
+        </DropdownMenu.Frame>
+        <div>outside</div>
+      </>,
+    );
+
+    expect(result.current.open).toBe(false);
+    expect(
+      screen.getByText(/triggerButton/).nextElementSibling,
+    ).not.toBeInTheDocument();
+  });
+
+  test('A click event should occur and the DropdownMenu should be closed when you click in the DropdownMenu', async () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    const onMenuButtonClick = jest.fn();
+    const { result } = renderHook(() => useDropdownMenuOpen());
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    expect(result.current.open).toBe(true);
+
+    const { rerender } = render(
+      <>
+        <DropdownMenu.Frame>
+          <Button onClick={result.current.onClick} ref={triggerRef}>
+            triggerButton
+          </Button>
+          <DropdownMenu.List
+            onClose={result.current.onClose}
+            open={result.current.open}
+            triggerRef={triggerRef}
+          >
+            <DropdownMenu.ListItem onClick={onMenuButtonClick}>
+              <DropdownMenu.Title>testTitle</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.List>
+        </DropdownMenu.Frame>
+      </>,
+    );
+
+    const menu = screen.getByText(/triggerButton/).nextElementSibling;
+    expect(menu).toHaveClass(`${BLOCK_NAME}-menu`);
+    expect(menu).toBeInTheDocument();
+
+    const menuButton =
+      screen.getByText(/testTitle/).parentElement?.parentElement;
+    expect(menuButton).toHaveClass(`${BLOCK_NAME}-menuButton`);
+    expect(menuButton).toBeInTheDocument();
+
+    if (menuButton) await user.click(menuButton);
+
+    expect(onMenuButtonClick).toBeCalled();
+    expect(menu).toHaveClass('is-fade-out');
+
+    act(() => {
+      jest.advanceTimersByTime(ANIMATION_DURATION);
+      if (menu) fireEvent.animationEnd(menu);
+    });
+
+    rerender(
+      <>
+        <DropdownMenu.Frame>
+          <Button onClick={result.current.onClick} ref={triggerRef}>
+            triggerButton
+          </Button>
+          <DropdownMenu.List
+            onClose={result.current.onClose}
+            open={result.current.open}
+            triggerRef={triggerRef}
+          >
+            <DropdownMenu.ListItem onClick={onMenuButtonClick}>
+              <DropdownMenu.Title>testTitle</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.List>
+        </DropdownMenu.Frame>
+      </>,
+    );
+
+    expect(result.current.open).toBe(false);
+    expect(
+      screen.getByText(/triggerButton/).nextElementSibling,
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useCallback, useRef, useState } from 'react';
+
+type Variant =
+  | 'text'
+  | 'textWithIcon'
+  | 'headWithIcon'
+  | 'headWithIconAndCaption';
+
+interface DefaultProps {
+  children: React.ReactNode;
+}
+
+interface ListItemProps extends DefaultProps {
+  icon?: React.ReactNode;
+  onClick: () => void;
+}
+
+interface ListProps extends DefaultProps {
+  id?: string;
+  onClose: () => void;
+  open: boolean;
+  position?: 'left' | 'right';
+  triggerRef: React.RefObject<HTMLButtonElement>;
+  variant?: Variant;
+}
+
+export const BLOCK_NAME = 'spui-DropdownMenu';
+const FADE_IN_ANIMATION = 'spui-DropdownMenu-fade-in';
+
+const Caption = ({ children }: DefaultProps) => {
+  return <p className={`${BLOCK_NAME}-caption`}>{children}</p>;
+};
+
+const Frame = ({ children }: DefaultProps) => {
+  return <div className={`${BLOCK_NAME}`}>{children}</div>;
+};
+
+const List = ({
+  children,
+  id,
+  onClose,
+  open,
+  position = 'left',
+  triggerRef,
+  variant = 'text',
+}: ListProps) => {
+  const CLOSE_KEY_LIST = ['Escape', 'Esc'];
+  const menuEl = useRef<HTMLUListElement>(null);
+  const [fadeOut, setFadeOut] = useState(false);
+
+  const onClickBody = useCallback(
+    (e: MouseEvent) => {
+      if (!open) return;
+      if (triggerRef.current && e.composedPath().includes(triggerRef.current))
+        return;
+      const menuEl = document.querySelector(`.${BLOCK_NAME}-menu`);
+      if (menuEl && e.composedPath().includes(menuEl)) return;
+
+      setFadeOut(true);
+    },
+    [open, setFadeOut, triggerRef],
+  );
+
+  const onClickCloser = useCallback(() => {
+    setFadeOut(true);
+    triggerRef.current?.focus();
+  }, [setFadeOut, triggerRef]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (CLOSE_KEY_LIST.includes(e.key)) {
+        onClickCloser();
+      }
+    },
+    [onClickCloser],
+  );
+
+  const handleAnimationEnd = useCallback(
+    (event: AnimationEvent) => {
+      if (event.animationName === FADE_IN_ANIMATION) return;
+
+      onClose();
+      setFadeOut(false);
+    },
+    [onClose, setFadeOut],
+  );
+
+  useEffect(() => {
+    menuEl.current?.addEventListener('animationend', handleAnimationEnd, false);
+
+    return () =>
+      menuEl.current?.removeEventListener(
+        'animationend',
+        handleAnimationEnd,
+        false,
+      );
+  }, [menuEl, handleAnimationEnd]);
+
+  useEffect(() => {
+    window.addEventListener('click', onClickBody, false);
+
+    return () => {
+      window.removeEventListener('click', onClickBody, false);
+    };
+  }, [onClickBody]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
+  if (!open) {
+    return <></>;
+  }
+
+  return (
+    <ul
+      id={id}
+      onClick={onClickCloser}
+      className={[
+        `${BLOCK_NAME}-menu`,
+        `${BLOCK_NAME}-menu--${variant}`,
+        position === 'right' && `${BLOCK_NAME}-menu--right`,
+        fadeOut && 'is-fade-out',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      ref={menuEl}
+      role="menu"
+    >
+      {children}
+    </ul>
+  );
+};
+
+const ListItem = ({ children, icon, onClick }: ListItemProps) => {
+  return (
+    <li className={`${BLOCK_NAME}-menuItem`} role="menuItem">
+      <button className={`${BLOCK_NAME}-menuButton`} onClick={onClick}>
+        {icon && <div className={`${BLOCK_NAME}-iconContainer`}>{icon}</div>}
+        <div className={`${BLOCK_NAME}-textContainer`}>{children}</div>
+      </button>
+    </li>
+  );
+};
+
+const Title = ({ children }: DefaultProps) => {
+  return <p className={`${BLOCK_NAME}-title`}>{children}</p>;
+};
+
+export const DropdownMenu = {
+  Caption,
+  Frame,
+  List,
+  ListItem,
+  Title,
+};

--- a/packages/spindle-ui/src/DropdownMenu/index.ts
+++ b/packages/spindle-ui/src/DropdownMenu/index.ts
@@ -1,0 +1,1 @@
+export { DropdownMenu } from './DropdownMenu';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -15,3 +15,4 @@
 @import './Toast/Toast.css';
 @import './SnackBar/SnackBar.css';
 @import './List/index.css';
+@import './DropdownMenu/DropdownMenu.css';

--- a/packages/spindle-ui/src/index.ts
+++ b/packages/spindle-ui/src/index.ts
@@ -9,6 +9,7 @@ import { IconButton } from './IconButton';
 import { LinkButton } from './LinkButton';
 import { TextButton } from './TextButton';
 import { Toast } from './Toast';
+import { DropdownMenu } from './DropdownMenu';
 import { SnackBar } from './SnackBar';
 
 // Components are currently exported after "import" for projects using TS lower v3.8 that does not support "export * as".
@@ -25,5 +26,6 @@ export {
   LinkButton,
   TextButton,
   Toast,
+  DropdownMenu,
   SnackBar,
 };


### PR DESCRIPTION
## 概要
DropdownMenuコンポーネントを作成しました 🚀 

DropdownMenuは、全部で4パターンあります

| Textのみパターン | Icon + Textパターン（1line 44px） | Icon + Headパターン（1line 56px） | Icon + Head + Captionパターン |
| -- | -- | -- | -- |
| ![スクリーンショット 2022-08-10 14 52 16](https://user-images.githubusercontent.com/42470015/183825826-cd035e64-c2c6-4dde-a7d3-3e468b53372d.png) | ![スクリーンショット 2022-08-10 14 52 22](https://user-images.githubusercontent.com/42470015/183825847-586542eb-398c-4e5d-b5c3-e9dd86e16582.png) | ![スクリーンショット 2022-08-10 14 52 28](https://user-images.githubusercontent.com/42470015/183825880-06209c18-76ad-4a64-92f2-acc3d2937281.png) | ![スクリーンショット 2022-08-10 14 52 34](https://user-images.githubusercontent.com/42470015/183825914-171fd71a-4e23-4877-a0fa-f37d78b75b8d.png) |

上記の例ではTriggerボタンに対して右側にMenuを開いていますが、左に開くことも可能です
また、SP時は問答無用でTriggerボタンに対して下に開かれます（MenuがTriggerボタンに対して右揃えなのか左揃えなのかは、positionの値に依存します）

| `position` = `left`時 | SP時 |
| -- | -- |
| ![スクリーンショット 2022-08-10 14 54 24](https://user-images.githubusercontent.com/42470015/183826172-ae25033a-9203-42e9-9519-c7e75bcec628.png) | ![スクリーンショット 2022-08-10 14 52 49](https://user-images.githubusercontent.com/42470015/183826208-3853403d-0e98-4b05-8404-576c5389bf0c.png) |

## 詳細
詳細な仕様については、Experimental Features docs, a11y要件定義docsにまとめているので、そちらをご覧ください（Slackの通知スレに貼ります）

## レビュー完了希望日
DropdownMenuを使う予定の施策が2つ存在するため、8/17(水)に完了できると嬉しいです

## TODO
- [x] 最後にcommitをまとめます
- [x] 最後にbundlesizeを調整します
- [x] （仕様変更等があった場合は）最後にdocsを最新状態にします