### PR TITLE
fix(spindle-ui): pagination style

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-v2
       - run: yarn install --frozen-lockfile
-      - run: npx lerna bootstrap -- --frozen-lockfile
+      - run: yarn lerna bootstrap -- --frozen-lockfile
       - name: Set git user
         run: |
           git config --global user.email "<>"
@@ -47,7 +47,7 @@ jobs:
         id: extract_branch
       - name: Releaseing with lerna
         # also see some options in lerna.json
-        run: npx lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
+        run: yarn lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Create Pull Request

--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -97,13 +97,13 @@
 @media screen and (max-width: 414px) {
   .spui-Pagination-item:nth-child(4),
   .spui-Pagination-item:nth-child(6) {
-    display: block;
+    display: none;
   }
 }
 
 @media screen and (max-width: 360px) {
-  .spui-Pagination-item:nth-child(4),
-  .spui-Pagination-item:nth-child(6) {
+  .spui-Pagination-item--first,
+  .spui-Pagination-item--last {
     display: none;
   }
 }

--- a/packages/spindle-ui/src/Pagination/PaginationItem.css
+++ b/packages/spindle-ui/src/Pagination/PaginationItem.css
@@ -49,11 +49,11 @@
   flex-direction: row-reverse;
 }
 
-.spui-PaginationItem-link--prev {
+.spui-PaginationItem-link--prev .spui-PaginationItem-label {
   padding-right: 8px;
 }
 
-.spui-PaginationItem-link--next {
+.spui-PaginationItem-link--next .spui-PaginationItem-label {
   padding-left: 8px;
 }
 
@@ -65,22 +65,6 @@
 
 @media screen and (max-width: 768px) {
   .spui-PaginationItem-label {
-    display: none;
-  }
-}
-
-@media screen and (max-width: 414px) {
-  .spui-PaginationItem-label,
-  .spui-PaginationItem--first,
-  .spui-PaginationItem--last {
-    display: none;
-  }
-}
-
-@media screen and (max-width: 360px) {
-  .spui-PaginationItem-label,
-  .spui-PaginationItem-item--first,
-  .spui-PaginationItem-item--last {
     display: none;
   }
 }


### PR DESCRIPTION
### 概要
Paginationのstyleで一部不具合があったため修正しました。
おそらくコンポーネントを作っている間にもれが発生していたようで。

### スクリーンショット
<img width="252" alt="スクリーンショット 2022-10-13 10 12 01" src="https://user-images.githubusercontent.com/80251820/195476789-6eb656ed-2f23-4cf0-b245-b9b3cf7f7a53.png">
focus時のstyleが少しズレている

<img width="352" alt="スクリーンショット 2022-10-13 10 11 53" src="https://user-images.githubusercontent.com/80251820/195477867-e315936c-83d0-461c-9dc8-d6470f1705e6.png">
少しわかりづらいですが最初への矢印が消えるはずが残っており画面からはみ出している

### リリースされているPaginationのstorybook
https://ameba-spindle.web.app/?path=/story/pagination--current-8-total-20