### PR TITLE
docs(spindle-ui): note for Breadcrumb position

### DIFF
--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
@@ -99,6 +99,8 @@ import { BreadcrumbItem } from './BreadcrumbItem';
   </Story>
 </Preview>
 
+NOTE: Standard Variantはタップエリアを確保する目的でテキストに余白が指定されています。ページ内での左端を揃えたい場合には、個別に余白を指定しBreadcrumb要素の位置を調整してください。
+
 <Source
   code={`
 <BreadcrumbList variant="standard">

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
@@ -99,7 +99,7 @@ import { BreadcrumbItem } from './BreadcrumbItem';
   </Story>
 </Preview>
 
-NOTE: Standard Variantはタップエリアを確保する目的でテキストに余白が指定されています。ページ内での左端を揃えたい場合には、個別に余白を指定しBreadcrumb要素の位置を調整してください。
+Standard Variantはタップエリアを確保する目的でテキストに余白が指定されています。ページ内での左端を揃えたい場合には、個別に余白を指定しBreadcrumb要素の位置を調整してください。
 
 <Source
   code={`


### PR DESCRIPTION
利用時に、`Breadcrumb[variant=standard]`の位置をページ内で揃えたい要望が出てきたので注記しました。

コンポーネント定義・実装は余白を持ちつつ、利用時に位置調整をすることとしています。位置調整の方法はアプリケーション毎に異なる可能性があるためここでは触れていません。