### PR TITLE
fix(spindle-ui): pagination item hidden style

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -70,9 +70,18 @@ import { Pagination } from './Pagination';
 
 <Description>例えば、showFirstLastがfalseの場合は最初と最後をページ番号で担保します。</Description>
 
-<Description>showPrevNextがtrueの場合、現在のページ数に対してその前後に値するページ番号がブレイクポイント（414px以下）により非表示になります。</Description>
+### showPrevNextがtrueの場合
+
+<Description>現在のページ数に対してその前後に値するページ番号がブレイクポイント（414px以下）により非表示になります。</Description>
 
 <Description>例えば、1・2・3（current）・4・5とした場合、2と4が非表示になります。</Description>
+
+### 総ページ数が5件以上の場合
+
+- currentが2の場合はcurrentに対して前のページ番号のみが非表示
+- currentが3の場合はcurrentに対して次のページ番号のみが非表示
+
+<Description>となります。</Description>
 
 export const url = '/detail/CURRENT.html';
 export const pageNumber = 1;

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -177,6 +177,86 @@ export const pageNumber = 1;
   code={'<Pagination total={4} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
+## current 1 total 20
+
+<Preview withSource="open">
+  <Story name="current 1 total 20">
+    <Pagination
+      total={20}
+      current={1}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={1} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 2 total 20
+
+<Preview withSource="open">
+  <Story name="current 2 total 20">
+    <Pagination
+      total={20}
+      current={2}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 3 total 20
+
+<Preview withSource="open">
+  <Story name="current 3 total 20">
+    <Pagination
+      total={20}
+      current={3}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={3} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 4 total 20
+
+<Preview withSource="open">
+  <Story name="current 4 total 20">
+    <Pagination
+      total={20}
+      current={4}
+      showCount={true}
+      showPrevNext={true}
+      showFirstLast={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={4} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
 ## current 8 total 20
 
 <Preview withSource="open">

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -83,10 +83,17 @@ export const Pagination = (props: Props) => {
         )}
         {displayItem.map((pageNumber, index) => {
           const isCurrent = current === pageNumber;
-          const isHidden =
+          const isHiddenPrevItem =
             showPrevNext &&
             hideDisplayItem &&
-            (current - 1 === pageNumber || current + 1 === pageNumber);
+            current - 1 === pageNumber &&
+            current !== 3;
+          const isHiddenNextItem =
+            showPrevNext &&
+            hideDisplayItem &&
+            current + 1 === pageNumber &&
+            current !== 1 &&
+            current !== 2;
           const hasRelAttribute = current === pageNumber + 1;
           const showPrevMenuHorizontal = index === 0 && showPrevHorizontal;
           const showNextMenuHorizontal =
@@ -96,7 +103,8 @@ export const Pagination = (props: Props) => {
             <li
               className={[
                 `${BLOCK_NAME}-item`,
-                isHidden && `${BLOCK_NAME}-item--hidden`,
+                (isHiddenPrevItem || isHiddenNextItem) &&
+                  `${BLOCK_NAME}-item--hidden`,
               ]
                 .filter(Boolean)
                 .join(' ')}


### PR DESCRIPTION
### 概要
画面幅によってはページ番号が歯抜けのような形になってしまっていたため、
Paginationコンポーネントの非表示スタイルを調整しました。

#### レスポンシブ時
<img width="306" alt="198232877-f120af51-3c53-4455-a3b5-1f3e3d13481e" src="https://user-images.githubusercontent.com/80251820/198451598-9df6eb17-5851-4e50-ad87-c5af6b1b47b2.png">
<img width="301" alt="198232958-1a7debbd-2d3d-44fb-b800-97483ceb8e8b" src="https://user-images.githubusercontent.com/80251820/198451612-2c73cf98-b429-4311-909c-71e754544179.png">
<img width="296" alt="198233082-7ae408cf-b31c-4fb2-a39d-eb8a259a1377" src="https://user-images.githubusercontent.com/80251820/198451621-57d0d20f-0e15-4424-bd15-0801d62e0962.png">

上記スクリーンショットのように

- currentが1 or 2の場合はcurrentの次が非表示だと歯抜けのような表示になる
- currentが3の場合はcurrentの前が非表示だと歯抜けのような表示になる

を踏まえて条件式を一部変更しました。

#### storybook
ページ総数が5件以上ありcurrentが1・2・3・4のパターンを追加しております。