### PR TITLE
chore(deps): add eslint-plugin-react-hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
     "prettier"
   ],
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint": "7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^7.0.2",
     "is-ci": "^3.0.0",
     "lerna": "^5.0.0",

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.tsx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.tsx
@@ -17,10 +17,6 @@ const ITEM_LINK_CLASS_NAME = 'js-auto-play-carousel-item-link';
 export const HeroCarousel: FC<Props> = React.memo(function HeroCarousel({
   carouselList,
 }) {
-  if (carouselList.length === 0) {
-    return null;
-  }
-
   const {
     handleSlideToPrev,
     handleSlideToNext,
@@ -41,6 +37,10 @@ export const HeroCarousel: FC<Props> = React.memo(function HeroCarousel({
     items: carouselList,
     itemLinkClassName: ITEM_LINK_CLASS_NAME,
   });
+
+  if (carouselList.length === 0) {
+    return null;
+  }
 
   return (
     <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11287,6 +11287,11 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react@7.30.1:
   version "7.30.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz#2be4ab23ce09b5949c6631413ba64b2810fd3e22"


### PR DESCRIPTION
ESLintプラグインの[`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks)を追加しました。

これにはhooksの依存の整合性を検知する`react-hooks/exhaustive-deps`などのルールが含まれており、実装レビュー時の見落としを防ぐために導入します。

`react-hooks/rules-of-hooks`によるError1件のみ、変更内容が軽微でもあるためコンポーネントの修正を追加しています：https://github.com/openameba/spindle/commit/d1b3eea6a7bf3be8549e3b48020b2b5062228955

そのほか`react-hooks/exhaustive-deps`によるWarningが複数発生しますが、この修正は差分が大きくなるほか、コンポーネントの機能に関わる可能性もあるため、別PRで対応することにします。