### PR TITLE
Expand dropdown menu

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -9,7 +9,7 @@
       "maxSize": "1.1 kB"
     },
     {
-      "path": "./dist/!(Icon|Toast|Modal|SnackBar|StackNotificationManager)/*.mjs",
+      "path": "./dist/!(Icon|Toast|DropdownMenu|Modal|SnackBar|StackNotificationManager)/*.mjs",
       "maxSize": "1.1 kB"
     },
     {
@@ -22,6 +22,10 @@
     },
     {
       "path": "./dist/Toast/*.mjs",
+      "maxSize": "1.5 kB"
+    },
+    {
+      "path": "./dist/DropdownMenu/*.mjs",
       "maxSize": "1.5 kB"
     },
     {

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.css
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.css
@@ -18,12 +18,10 @@
   border-radius: 12px;
   box-shadow: 0px 11px 28px rgba(8, 18, 26, 0.12);
   box-sizing: border-box;
-  left: -256px;
   list-style: none;
   margin: 0;
   padding: 12px 0;
   position: absolute;
-  top: 0;
   width: 256px;
   z-index: var(--DropdownMenu-z-index);
 }
@@ -34,10 +32,50 @@
   opacity: 0;
 }
 
-.spui-DropdownMenu-menu--right {
-  left: auto;
-  right: -256px;
-  width: 256px;
+.spui-DropdownMenu-menu--topLeft,
+.spui-DropdownMenu-menu--topCenter,
+.spui-DropdownMenu-menu--topRight {
+  margin-bottom: 8px;
+}
+
+.spui-DropdownMenu-menu--bottomLeft,
+.spui-DropdownMenu-menu--bottomCenter,
+.spui-DropdownMenu-menu--bottomRight {
+  margin-top: 8px;
+}
+
+.spui-DropdownMenu-menu--topLeft,
+.spui-DropdownMenu-menu--bottomLeft {
+  left: 0;
+}
+
+.spui-DropdownMenu-menu--topRight,
+.spui-DropdownMenu-menu--bottomRight {
+  right: 0;
+}
+
+.spui-DropdownMenu-menu--rightTop,
+.spui-DropdownMenu-menu--rightCenter,
+.spui-DropdownMenu-menu--rightBottom {
+  /* Menuの横幅256px + margin8px */
+  right: -264px;
+}
+
+.spui-DropdownMenu-menu--leftTop,
+.spui-DropdownMenu-menu--leftCenter,
+.spui-DropdownMenu-menu--leftBottom {
+  /* Menuの横幅256px + margin8px */
+  left: -264px;
+}
+
+.spui-DropdownMenu-menu--rightTop,
+.spui-DropdownMenu-menu--leftTop {
+  top: 0;
+}
+
+.spui-DropdownMenu-menu--rightBottom,
+.spui-DropdownMenu-menu--leftBottom {
+  bottom: 0;
 }
 
 .spui-DropdownMenu-menuButton {
@@ -130,15 +168,23 @@
 }
 
 @media screen and (max-width: 768px) {
-  .spui-DropdownMenu-menu {
-    left: auto;
-    right: 0;
-    top: auto;
+  .spui-DropdownMenu-menu--rightTop,
+  .spui-DropdownMenu-menu--rightCenter,
+  .spui-DropdownMenu-menu--rightBottom {
+    bottom: auto;
+    left: 0;
+    margin-top: 8px;
+    top: auto !important;
   }
 
-  .spui-DropdownMenu-menu--right {
-    left: 0;
-    top: auto;
+  .spui-DropdownMenu-menu--leftTop,
+  .spui-DropdownMenu-menu--leftCenter,
+  .spui-DropdownMenu-menu--leftBottom {
+    bottom: auto;
+    left: auto;
+    margin-top: 8px;
+    right: 0;
+    top: auto !important;
   }
 }
 

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.example.tsx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.example.tsx
@@ -196,3 +196,219 @@ export function HeadWithIconAndCaption() {
     </div>
   );
 }
+
+// Storybookでのpositionプロパティのバリエーション確認用
+export function Position() {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <div
+        style={{
+          ['--DropdownMenu-z-index']: 2,
+          marginTop: 80,
+          marginLeft: 210,
+        }}
+      >
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="topRight" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>position: topRightを指定</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+      <div
+        style={{
+          ['--DropdownMenu-z-index']: 2,
+          marginTop: 90,
+          marginLeft: 105,
+        }}
+      >
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="topCenter" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>position: topCenterを指定</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+      <div style={{ ['--DropdownMenu-z-index']: 2, marginTop: 90 }}>
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="topLeft" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>position: topLeftを指定</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+
+      <div style={{ ['--DropdownMenu-z-index']: 2, marginTop: 20 }}>
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="rightTop" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>position: rightTopを指定</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+      <div style={{ ['--DropdownMenu-z-index']: 2, marginTop: 90 }}>
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="rightCenter" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>
+                position: rightCenterを指定
+              </DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+      <div style={{ ['--DropdownMenu-z-index']: 2, marginTop: 90 }}>
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="rightBottom" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>
+                position: rightBottomを指定
+              </DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+
+      <div
+        style={{
+          ['--DropdownMenu-z-index']: 2,
+          marginTop: 90,
+          marginLeft: 210,
+        }}
+      >
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="bottomRight" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>
+                position: bottomRightを指定
+              </DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+      <div
+        style={{
+          ['--DropdownMenu-z-index']: 2,
+          marginTop: 90,
+          marginLeft: 110,
+        }}
+      >
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position
+            position="bottomCenter"
+            triggerRef={triggerRef}
+          >
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>
+                position: bottomCenterを指定
+              </DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+      <div style={{ ['--DropdownMenu-z-index']: 2, marginTop: 90 }}>
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="bottomLeft" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>
+                position: bottomLeftを指定
+              </DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+
+      <div
+        style={{
+          ['--DropdownMenu-z-index']: 2,
+          marginTop: 90,
+          marginLeft: 265,
+        }}
+      >
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="leftTop" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>position: leftTopを指定</DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+      <div
+        style={{
+          ['--DropdownMenu-z-index']: 2,
+          marginTop: 90,
+          marginLeft: 265,
+        }}
+      >
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="leftCenter" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>
+                position: leftCenterを指定
+              </DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+      <div
+        style={{
+          ['--DropdownMenu-z-index']: 2,
+          marginTop: 90,
+          marginLeft: 265,
+        }}
+      >
+        <DropdownMenu.Frame>
+          <Button ref={triggerRef} size="medium" variant="neutral">
+            例
+          </Button>
+          <DropdownMenu.Position position="leftBottom" triggerRef={triggerRef}>
+            <DropdownMenu.ListItem {...actions('onClick')}>
+              <DropdownMenu.Title>
+                position: leftBottomを指定
+              </DropdownMenu.Title>
+            </DropdownMenu.ListItem>
+          </DropdownMenu.Position>
+        </DropdownMenu.Frame>
+      </div>
+    </>
+  );
+}

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.example.tsx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.example.tsx
@@ -32,7 +32,7 @@ export function Text() {
           id="dropdown-menu-example1"
           onClose={onClose}
           open={open}
-          position="right"
+          position="rightTop"
           triggerRef={triggerRef}
           variant="text"
         >
@@ -75,7 +75,7 @@ export function TextWithIcon() {
           id="dropdown-menu-example2"
           onClose={onClose}
           open={open}
-          position="right"
+          position="rightTop"
           triggerRef={triggerRef}
           variant="textWithIcon"
         >
@@ -124,7 +124,7 @@ export function HeadWithIcon() {
           id="dropdown-menu-example3"
           onClose={onClose}
           open={open}
-          position="right"
+          position="rightTop"
           triggerRef={triggerRef}
           variant="headWithIcon"
         >
@@ -173,7 +173,7 @@ export function HeadWithIconAndCaption() {
           id="dropdown-menu-example4"
           onClose={onClose}
           open={open}
-          position="right"
+          position="rightTop"
           triggerRef={triggerRef}
           variant="headWithIconAndCaption"
         >

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.mdx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.mdx
@@ -5,6 +5,7 @@ import {
   TextWithIcon,
   HeadWithIcon,
   HeadWithIconAndCaption,
+  Position,
 } from './DropdownMenu.stories.example';
 
 # DropdownMenu
@@ -288,3 +289,13 @@ return (
 );
   `}
 />
+
+## Position
+<Description>positionプロパティのバリエーション確認用です</Description>
+<Description>デフォルトはleftTopで、その他にもtopLeft, topCenter, topRight, rightTop, rightCenter, rightBottom, bottomLeft, bottomCenter, bottomRight, leftTop, leftCenter, leftBottomを指定することができます</Description>
+
+<Preview withSource="open">
+  <Story name="Position">
+    <Position />
+  </Story>
+</Preview>

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.mdx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.stories.mdx
@@ -11,17 +11,7 @@ import {
 
 <Meta title="DropdownMenu" component={DropdownMenu} />
 
-![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
-
-<Description>
-  - `DropdownMenu.List`は`open`プロパティの値を見て、開閉を行います。`onClick`や`onClose`内で`open`プロパティを変更してください
-</Description>
-<Description>
-  - DropdownMenuをボタンに対して左側に開くか右側に開くかは、`DropdownMenu.List`の`position`プロパティに指定してください。デフォルトは`left`です
-</Description>
-<Description>
-  - DropdownMenuのコンテンツの種類は、`DropdownMenu.List`の`variant`プロパティに指定してください。デフォルトは`text`です
-</Description>
+![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
 
 <Source
   language='javascript'
@@ -37,6 +27,35 @@ import {
   language='html'
   code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/DropdownMenu/DropdownMenu.css">`}
 />
+
+## 指定できるプロパティ
+### DropdownMenu.List
+<Description>
+  - `open`(必須): DropdownMenuの開閉状態です。DropdownMenuは`open`プロパティの値を見て開閉を行うため、`onClick`や`onClose`内で`open`プロパティを変更してください。
+</Description>
+<Description>
+  - `triggerRef`（必須）: Triggerボタンのrefを指定してください。
+</Description>
+<Description>
+  - `onClose`（必須）: `open`プロパティをfalseにするための処理を指定してください。
+</Description>
+<Description>
+  - `position`（任意）: DropdownMenuをボタンに対してどの位置に開くかを指定します。デフォルトは`leftTop`で、その他にも`topLeft`, `topCenter`, `topRight`, `rightTop`, `rightCenter`, `rightBottom`, `bottomLeft`, `bottomCenter`, `bottomRight`, `leftTop`, `leftCenter`, `leftBottom`を指定することができます。
+</Description>
+<Description>
+  - `variant`（任意）: DropdownMenuの種類を指定します。デフォルトは`text`で、その他にも`textWithIcon`, `headWithIcon`, `headWithIconAndCaption`を指定することができます。
+</Description>
+<Description>
+  - `id`（任意）: idを指定することができます。
+</Description>
+
+### DropdownMenu.ListItem
+<Description>
+  - `onClick`（必須）: `open`プロパティを変更するための処理を指定してください。
+</Description>
+<Description>
+  - `icon`（任意）: DropdownMenu内にアイコンを表示したい場合は、指定することができます。
+</Description>
 
 ## Text
 <Description>テキストのみのDropdownMenuです</Description>
@@ -74,7 +93,7 @@ return (
         id="dropdown-menu-example1"
         onClose={onClose}
         open={open}
-        position="right"
+        position="rightTop"
         triggerRef={triggerRef}
         variant="text"
       >
@@ -127,7 +146,7 @@ return (
         id="dropdown-menu-example2"
         onClose={onClose}
         open={open}
-        position="right"
+        position="rightTop"
         triggerRef={triggerRef}
         variant="textWithIcon"
       >
@@ -186,7 +205,7 @@ return (
         id="dropdown-menu-example3"
         onClose={onClose}
         open={open}
-        position="right"
+        position="rightTop"
         triggerRef={triggerRef}
         variant="headWithIcon"
       >
@@ -245,7 +264,7 @@ return (
         id="dropdown-menu-example4"
         onClose={onClose}
         open={open}
-        position="right"
+        position="rightTop"
         triggerRef={triggerRef}
         variant="headWithIconAndCaption"
       >

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.tsx
@@ -6,6 +6,20 @@ type Variant =
   | 'headWithIcon'
   | 'headWithIconAndCaption';
 
+type Position =
+  | 'topLeft'
+  | 'topCenter'
+  | 'topRight'
+  | 'rightTop'
+  | 'rightCenter'
+  | 'rightBottom'
+  | 'bottomLeft'
+  | 'bottomCenter'
+  | 'bottomRight'
+  | 'leftTop'
+  | 'leftCenter'
+  | 'leftBottom';
+
 interface DefaultProps {
   children: React.ReactNode;
 }
@@ -19,7 +33,7 @@ interface ListProps extends DefaultProps {
   id?: string;
   onClose: () => void;
   open: boolean;
-  position?: 'left' | 'right';
+  position?: Position;
   triggerRef: React.RefObject<HTMLButtonElement>;
   variant?: Variant;
 }
@@ -27,6 +41,7 @@ interface ListProps extends DefaultProps {
 export const BLOCK_NAME = 'spui-DropdownMenu';
 const FADE_IN_ANIMATION = 'spui-DropdownMenu-fade-in';
 const CLOSE_KEY_LIST = ['Escape', 'Esc'];
+const MENU_WIDTH = 256;
 
 const Caption = ({ children }: DefaultProps) => {
   return <p className={`${BLOCK_NAME}-caption`}>{children}</p>;
@@ -41,12 +56,15 @@ const List = ({
   id,
   onClose,
   open,
-  position = 'left',
+  position = 'leftTop',
   triggerRef,
   variant = 'text',
 }: ListProps) => {
   const menuEl = useRef<HTMLUListElement>(null);
   const [fadeOut, setFadeOut] = useState(false);
+  const [triggerHeight, setTriggerHeight] = useState(0);
+  const [triggerWidth, setTriggerWidth] = useState(0);
+  const [menuHeight, setMenuHeight] = useState(0);
 
   const onClickBody = useCallback(
     (e: MouseEvent) => {
@@ -85,6 +103,24 @@ const List = ({
     [onClose, setFadeOut],
   );
 
+  // Triggerボタンの縦横幅を取得
+  useEffect(() => {
+    if (!triggerRef.current) return;
+
+    const { height, width } = triggerRef.current.getBoundingClientRect();
+    setTriggerHeight(height);
+    setTriggerWidth(width);
+  }, [triggerRef]);
+
+  // Menuの縦幅を取得
+  useEffect(() => {
+    if (!open) return;
+    if (!menuEl.current) return;
+
+    const { height } = menuEl.current.getBoundingClientRect();
+    setMenuHeight(height);
+  }, [open]);
+
   useEffect(() => {
     const menu = menuEl.current;
     menu?.addEventListener('animationend', handleAnimationEnd, false);
@@ -113,6 +149,22 @@ const List = ({
     return <></>;
   }
 
+  let top;
+  let bottom;
+  let left;
+  if (['topLeft', 'topCenter', 'topRight'].includes(position)) {
+    bottom = `${triggerHeight}px`;
+  }
+  if (['topCenter', 'bottomCenter'].includes(position)) {
+    left = `-${(MENU_WIDTH - triggerWidth) / 2}px`;
+  }
+  if (['rightCenter', 'leftCenter'].includes(position)) {
+    top = `-${(menuHeight - triggerHeight) / 2}px`;
+  }
+  if (['bottomLeft', 'bottomCenter', 'bottomRight'].includes(position)) {
+    top = `${triggerHeight}px`;
+  }
+
   return (
     <ul
       id={id}
@@ -120,13 +172,14 @@ const List = ({
       className={[
         `${BLOCK_NAME}-menu`,
         `${BLOCK_NAME}-menu--${variant}`,
-        position === 'right' && `${BLOCK_NAME}-menu--right`,
+        `${BLOCK_NAME}-menu--${position}`,
         fadeOut && 'is-fade-out',
       ]
         .filter(Boolean)
         .join(' ')}
       ref={menuEl}
       role="menu"
+      style={{ bottom, left, top }}
     >
       {children}
     </ul>

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.tsx
@@ -197,6 +197,68 @@ const ListItem = ({ children, icon, onClick }: ListItemProps) => {
   );
 };
 
+// Storybookでのpositionプロパティのバリエーション確認用
+const Position = ({
+  children,
+  position = 'leftTop',
+  triggerRef,
+}: Omit<ListProps, 'onClose' | 'open'>) => {
+  const menuEl = useRef<HTMLUListElement>(null);
+  const [triggerHeight, setTriggerHeight] = useState(0);
+  const [triggerWidth, setTriggerWidth] = useState(0);
+  const [menuHeight, setMenuHeight] = useState(0);
+
+  // Triggerボタンの縦横幅を取得
+  useEffect(() => {
+    if (!triggerRef.current) return;
+
+    const { height, width } = triggerRef.current.getBoundingClientRect();
+    setTriggerHeight(height);
+    setTriggerWidth(width);
+  }, [triggerRef]);
+
+  // Menuの縦幅を取得
+  useEffect(() => {
+    if (!menuEl.current) return;
+
+    const { height } = menuEl.current.getBoundingClientRect();
+    setMenuHeight(height);
+  }, []);
+
+  let top;
+  let bottom;
+  let left;
+  if (['topLeft', 'topCenter', 'topRight'].includes(position)) {
+    bottom = `${triggerHeight}px`;
+  }
+  if (['topCenter', 'bottomCenter'].includes(position)) {
+    left = `-${(MENU_WIDTH - triggerWidth) / 2}px`;
+  }
+  if (['rightCenter', 'leftCenter'].includes(position)) {
+    top = `-${(menuHeight - triggerHeight) / 2}px`;
+  }
+  if (['bottomLeft', 'bottomCenter', 'bottomRight'].includes(position)) {
+    top = `${triggerHeight}px`;
+  }
+
+  return (
+    <ul
+      className={[
+        `${BLOCK_NAME}-menu`,
+        `${BLOCK_NAME}-menu--text`,
+        `${BLOCK_NAME}-menu--${position}`,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      ref={menuEl}
+      role="menu"
+      style={{ bottom, left, top }}
+    >
+      {children}
+    </ul>
+  );
+};
+
 const Title = ({ children }: DefaultProps) => {
   return <p className={`${BLOCK_NAME}-title`}>{children}</p>;
 };
@@ -206,5 +268,6 @@ export const DropdownMenu = {
   Frame,
   List,
   ListItem,
+  Position,
   Title,
 };


### PR DESCRIPTION
## 概要
https://github.com/openameba/spindle/pull/502 で実装したDropdownMenuを拡張しました 🚀 

当初はTriggerボタンに対してMenuを左に開くか右に開くかの用途しかありませんでした
しかし、現在進行形の施策にて新たに上下にも開きたいという要望が出たので、新たに上下左右4方向 × 左右中央寄せ3パターンの計12パターンを指定できるように拡張しました

加えて、TriggerボタンとMenuの間を8px開けて欲しいとデザイナーさんから依頼があったので、そちらの対応もしています

## 詳細
`position`プロパティに、menuをボタンに対してどの位置に開くかを指定できます
デフォルトは`leftTop`で、その他にも`topLeft`, `topCenter`, `topRight`, `rightTop`, `rightCenter`, `rightBottom`, `bottomLeft`, `bottomCenter`, `bottomRight`, `leftTop`, `leftCenter`, `leftBottom`を指定することができます

（画像にまとめてみました👇）
<img width="1297" alt="DropdownMenu" src="https://user-images.githubusercontent.com/42470015/192916187-43d165b9-8063-412c-9193-8419fa27f7db.png">

## レビュー完了希望日
某チームの施策内で使いたいとのことですので、10/4(火)あたりには完了できていると嬉しいです

## TODO
- [x] 最後にcommitをまとめます
- [x] 最後にbundlesizeを調整します
- [x] （仕様変更等があった場合は）最後にdocsを最新状態にします

## その他
関連リンクに関してはSlackの通知スレに貼ります