### PR TITLE
fix(spindle-theme-switch): expand tap area

### DIFF
--- a/packages/spindle-theme-switch/README.md
+++ b/packages/spindle-theme-switch/README.md
@@ -37,7 +37,7 @@
     }
   </style>
   <!-- type=moduleを指定してスクリプトを読み込みます -->
-  <script src="https://unpkg.com/@openameba/spindle-theme-switch/spindle-theme-switch.js" type="module"></script>
+  <script src="https://unpkg.com/@openameba/spindle-theme-switch/dist/spindle-theme-switch.js" type="module"></script>
 </head>
 
 <body>
@@ -53,7 +53,7 @@
 - `legend` (Optional): ラジオボタンで構成されているテーマスイッチにタイトルを設定します。
 - `permanent` (Optional): テーマの変更をLocal Storageに保存し、再表示時に保存されたテーマを適用します。
 
-NOTE: 「スイッチなのになぜ`appearance=switch`を指定するの？」いい質問ですね。Custom Elements内で固定したいのですが、適切に指定できる場所がなく(constructorで属性を設定するとエラーになります)、Custom Elementsのデータフローに則って属性値として指定するのがよさそうなんです。
+NOTE: 「スイッチなのになぜ`appearance=switch`を指定するの？」いい質問ですね。Custom Elements内で固定したいのですが、適切に指定できる場所がなく(constructorで属性を設定するとエラーになります)、Custom Elementsのデータフローに則って属性値として指定するのがよさそうなんです。なお、現時点の実装では指定しなくても動作しますが、今後意図した動作にならない可能性があります。
 
 ## 型定義の利用
 `<spindle-theme-switch>`を拡張する場合には以下のようにして、定義された型を利用できます。

--- a/packages/spindle-theme-switch/src/spindle-theme-switch.ts
+++ b/packages/spindle-theme-switch/src/spindle-theme-switch.ts
@@ -97,6 +97,10 @@ export class SpindleThemeSwitch extends DarkModeToggle {
         right: 0;
       }
 
+      [part=lightLabel]::after {
+        z-index: 2;
+      }
+
       input:focus + label {
         border-radius: 40px;
         outline: 2px solid var(--light-mode-focus-outline-color);
@@ -132,12 +136,13 @@ export class SpindleThemeSwitch extends DarkModeToggle {
       [part=darkRadio]:checked ~ [part=toggleLabel] {
         background: var(--dark-mode-checked-background);
         transform: translate(0, 0);
+        z-index: 1;
       }
 
       [part=aside] {
         display: none;
       }
-      
+
       @media (prefers-reduced-motion: reduce) {
         [part=toggleLabel] {
           transition-duration: 0.1ms;

--- a/packages/spindle-theme-switch/src/spindle-theme-switch.ts
+++ b/packages/spindle-theme-switch/src/spindle-theme-switch.ts
@@ -97,10 +97,6 @@ export class SpindleThemeSwitch extends DarkModeToggle {
         right: 0;
       }
 
-      [part=lightLabel]::after {
-        z-index: 2;
-      }
-
       input:focus + label {
         border-radius: 40px;
         outline: 2px solid var(--light-mode-focus-outline-color);


### PR DESCRIPTION
ダークテーマ選択時に[タップエリアを広げる処理](https://github.com/openameba/a11y-guidelines/pull/260)が動作していなかったため、修正しました。

本PRではできるだけ範囲を絞り「ダークテーマ選択時のみタップエリアの要素を選択中を表す背景要素より上にする」対応をしています。いくつか改善方法がありそうなので、提案絶賛募集中です 🐗 

対応前: https://ameba-spindle-theme-switch.web.app/

https://user-images.githubusercontent.com/869023/187384899-6b702a3c-44ec-48ca-9951-9b3fb34cec95.mov

対応後: https://ameba-spindle-theme-switch--pr520-fix-switch-1kn7zyh2.web.app/

https://user-images.githubusercontent.com/869023/187384992-c316cb03-254b-427c-a281-d4c37d5740e3.mov


