### PR TITLE
fix(spindle-ui): pagination style

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -95,8 +95,7 @@
 }
 
 @media screen and (max-width: 414px) {
-  .spui-Pagination-item:nth-child(4),
-  .spui-Pagination-item:nth-child(6) {
+  .spui-Pagination-item--hidden {
     display: none;
   }
 }

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -6,7 +6,7 @@ import { Pagination } from './Pagination';
 
 <Meta title="Pagination" component={Pagination} />
 
-![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
+![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
 
 <Source
   language="javascript"
@@ -26,7 +26,7 @@ import { Pagination } from './Pagination';
 <Description>Paginationはページの移動を目的として利用します。</Description>
 
 <Description>
-  ページの前後に移動することができます。また、画面幅によりレイアウトが変化します。
+  ページの前後に移動することができます。
 </Description>
 
 <Description>デフォルトではアンカー要素を使用します。</Description>
@@ -34,6 +34,45 @@ import { Pagination } from './Pagination';
 <Description>
   `createUrl`に関数を渡すことでURLを任意の形で生成することが可能です。
 </Description>
+
+## 指定できるプロパティ
+
+<Description>
+  - `current`(必須): 現在のページ数を指定してください。
+</Description>
+<Description>
+  - `total`(必須): 総ページ数を指定してください。
+</Description>
+<Description>
+  - `showCount`(任意): ページのカウントを表示したい場合は、指定することができます。デフォルト値はfalseです。
+</Description>
+<Description>
+  - `showPrevNext`(任意): 「前へ」「次へ」アイコンを表示したい場合は、指定することができます。デフォルト値はtrueです。
+</Description>
+<Description>
+  - `showFirstLast`(任意): 「最初へ」「最後へ」アイコンを表示したい場合は、指定することができます。デフォルト値はfalseです。
+</Description>
+<Description>
+  - `onPageChange`(必須): リンクをクリック後に処理をしたい場合に利用することができます。
+</Description>
+<Description>
+  - `createUrl`(必須): リンクのhrefとなる値を指定してください。
+</Description>
+
+## レスポンシブデザイン
+
+<Description>Paginationは画面幅によりレイアウトが変化します。</Description>
+
+- showPrevNext
+- showFirstLast
+
+<Description>上記、オプショナルなプロパティの存在有無に限らず「ページの前後」「ページの最初と最後」への移動が可能となります。</Description>
+
+<Description>例えば、showFirstLastがfalseの場合は最初と最後をページ番号で担保します。</Description>
+
+<Description>showPrevNextがtrueの場合、現在のページ数に対してその前後に値するページ番号がブレイクポイント（414px以下）により非表示になります。</Description>
+
+<Description>例えば、1・2・3（current）・4・5とした場合、2と4が非表示になります。</Description>
 
 export const url = '/detail/CURRENT.html';
 export const pageNumber = 1;
@@ -122,14 +161,70 @@ export const pageNumber = 1;
   code={'<Pagination total={20000} current={10000} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
-## showPrevNext showFirstLast props false
+## showFirstLast props false
 
 <Description>
-  `showPrevNext`と`showFirstLast`propsは`false`にすることが可能です。
+  `showFirstLast`プロパティは`false`にすることで、「最初へ」と「最後へ」アイコンを非表示にできます。
 </Description>
 
 <Description>
-  その場合、ページリンクにて前後と最初最後のリンクを担保します。
+  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
+</Description>
+
+<Preview withSource="open">
+  <Story name="showFirstLast props false">
+    <Pagination
+      total={20}
+      current={8}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={false}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## showPrevNext props false
+
+<Description>
+  `showPrevNext`プロパティは`false`にすることで、「前へ」と「次へ」アイコンを非表示にできます。
+</Description>
+
+<Description>
+  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
+</Description>
+
+<Preview withSource="open">
+  <Story name="showPrevNext props false">
+    <Pagination
+      total={20}
+      current={8}
+      showCount={true}
+      showPrevNext={false}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## showPrevNext showFirstLast props false
+
+<Description>
+  `showPrevNext`と`showFirstLast`プロパティは`false`にすることで、全てのアイコンを非表示にできます。
+</Description>
+
+<Description>
+  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
 </Description>
 
 <Preview withSource="open">

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -81,10 +81,16 @@ export const Pagination = (props: Props) => {
         {displayItem.map((pageNumber, index) => {
           const isCurrent = current === pageNumber;
           const hasRelAttribute = current === pageNumber + 1;
+          const isHidden = showPrevNext && (index === 1 || index === 3);
 
           return (
             <li
-              className={`${BLOCK_NAME}-item`}
+              className={[
+                `${BLOCK_NAME}-item`,
+                isHidden && `${BLOCK_NAME}-item--hidden`,
+              ]
+                .filter(Boolean)
+                .join(' ')}
               key={`pagination-item-${pageNumber}`}
             >
               {index === pageItem - 1 && showNextHorizontal && (


### PR DESCRIPTION
### 概要
- 最初と最後の矢印（showFirstLast）がある時
- 最初と最後の矢印（showFirstLast）がない時
上記で除外されるべき（display: none;）リストの順序に不具合があったため修正しました。

修正内容としては親に起点となるclassを付与してなのですがもうちょっといいやり方ないかと思っていたりもします。