### PR TITLE
fix(deps): revert version of react-merge-refs to v1

### DIFF
--- a/packages/spindle-ui/jest.config.js
+++ b/packages/spindle-ui/jest.config.js
@@ -5,12 +5,5 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  transformIgnorePatterns: ['/node_modules/(?!@testing-library/jest-dom)/'],
   testEnvironment: 'jest-environment-jsdom',
-  preset: 'ts-jest/presets/default-esm',
-  globals: {
-    'ts-jest': {
-      useESM: true,
-    },
-  },
 };

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -13,7 +13,7 @@
     "lint": "yarn lint:style",
     "lint:style": "stylelint '**/*.css'",
     "fix": "yarn lint:style --fix",
-    "test:interaction": "node --experimental-vm-modules node_modules/.bin/jest",
+    "test:interaction": "jest",
     "prebundlesize": "yarn build",
     "bundlesize": "npx bundlesize",
     "dev": "yarn storybook:start",

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "ameba-color-palette.css": "^4.8.0",
-    "react-merge-refs": "^2.0.0"
+    "react-merge-refs": "^1.1.0"
   },
   "devDependencies": {
     "@mdx-js/react": "^1.6.22",

--- a/packages/spindle-ui/src/Dialog/Dialog.tsx
+++ b/packages/spindle-ui/src/Dialog/Dialog.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { ButtonGroup as Group } from '../ButtonGroup';
 
 interface DialogProps extends React.DialogHTMLAttributes<HTMLElement> {

--- a/packages/spindle-ui/src/Form/DropDown.tsx
+++ b/packages/spindle-ui/src/Form/DropDown.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 
 import { ChevronDownBold } from '../Icon';
 

--- a/packages/spindle-ui/src/Form/InlineDropDown.tsx
+++ b/packages/spindle-ui/src/Form/InlineDropDown.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 
 import { ChevronDownBold } from '../Icon';
 

--- a/packages/spindle-ui/src/Modal/AppealModal.tsx
+++ b/packages/spindle-ui/src/Modal/AppealModal.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { ButtonGroup as Group } from '../ButtonGroup';
 import { CrossBold } from '../Icon';
 import { IconButton } from '../IconButton';

--- a/packages/spindle-ui/tsconfig.json
+++ b/packages/spindle-ui/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "node",
     "lib": [
       "DOM"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -21177,10 +21177,10 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-merge-refs@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-2.0.1.tgz#a1f8c2dadefa635333e9b91ec59f30b65228b006"
-  integrity sha512-pywF6oouJWuqL26xV3OruRSIqai31R9SdJX/I3gP2q8jLxUnA1IwXcLW8werUHLZOrp4N7YOeQNZrh/BKrHI4A==
+react-merge-refs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
+  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
 react-refresh@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
https://github.com/openameba/spindle/pull/477 こちらのPRの取り戻しです

ESMのみの対応になったことで、ESM未対応のプロダクトで利用する際に問題があったため、暫定対応としてパッケージのバージョンを元に戻します

改めてバージョンを上げる際には、ESMのパッケージはCJSにトランスパイルして配信するか、利用側のESM対応が前提である場合とします

ref：https://github.com/openameba/spindle/pull/477#issuecomment-1231077349