### PR TITLE
docs(spindle-ui): stopped global import

### DIFF
--- a/packages/spindle-ui/README.md
+++ b/packages/spindle-ui/README.md
@@ -29,6 +29,8 @@ Spindle UIは以下のように利用できます。
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Button } from '@openameba/spindle-ui';
+// Tree Shakingされない環境下では個別にインポートすることを推奨します
+// 例）`import { Button } from '@openameba/spindle-ui/Button';`
 
 function App() {
   return <Button size="large" variant="contained">Spindle</Button>;

--- a/packages/spindle-ui/src/BottomButton/BottomButton.stories.mdx
+++ b/packages/spindle-ui/src/BottomButton/BottomButton.stories.mdx
@@ -10,7 +10,7 @@ import { BottomButton } from './BottomButton';
 
 <Source
   language='javascript'
-  code={`import { BottomButton } from '@openameba/spindle-ui/BottomButton'`}
+  code={`import { BottomButton } from '@openameba/spindle-ui'`}
 />
 
 <Source

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
@@ -11,7 +11,7 @@ import { BreadcrumbItem } from './BreadcrumbItem';
 
 <Source
   language='javascript'
-  code={`import { BreadcrumbList } from '@openameba/spindle-ui/Breadcrumb'`}
+  code={`import { BreadcrumbList } from '@openameba/spindle-ui'`}
 />
 
 <Source

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -10,7 +10,7 @@ import { Pagination } from './Pagination';
 
 <Source
   language="javascript"
-  code={`import { Pagination } from '@openameba/spindle-ui/Pagination'`}
+  code={`import { Pagination } from '@openameba/spindle-ui'`}
 />
 
 <Source


### PR DESCRIPTION
## 概要
ほとんどのコンポーネントのdocsにて、import文が個別インポート👇ではなく
```
import { Button } from '@openameba/spindle-ui/Button';
```
spindle-ui丸ごとインポート👇になっていたので変更しました 🚀 
```
import { Button } from '@openameba/spindle-ui';
```

## レビュー期限
修正としては特に急ぎではないですが、docsを正しい状態にするという意味ではなるはやだと嬉しいです！