### PR TITLE
feat(spindle-ui): add Breadcrumb variants

### DIFF
--- a/packages/spindle-ui/CHANGELOG.md
+++ b/packages/spindle-ui/CHANGELOG.md
@@ -40,6 +40,22 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **spindle-ui:** create BottomButton ([b02b4d8](https://github.com/openameba/spindle/commit/b02b4d8a1bad595d5e4772f2fcf803e543cbfcb6))
 
 
+## [0.47.1-alpha.0](https://github.com/openameba/spindle/compare/@openameba/spindle-ui@0.47.0...@openameba/spindle-ui@0.47.1-alpha.0) (2022-10-05)
+
+
+### Features
+
+* **spindle-ui:** create BottomButton ([b02b4d8](https://github.com/openameba/spindle/commit/b02b4d8a1bad595d5e4772f2fcf803e543cbfcb6))
+* **spindle-ui:** add Breadcrumb variants ([e0a8a1f](https://github.com/openameba/spindle/commit/e0a8a1f5ae5cfd0dad3e06ab594d397f84b7f1ce))
+* **spindle-ui:** add wrap option to Breadcrumb ([b925471](https://github.com/openameba/spindle/commit/b925471284922e180a2b6bbdfba6deb9aca17f8c))
+* **spindle-ui:** scrollable breadcrumb ([d85cb2e](https://github.com/openameba/spindle/commit/d85cb2ecc984eb25671bf40422f988d73ef4b228))
+
+
+### BREAKING CHANGES
+
+* **spindle-ui:** the default variant is changed.
+
+
 
 
 

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -3,34 +3,53 @@
 */
 .spui-Breadcrumb {
   overflow: scroll hidden;
+}
+
+.spui-Breadcrumb--standard {
+  padding: 12px 0;
+  position: relative;
+}
+
+/* Display inner border */
+.spui-Breadcrumb--standard::before {
+  background: var(--color-border-low-emphasis);
+  bottom: 0;
+  content: '';
+  height: 1px;
+  position: absolute;
+  width: 100%;
+}
+
+.spui-Breadcrumb--emphasized .spui-Breadcrumb-list {
   background: var(--color-surface-secondary);
   border-radius: 70px;
-  display: inline-block;
-  overflow: scroll hidden;
-  padding: 0 16px;
 }
 
 .spui-Breadcrumb-list {
-  align-items: center;
   display: flex;
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 16px;
+  width: max-content;
 }
 
 .spui-Breadcrumb-item {
   align-items: center;
   display: flex;
-  min-height: 56px;
 }
 
 /* stylelint-disable plugin/selector-bem-pattern */
+.spui-Breadcrumb--emphasized .spui-Breadcrumb-item,
+.spui-Breadcrumb--emphasized a::before {
+  min-height: 44px;
+}
+
 .spui-Breadcrumb a {
   align-items: center;
   border-radius: 4px;
   display: flex;
-  letter-spacing: 0.1em;
-  line-height: 1.3;
+  font-size: 0.875em;
+  line-height: 1.4;
   padding: 4px 8px;
   position: relative;
   text-decoration: none;
@@ -50,7 +69,6 @@
   border-radius: 4px;
   content: '';
   left: 0;
-  min-height: 56px;
   position: absolute;
   top: -50%;
   width: 100%;
@@ -83,22 +101,19 @@
 }
 
 @media screen and (max-width: 768px) {
-  .spui-Breadcrumb {
+  .spui-Breadcrumb-list {
     padding: 0 14px;
   }
 
-  .spui-Breadcrumb-item {
-    min-height: 40px;
+  /* stylelint-disable plugin/selector-bem-pattern */
+  .spui-Breadcrumb--emphasized .spui-Breadcrumb-item,
+  .spui-Breadcrumb--emphasized a::before {
+    min-height: 36px;
   }
 
-  /* stylelint-disable plugin/selector-bem-pattern */
   .spui-Breadcrumb a {
     font-size: 0.8125em;
     padding: 2px 6px;
-  }
-
-  .spui-Breadcrumb a:not([aria-current])::before {
-    min-height: 40px;
   }
   /* stylelint-enable plugin/selector-bem-pattern */
 

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -74,6 +74,7 @@
   font-weight: normal;
 }
 
+/* To expand tap area */
 .spui-Breadcrumb a::before {
   border-radius: 4px;
   content: '';

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -24,17 +24,21 @@
   width: 100%;
 }
 
-.spui-Breadcrumb--emphasized .spui-Breadcrumb-list {
-  background: var(--color-surface-secondary);
-  border-radius: 70px;
-}
-
 .spui-Breadcrumb-list {
   display: flex;
   list-style: none;
   margin: 0;
-  padding: 0 16px;
   width: max-content;
+}
+
+.spui-Breadcrumb--standard .spui-Breadcrumb-list {
+  padding: 0;
+}
+
+.spui-Breadcrumb--emphasized .spui-Breadcrumb-list {
+  background: var(--color-surface-secondary);
+  border-radius: 70px;
+  padding: 0 16px;
 }
 
 .spui-Breadcrumb--standard.spui-Breadcrumb--wrap .spui-Breadcrumb-list {
@@ -91,6 +95,11 @@
 .spui-Breadcrumb a:focus {
   outline: 2px solid var(--color-focus-clarity);
   outline-offset: 1px;
+}
+
+/* To avoid overflow, standard variant has no padding */
+.spui-Breadcrumb--standard a:focus {
+  outline-offset: -2px;
 }
 
 .spui-Breadcrumb a:focus:not(:focus-visible) {

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -2,7 +2,7 @@
  * Breadcrumb
 */
 .spui-Breadcrumb {
-  overflow: scroll hidden;
+  overflow: auto hidden;
 }
 
 .spui-Breadcrumb--wrap {

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -2,10 +2,11 @@
  * Breadcrumb
 */
 .spui-Breadcrumb {
+  overflow: scroll hidden;
   background: var(--color-surface-secondary);
   border-radius: 70px;
   display: inline-block;
-  overflow: hidden;
+  overflow: scroll hidden;
   padding: 0 16px;
 }
 

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -99,6 +99,7 @@
 /* stylelint-enable plugin/selector-bem-pattern */
 
 .spui-Breadcrumb-chevron {
+  box-sizing: content-box;
   color: var(--color-object-low-emphasis);
   height: 16px;
   padding: 0 4px;

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -5,6 +5,10 @@
   overflow: scroll hidden;
 }
 
+.spui-Breadcrumb--wrap {
+  overflow: hidden;
+}
+
 .spui-Breadcrumb--standard {
   padding: 12px 0;
   position: relative;
@@ -31,6 +35,11 @@
   margin: 0;
   padding: 0 16px;
   width: max-content;
+}
+
+.spui-Breadcrumb--standard.spui-Breadcrumb--wrap .spui-Breadcrumb-list {
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .spui-Breadcrumb-item {
@@ -114,6 +123,11 @@
   .spui-Breadcrumb a {
     font-size: 0.8125em;
     padding: 2px 6px;
+  }
+
+  .spui-Breadcrumb--standard.spui-Breadcrumb--wrap a {
+    padding-bottom: 4px;
+    padding-top: 4px;
   }
   /* stylelint-enable plugin/selector-bem-pattern */
 

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.css
@@ -14,16 +14,6 @@
   position: relative;
 }
 
-/* Display inner border */
-.spui-Breadcrumb--standard::before {
-  background: var(--color-border-low-emphasis);
-  bottom: 0;
-  content: '';
-  height: 1px;
-  position: absolute;
-  width: 100%;
-}
-
 .spui-Breadcrumb-list {
   display: flex;
   list-style: none;

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
@@ -28,7 +28,7 @@ import { BreadcrumbItem } from './BreadcrumbItem';
 
 <Preview withSource="open">
   <Story name="BreadcrumbList">
-    <BreadcrumbList>
+    <BreadcrumbList variant="emphasized">
       <BreadcrumbItem href="#">Top</BreadcrumbItem>
       <BreadcrumbItem href="#">Team</BreadcrumbItem>
       <BreadcrumbItem href="#" current>Amebaとは</BreadcrumbItem>
@@ -40,7 +40,7 @@ import { BreadcrumbItem } from './BreadcrumbItem';
 
 <Source
   code={`
-<BreadcrumbList>
+<BreadcrumbList variant="emphasized">
   <BreadcrumbItem href="#">Top</BreadcrumbItem>
   <BreadcrumbItem href="#">Team</BreadcrumbItem>
   <BreadcrumbItem href="#" current>Amebaとは</BreadcrumbItem>
@@ -65,7 +65,7 @@ import { BreadcrumbItem } from './BreadcrumbItem';
 
 <Preview withSource="open">
   <Story name="BreadcrumbList Without BreadcrumbItem">
-    <BreadcrumbList>
+    <BreadcrumbList variant="emphasized">
       <a href="#">Top</a>
       <a href="#">Team</a>
       <a href="#" aria-current="page">Amebaとは</a>
@@ -73,14 +73,112 @@ import { BreadcrumbItem } from './BreadcrumbItem';
   </Story>
 </Preview>
 
-`<BreadcrumbItem>`を使わず、直接`<a>`要素を指定することもできます。`<Link>`も同様に指定できます。その際には、現在地となるa要素にaria-current属性を付与してください。
+`<BreadcrumbItem>`を使わず、直接`<a>`要素を指定することもできます。各種フレームワークで定義された`<Link>`も同様に指定できます。その際には、現在地となるa要素にaria-current属性を付与してください。
 
 <Source
   code={`
-<BreadcrumbList>
+<BreadcrumbList variant="emphasized">
   <a href="#">Top</a>
   <a href="#">Team</a>
   <a href="#" aria-current="page">Amebaとは</a>
+</BreadcrumbList>
+  `}
+/>
+
+## Variant
+
+### Standard
+
+<Preview withSource="open">
+  <Story name="Standard">
+    <BreadcrumbList variant="standard">
+      <BreadcrumbItem href="#">Top</BreadcrumbItem>
+      <BreadcrumbItem href="#">Team</BreadcrumbItem>
+      <BreadcrumbItem href="#" current>Amebaとは</BreadcrumbItem>
+    </BreadcrumbList>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<BreadcrumbList variant="standard">
+  <BreadcrumbItem href="#">Top</BreadcrumbItem>
+  <BreadcrumbItem href="#">Team</BreadcrumbItem>
+  <BreadcrumbItem href="#" current>Amebaとは</BreadcrumbItem>
+</BreadcrumbList>
+  `}
+/>
+
+### Emphasized
+
+<Preview withSource="open">
+  <Story name="Emphasized">
+    <BreadcrumbList variant="emphasized">
+      <BreadcrumbItem href="#">Top</BreadcrumbItem>
+      <BreadcrumbItem href="#">Team</BreadcrumbItem>
+      <BreadcrumbItem href="#" current>Amebaとは</BreadcrumbItem>
+    </BreadcrumbList>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<BreadcrumbList variant="emphasized">
+  <BreadcrumbItem href="#">Top</BreadcrumbItem>
+  <BreadcrumbItem href="#">Team</BreadcrumbItem>
+  <BreadcrumbItem href="#" current>Amebaとは</BreadcrumbItem>
+</BreadcrumbList>
+  `}
+/>
+
+## Wrap
+
+Standard variantにwrapオプションを指定すると、画面幅に入り切らなくなったタイミングで折り返されます。
+
+<Preview withSource="open">
+  <Story name="Wrap">
+    <BreadcrumbList variant="standard" wrap="wrap">
+      <BreadcrumbItem href="#">Amebaとは</BreadcrumbItem>
+      <BreadcrumbItem href="#">Ameヨコ (アメヨコ)</BreadcrumbItem>
+      <BreadcrumbItem href="#">福利厚生・社内制度</BreadcrumbItem>
+      <BreadcrumbItem href="#" current>「わたしたち、育休取得した経営陣です！」育休が2秒で快諾される、"取るのが当たり前"な環境とは</BreadcrumbItem>
+    </BreadcrumbList>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<BreadcrumbList variant="standard" wrap="wrap">
+  <BreadcrumbItem href="#">Amebaとは</BreadcrumbItem>
+  <BreadcrumbItem href="#">Ameヨコ (アメヨコ)</BreadcrumbItem>
+  <BreadcrumbItem href="#">福利厚生・社内制度</BreadcrumbItem>
+  <BreadcrumbItem href="#" current>「わたしたち、育休取得した経営陣です！」育休が2秒で快諾される、"取るのが当たり前"な環境とは</BreadcrumbItem>
+</BreadcrumbList>
+  `}
+/>
+
+## Scroll Management
+
+コンテンツが長く、見切れた場合にはcurrent指定されているアイテムが画面内に表示されるようにスクロールします。
+
+<Preview withSource="open">
+  <Story name="Standard Overflow">
+    <BreadcrumbList variant="standard">
+      <BreadcrumbItem href="#">Amebaとは</BreadcrumbItem>
+      <BreadcrumbItem href="#">Ameヨコ (アメヨコ)</BreadcrumbItem>
+      <BreadcrumbItem href="#">福利厚生・社内制度</BreadcrumbItem>
+      <BreadcrumbItem href="#" current>「わたしたち、育休取得した経営陣です！」育休が2秒で快諾される、"取るのが当たり前"な環境とは</BreadcrumbItem>
+    </BreadcrumbList>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<BreadcrumbList variant="standard">
+  <BreadcrumbItem href="#">Amebaとは</BreadcrumbItem>
+  <BreadcrumbItem href="#">Ameヨコ (アメヨコ)</BreadcrumbItem>
+  <BreadcrumbItem href="#">福利厚生・社内制度</BreadcrumbItem>
+  <BreadcrumbItem href="#" current>「わたしたち、育休取得した経営陣です！」育休が2秒で快諾される、"取るのが当たり前"な環境とは</BreadcrumbItem>
 </BreadcrumbList>
   `}
 />

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
@@ -18,7 +18,7 @@ export const BreadcrumbList = (props: Props) => {
   const currentRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
-    currentRef?.current?.scrollIntoView();
+    currentRef.current?.scrollIntoView();
   }, []);
 
   return (

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ChevronRightBold from '../Icon/ChevronRightBold';
 
 interface Props extends React.HTMLAttributes<HTMLElement> {
@@ -9,6 +9,12 @@ const BLOCK_NAME = 'spui-Breadcrumb';
 
 export const BreadcrumbList = (props: Props) => {
   const { children, className, ...rest } = props;
+  const currentRef = useRef<HTMLLIElement>(null);
+
+  useEffect(() => {
+    currentRef?.current?.scrollIntoView();
+  }, []);
+
   return (
     <nav
       aria-label="パンくずリスト"
@@ -18,7 +24,12 @@ export const BreadcrumbList = (props: Props) => {
       <ol className={`${BLOCK_NAME}-list`}>
         {React.Children.map(children, (child) => {
           return React.isValidElement(child) ? (
-            <li className={`${BLOCK_NAME}-item`}>
+            <li
+              className={`${BLOCK_NAME}-item`}
+              {...(child.props.current || child.props['aria-current']
+                ? { ref: currentRef }
+                : {})}
+            >
               {child}
               <ChevronRightBold
                 aria-hidden="true"

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
@@ -3,16 +3,18 @@ import ChevronRightBold from '../Icon/ChevronRightBold';
 import ChevronRight from '../Icon/ChevronRight';
 
 type Variant = 'standard' | 'emphasized';
+type Wrap = 'wrap';
 
 interface Props extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
   variant?: Variant;
+  wrap?: Wrap;
 }
 
 const BLOCK_NAME = 'spui-Breadcrumb';
 
 export const BreadcrumbList = (props: Props) => {
-  const { children, className, variant = 'standard', ...rest } = props;
+  const { children, className, variant = 'standard', wrap, ...rest } = props;
   const currentRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
@@ -22,7 +24,12 @@ export const BreadcrumbList = (props: Props) => {
   return (
     <nav
       aria-label="パンくずリスト"
-      className={[BLOCK_NAME, `${BLOCK_NAME}--${variant}`, className]
+      className={[
+        BLOCK_NAME,
+        `${BLOCK_NAME}--${variant}`,
+        wrap && `${BLOCK_NAME}--${wrap}`,
+        className,
+      ]
         .filter(Boolean)
         .join(' ')
         .trim()}

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
@@ -1,14 +1,18 @@
 import React, { useEffect, useRef } from 'react';
 import ChevronRightBold from '../Icon/ChevronRightBold';
+import ChevronRight from '../Icon/ChevronRight';
+
+type Variant = 'standard' | 'emphasized';
 
 interface Props extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
+  variant?: Variant;
 }
 
 const BLOCK_NAME = 'spui-Breadcrumb';
 
 export const BreadcrumbList = (props: Props) => {
-  const { children, className, ...rest } = props;
+  const { children, className, variant = 'standard', ...rest } = props;
   const currentRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
@@ -18,7 +22,10 @@ export const BreadcrumbList = (props: Props) => {
   return (
     <nav
       aria-label="パンくずリスト"
-      className={[BLOCK_NAME, className].join(' ').trim()}
+      className={[BLOCK_NAME, `${BLOCK_NAME}--${variant}`, className]
+        .filter(Boolean)
+        .join(' ')
+        .trim()}
       {...rest}
     >
       <ol className={`${BLOCK_NAME}-list`}>
@@ -31,10 +38,17 @@ export const BreadcrumbList = (props: Props) => {
                 : {})}
             >
               {child}
-              <ChevronRightBold
-                aria-hidden="true"
-                className={`${BLOCK_NAME}-chevron`}
-              />
+              {variant === 'standard' ? (
+                <ChevronRight
+                  aria-hidden="true"
+                  className={`${BLOCK_NAME}-chevron`}
+                />
+              ) : (
+                <ChevronRightBold
+                  aria-hidden="true"
+                  className={`${BLOCK_NAME}-chevron`}
+                />
+              )}
             </li>
           ) : null;
         })}


### PR DESCRIPTION
Breadcrumbに新しいvariantが追加されたので対応しました。この変更によりdefault variantが変更されるため、Breaking changeとなります。

## 変更点
- VariantがStandardとEmphasizedの2種類になりました
- overflowした部分はスクロール表示になりました
- overflowした場合には、現在地(current)がviewport内に表示されます
- Standardにwrapオプションを指定すると折返します

![Standard](https://user-images.githubusercontent.com/869023/193188999-1097fe8a-5114-4aac-b9bd-074f07d4c290.png)
![Standard x wrap](https://user-images.githubusercontent.com/869023/193189045-f1fd446d-6ede-4f17-a4c3-6ef0138e1298.png)
![Emphasized](https://user-images.githubusercontent.com/869023/193189068-2be73125-2f1a-467a-b54a-24cb0f4358ba.png)

