### PR TITLE
fix(spindle-ui): pagination display item

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -97,6 +97,86 @@ export const pageNumber = 1;
   code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
+## current 1 total 1
+
+<Preview withSource="open">
+  <Story name="current 1 total 1">
+    <Pagination
+      total={1}
+      current={1}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={false}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={1} current={1} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 2 total 2
+
+<Preview withSource="open">
+  <Story name="current 2 total 2">
+    <Pagination
+      total={2}
+      current={2}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={false}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={2} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 2 total 3
+
+<Preview withSource="open">
+  <Story name="current 2 total 3">
+    <Pagination
+      total={3}
+      current={2}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={false}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={3} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 2 total 4
+
+<Preview withSource="open">
+  <Story name="current 2 total 4">
+    <Pagination
+      total={4}
+      current={2}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={false}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={4} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
 ## current 8 total 20
 
 <Preview withSource="open">

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -32,11 +32,14 @@ export const Pagination = (props: Props) => {
     ...rest
   } = props;
 
-  const pageItem = 5;
-  const { displayItem, showPrevHorizontal, showNextHorizontal } = useShowItem({
+  const {
+    displayItem,
+    showPrevHorizontal,
+    showNextHorizontal,
+    hideDisplayItem,
+  } = useShowItem({
     current,
     total,
-    pageItem,
   });
 
   const handleClick = useCallback(
@@ -80,8 +83,14 @@ export const Pagination = (props: Props) => {
         )}
         {displayItem.map((pageNumber, index) => {
           const isCurrent = current === pageNumber;
+          const isHidden =
+            showPrevNext &&
+            hideDisplayItem &&
+            (current - 1 === pageNumber || current + 1 === pageNumber);
           const hasRelAttribute = current === pageNumber + 1;
-          const isHidden = showPrevNext && (index === 1 || index === 3);
+          const showPrevMenuHorizontal = index === 0 && showPrevHorizontal;
+          const showNextMenuHorizontal =
+            index === displayItem.length - 1 && showNextHorizontal;
 
           return (
             <li
@@ -93,7 +102,7 @@ export const Pagination = (props: Props) => {
                 .join(' ')}
               key={`pagination-item-${pageNumber}`}
             >
-              {index === pageItem - 1 && showNextHorizontal && (
+              {showNextMenuHorizontal && (
                 <MenuHorizontal
                   aria-hidden="true"
                   className={`${BLOCK_NAME}-horizontal`}
@@ -116,7 +125,7 @@ export const Pagination = (props: Props) => {
               >
                 {pageNumber}
               </a>
-              {index === 0 && showPrevHorizontal && (
+              {showPrevMenuHorizontal && (
                 <MenuHorizontal
                   aria-hidden="true"
                   className={`${BLOCK_NAME}-horizontal`}

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
@@ -5,42 +5,48 @@ describe('useShowItem()', () => {
   it('should return show props', () => {
     const current = 8;
     const total = 20;
-    const pageItem = 5;
 
-    const { result } = renderHook(() =>
-      useShowItem({ current, total, pageItem }),
-    );
+    const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 7, 8, 9, 20]);
     expect(result.current.showPrevHorizontal).toEqual(true);
     expect(result.current.showNextHorizontal).toEqual(true);
+    expect(result.current.hideDisplayItem).toEqual(true);
   });
 
   it('should return show props is current first', () => {
     const current = 1;
     const total = 20;
-    const pageItem = 5;
 
-    const { result } = renderHook(() =>
-      useShowItem({ current, total, pageItem }),
-    );
+    const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 2, 3, 4, 20]);
     expect(result.current.showPrevHorizontal).toEqual(false);
     expect(result.current.showNextHorizontal).toEqual(true);
+    expect(result.current.hideDisplayItem).toEqual(true);
   });
 
-  it('should return show props is current first', () => {
+  it('should return show props is current last', () => {
     const current = 20;
     const total = 20;
-    const pageItem = 5;
 
-    const { result } = renderHook(() =>
-      useShowItem({ current, total, pageItem }),
-    );
+    const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 17, 18, 19, 20]);
     expect(result.current.showPrevHorizontal).toEqual(true);
     expect(result.current.showNextHorizontal).toEqual(false);
+    expect(result.current.hideDisplayItem).toEqual(true);
+  });
+
+  it('should return show props is total is less than max page item', () => {
+    const current = 2;
+    const total = 3;
+
+    const { result } = renderHook(() => useShowItem({ current, total }));
+
+    expect(result.current.displayItem).toEqual([1, 2, 3]);
+    expect(result.current.showPrevHorizontal).toEqual(false);
+    expect(result.current.showNextHorizontal).toEqual(false);
+    expect(result.current.hideDisplayItem).toEqual(false);
   });
 });

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -3,12 +3,16 @@ import { useMemo } from 'react';
 type Payload = {
   current: number;
   total: number;
-  pageItem: number;
 };
 
-export function useShowItem({ current, total, pageItem = 5 }: Payload) {
+const MAX_PAGE_ITEM = 5;
+
+export function useShowItem({ current, total }: Payload) {
   const displayItem = useMemo(() => {
-    if (current === 1 || current === 2) {
+    if (total < MAX_PAGE_ITEM) {
+      // 総ページ数がMAX_PAGE_ITEMよりも小さい場合
+      return Array.from({ length: total }, (_element, index) => index + 1);
+    } else if (current === 1 || current === 2) {
       // 現在値が1か2の場合は"1,2,3,4,total"とする
       return [1, 2, 3, 4, total];
     } else if (current !== total && current !== total - 1) {
@@ -21,11 +25,19 @@ export function useShowItem({ current, total, pageItem = 5 }: Payload) {
   }, [current, total]);
 
   // totalは表示数超えている前提で、前から2つ目のアイテムが2より大きいかどうか（最初が連続した数字じゃないことをチェック）
-  const showPrevHorizontal = total > pageItem && 2 < displayItem[1];
+  const showPrevHorizontal = total > MAX_PAGE_ITEM && 2 < displayItem[1];
 
   // totalは表示数超えている前提で、後ろから2つ目のアイテムがtotal-1より小さいか（最後が連続した数字じゃないことをチェック）
   const showNextHorizontal =
-    total > pageItem && displayItem[pageItem - 2] < total - 1;
+    total > MAX_PAGE_ITEM && displayItem[MAX_PAGE_ITEM - 2] < total - 1;
 
-  return { displayItem, showPrevHorizontal, showNextHorizontal };
+  // 総ページ数が5件より大きい場合
+  const hideDisplayItem = total > MAX_PAGE_ITEM;
+
+  return {
+    displayItem,
+    showPrevHorizontal,
+    showNextHorizontal,
+    hideDisplayItem,
+  };
 }


### PR DESCRIPTION
### 概要
Paginationのコンポーネントのアイテム数（ページ番号）描画条件を修正しました。
5件想定でしたが5件以下の処理を追加した感じです。
sliceでコネコネしようかと思ったのですが現状、if文で処理しているのでそこに追記する方法で対応しています。

合わせてstorybookも追加しております。