### PR TITLE
fix(spindle-ui): pagination design pattern

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -27,6 +27,8 @@
   margin: 0 5px;
 }
 
+.spui-Pagination-item--prev,
+.spui-Pagination-item--next,
 .spui-Pagination-item--first,
 .spui-Pagination-item--last {
   margin: 0;
@@ -94,15 +96,8 @@
   margin-left: 8px;
 }
 
-@media screen and (max-width: 414px) {
-  .spui-Pagination-item--hidden {
-    display: none;
-  }
-}
-
 @media screen and (max-width: 360px) {
-  .spui-Pagination-item--first,
-  .spui-Pagination-item--last {
+  .spui-Pagination-item--hidden {
     display: none;
   }
 }

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -47,12 +47,6 @@ import { Pagination } from './Pagination';
   - `showCount`(任意): ページのカウントを表示したい場合は、指定することができます。デフォルト値はfalseです。
 </Description>
 <Description>
-  - `showPrevNext`(任意): 「前へ」「次へ」アイコンを表示したい場合は、指定することができます。デフォルト値はtrueです。
-</Description>
-<Description>
-  - `showFirstLast`(任意): 「最初へ」「最後へ」アイコンを表示したい場合は、指定することができます。デフォルト値はfalseです。
-</Description>
-<Description>
   - `onPageChange`(必須): リンクをクリック後に処理をしたい場合に利用することができます。
 </Description>
 <Description>
@@ -63,16 +57,66 @@ import { Pagination } from './Pagination';
 
 <Description>Paginationは画面幅によりレイアウトが変化します。</Description>
 
-- showPrevNext
-- showFirstLast
+### 画面幅360pxから414pxの間
 
-<Description>上記、オプショナルなプロパティの存在有無に限らず「ページの前後」「ページの最初と最後」への移動が可能となります。</Description>
+#### ページ数5件以下
+<Description>
+  - 「最初へ」「最後へ」非表示
+</Description>
+<Description>
+  - 「前へ」「次へ」表示
+</Description>
 
-<Description>例えば、showFirstLastがfalseの場合は最初と最後をページ番号で担保します。</Description>
+#### ページ数が6件以上
+<Description>
+  - 「最初へ」「最後へ」非表示
+</Description>
+<Description>
+  - 「前へ」「次へ」表示
+</Description>
 
-<Description>showPrevNextがtrueの場合、現在のページ数に対してその前後に値するページ番号がブレイクポイント（414px以下）により非表示になります。</Description>
+#### ページ数が100件以上
+<Description>
+  - 「最初へ」「最後へ」表示
+</Description>
+<Description>
+  - 「前へ」「次へ」非表示
+</Description>
 
-<Description>例えば、1・2・3（current）・4・5とした場合、2と4が非表示になります。</Description>
+### 画面幅360px以下
+
+#### ページ数5件以下
+<Description>
+  - 「最初へ」「最後へ」非表示
+</Description>
+<Description>
+  - 「前へ」「次へ」表示
+</Description>
+<Description>
+  - 最初と最後のページ番号が非表示
+</Description>
+
+#### ページ数が6件以上
+<Description>
+  - 「最初へ」「最後へ」非表示
+</Description>
+<Description>
+  - 「前へ」「次へ」は表示
+</Description>
+<Description>
+  - 現在のページに対して前後のページ番号が非表示
+</Description>
+
+#### ページ数が100件以上
+<Description>
+  - 「最初へ」「最後へ」表示
+</Description>
+<Description>
+  - 「前へ」「次へ」は非表示
+</Description>
+<Description>
+  - 最初と最後のページ番号が非表示
+</Description>
 
 export const url = '/detail/CURRENT.html';
 export const pageNumber = 1;
@@ -85,8 +129,6 @@ export const pageNumber = 1;
       total={5}
       current={3}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -105,8 +147,6 @@ export const pageNumber = 1;
       total={1}
       current={1}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -125,8 +165,6 @@ export const pageNumber = 1;
       total={2}
       current={2}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -145,8 +183,6 @@ export const pageNumber = 1;
       total={3}
       current={2}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -165,8 +201,6 @@ export const pageNumber = 1;
       total={4}
       current={2}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -177,6 +211,95 @@ export const pageNumber = 1;
   code={'<Pagination total={4} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
+## current 4 total 4
+
+<Preview withSource="open">
+  <Story name="current 4 total 4">
+    <Pagination
+      total={4}
+      current={4}
+      showCount={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={4} current={4} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+## current 1 total 20
+
+<Preview withSource="open">
+  <Story name="current 1 total 20">
+    <Pagination
+      total={20}
+      current={1}
+      showCount={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={1} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 2 total 20
+
+<Preview withSource="open">
+  <Story name="current 2 total 20">
+    <Pagination
+      total={20}
+      current={2}
+      showCount={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 3 total 20
+
+<Preview withSource="open">
+  <Story name="current 3 total 20">
+    <Pagination
+      total={20}
+      current={3}
+      showCount={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={3} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 4 total 20
+
+<Preview withSource="open">
+  <Story name="current 4 total 20">
+    <Pagination
+      total={20}
+      current={4}
+      showCount={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={4} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
 ## current 8 total 20
 
 <Preview withSource="open">
@@ -185,8 +308,6 @@ export const pageNumber = 1;
       total={20}
       current={8}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -197,16 +318,14 @@ export const pageNumber = 1;
   code={'<Pagination total={20} current={8} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
-## current 900 total 999
+## current 20 total 20
 
 <Preview withSource="open">
-  <Story name="current 900 total 999">
+  <Story name="current 20 total 20">
     <Pagination
-      total={999}
-      current={900}
+      total={20}
+      current={20}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -214,8 +333,63 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={999} current={900} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={20} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
+
+## current 97 total 100
+
+<Preview withSource="open">
+  <Story name="current 97 total 100">
+    <Pagination
+      total={100}
+      current={97}
+      showCount={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={100} current={97} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 1 total 100
+
+<Preview withSource="open">
+  <Story name="current 1 total 100">
+    <Pagination
+      total={100}
+      current={1}
+      showCount={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={100} current={1} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## current 100 total 100
+
+<Preview withSource="open">
+  <Story name="current 100 total 100">
+    <Pagination
+      total={100}
+      current={100}
+      showCount={true}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={100} current={100} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
 
 ## current 10000 total 20000
 
@@ -229,8 +403,6 @@ export const pageNumber = 1;
       total={20000}
       current={10000}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -241,90 +413,6 @@ export const pageNumber = 1;
   code={'<Pagination total={20000} current={10000} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
-## showFirstLast props false
-
-<Description>
-  `showFirstLast`プロパティは`false`にすることで、「最初へ」と「最後へ」アイコンを非表示にできます。
-</Description>
-
-<Description>
-  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
-</Description>
-
-<Preview withSource="open">
-  <Story name="showFirstLast props false">
-    <Pagination
-      total={20}
-      current={8}
-      showCount={true}
-      showPrevNext={true}
-      showFirstLast={false}
-      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
-      {...actions('onClick')}
-    />
-  </Story>
-</Preview>
-
-<Source
-  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
-/>
-
-## showPrevNext props false
-
-<Description>
-  `showPrevNext`プロパティは`false`にすることで、「前へ」と「次へ」アイコンを非表示にできます。
-</Description>
-
-<Description>
-  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
-</Description>
-
-<Preview withSource="open">
-  <Story name="showPrevNext props false">
-    <Pagination
-      total={20}
-      current={8}
-      showCount={true}
-      showPrevNext={false}
-      showFirstLast={true}
-      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
-      {...actions('onClick')}
-    />
-  </Story>
-</Preview>
-
-<Source
-  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
-/>
-
-## showPrevNext showFirstLast props false
-
-<Description>
-  `showPrevNext`と`showFirstLast`プロパティは`false`にすることで、全てのアイコンを非表示にできます。
-</Description>
-
-<Description>
-  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
-</Description>
-
-<Preview withSource="open">
-  <Story name="showPrevNext showFirstLast props false">
-    <Pagination
-      total={20}
-      current={8}
-      showCount={true}
-      showPrevNext={false}
-      showFirstLast={false}
-      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
-      {...actions('onClick')}
-    />
-  </Story>
-</Preview>
-
-<Source
-  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
-/>
-
 ## create url function
 
 <Preview withSource="open">
@@ -333,8 +421,6 @@ export const pageNumber = 1;
       total={20}
       current={8}
       showCount={true}
-      showPrevNext={true}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />

--- a/packages/spindle-ui/src/Pagination/Pagination.test.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.test.tsx
@@ -15,8 +15,6 @@ describe('<Pagination />', () => {
         total={20}
         current={8}
         showCount={true}
-        showPrevNext={true}
-        showFirstLast={true}
         createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
         onPageChange={onClick}
       />,

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -8,8 +8,6 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
   current: number;
   total: number;
   showCount?: boolean;
-  showPrevNext?: boolean;
-  showFirstLast?: boolean;
   onPageChange: (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
     pageNumber: number,
@@ -24,8 +22,6 @@ export const Pagination = (props: Props) => {
     current,
     total,
     showCount = false,
-    showPrevNext = true,
-    showFirstLast = false,
     onPageChange,
     createUrl,
     className,
@@ -34,9 +30,12 @@ export const Pagination = (props: Props) => {
 
   const {
     displayItem,
-    showPrevHorizontal,
-    showNextHorizontal,
-    hideDisplayItem,
+    hideDisplayItemLevel1,
+    hideDisplayItemLevel2,
+    hideDisplayItemLevel3,
+    showHorizontal,
+    showPrevNext,
+    showFirstLast,
   } = useShowItem({
     current,
     total,
@@ -50,6 +49,25 @@ export const Pagination = (props: Props) => {
       onPageChange?.(event, pageNumber);
     },
     [onPageChange],
+  );
+
+  const setHiddenItem = useCallback(
+    (
+      pageNumber: number,
+      index: number,
+      hideDisplayItemLevel1: boolean,
+      hideDisplayItemLevel2: boolean,
+      hideDisplayItemLevel3: boolean,
+    ) => {
+      if (hideDisplayItemLevel1 || hideDisplayItemLevel3) {
+        return index === 0 || index === 4;
+      } else if (hideDisplayItemLevel2) {
+        return current - 1 === pageNumber || current + 1 === pageNumber;
+      } else {
+        return false;
+      }
+    },
+    [],
   );
 
   return (
@@ -82,15 +100,15 @@ export const Pagination = (props: Props) => {
           </li>
         )}
         {displayItem.map((pageNumber, index) => {
+          const isHidden = setHiddenItem(
+            pageNumber,
+            index,
+            hideDisplayItemLevel1,
+            hideDisplayItemLevel2,
+            hideDisplayItemLevel3,
+          );
           const isCurrent = current === pageNumber;
-          const isHidden =
-            showPrevNext &&
-            hideDisplayItem &&
-            (current - 1 === pageNumber || current + 1 === pageNumber);
           const hasRelAttribute = current === pageNumber + 1;
-          const showPrevMenuHorizontal = index === 0 && showPrevHorizontal;
-          const showNextMenuHorizontal =
-            index === displayItem.length - 1 && showNextHorizontal;
 
           return (
             <li
@@ -102,7 +120,7 @@ export const Pagination = (props: Props) => {
                 .join(' ')}
               key={`pagination-item-${pageNumber}`}
             >
-              {showNextMenuHorizontal && (
+              {showHorizontal && index === displayItem.length - 1 && (
                 <MenuHorizontal
                   aria-hidden="true"
                   className={`${BLOCK_NAME}-horizontal`}
@@ -125,7 +143,7 @@ export const Pagination = (props: Props) => {
               >
                 {pageNumber}
               </a>
-              {showPrevMenuHorizontal && (
+              {showHorizontal && index === 0 && (
                 <MenuHorizontal
                   aria-hidden="true"
                   className={`${BLOCK_NAME}-horizontal`}

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
@@ -9,9 +9,10 @@ describe('useShowItem()', () => {
     const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 7, 8, 9, 20]);
-    expect(result.current.showPrevHorizontal).toEqual(true);
-    expect(result.current.showNextHorizontal).toEqual(true);
-    expect(result.current.hideDisplayItem).toEqual(true);
+    expect(result.current.showHorizontal).toEqual(true);
+    expect(result.current.hideDisplayItemLevel1).toEqual(false);
+    expect(result.current.hideDisplayItemLevel2).toEqual(true);
+    expect(result.current.hideDisplayItemLevel3).toEqual(false);
   });
 
   it('should return show props is current first', () => {
@@ -21,9 +22,10 @@ describe('useShowItem()', () => {
     const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 2, 3, 4, 20]);
-    expect(result.current.showPrevHorizontal).toEqual(false);
-    expect(result.current.showNextHorizontal).toEqual(true);
-    expect(result.current.hideDisplayItem).toEqual(true);
+    expect(result.current.showHorizontal).toEqual(true);
+    expect(result.current.hideDisplayItemLevel1).toEqual(false);
+    expect(result.current.hideDisplayItemLevel2).toEqual(true);
+    expect(result.current.hideDisplayItemLevel3).toEqual(false);
   });
 
   it('should return show props is current last', () => {
@@ -33,9 +35,10 @@ describe('useShowItem()', () => {
     const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 17, 18, 19, 20]);
-    expect(result.current.showPrevHorizontal).toEqual(true);
-    expect(result.current.showNextHorizontal).toEqual(false);
-    expect(result.current.hideDisplayItem).toEqual(true);
+    expect(result.current.showHorizontal).toEqual(true);
+    expect(result.current.hideDisplayItemLevel1).toEqual(false);
+    expect(result.current.hideDisplayItemLevel2).toEqual(true);
+    expect(result.current.hideDisplayItemLevel3).toEqual(false);
   });
 
   it('should return show props is total is less than max page item', () => {
@@ -45,8 +48,22 @@ describe('useShowItem()', () => {
     const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 2, 3]);
-    expect(result.current.showPrevHorizontal).toEqual(false);
-    expect(result.current.showNextHorizontal).toEqual(false);
-    expect(result.current.hideDisplayItem).toEqual(false);
+    expect(result.current.showHorizontal).toEqual(false);
+    expect(result.current.hideDisplayItemLevel1).toEqual(false);
+    expect(result.current.hideDisplayItemLevel2).toEqual(false);
+    expect(result.current.hideDisplayItemLevel3).toEqual(false);
+  });
+
+  it('should return show props is total is less than max page item', () => {
+    const current = 98;
+    const total = 100;
+
+    const { result } = renderHook(() => useShowItem({ current, total }));
+
+    expect(result.current.displayItem).toEqual([96, 97, 98, 99, 100]);
+    expect(result.current.showHorizontal).toEqual(true);
+    expect(result.current.hideDisplayItemLevel1).toEqual(false);
+    expect(result.current.hideDisplayItemLevel2).toEqual(false);
+    expect(result.current.hideDisplayItemLevel3).toEqual(true);
   });
 });

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -5,16 +5,24 @@ type Payload = {
   total: number;
 };
 
-const MAX_PAGE_ITEM = 5;
+const MINIMUM_PAGE_ITEM = 3;
+const DEFAULT_PAGE_ITEM = 5;
+const PAGE_ITEM_ONE_HUNDRED = 100;
 
 export function useShowItem({ current, total }: Payload) {
   const displayItem = useMemo(() => {
-    if (total < MAX_PAGE_ITEM) {
-      // 総ページ数がMAX_PAGE_ITEMよりも小さい場合
+    if (total < DEFAULT_PAGE_ITEM) {
+      // 総ページ数が5件よりも小さい場合
       return Array.from({ length: total }, (_element, index) => index + 1);
     } else if (current === 1 || current === 2) {
       // 現在値が1か2の場合は"1,2,3,4,total"とする
       return [1, 2, 3, 4, total];
+    } else if (
+      PAGE_ITEM_ONE_HUNDRED <= total &&
+      PAGE_ITEM_ONE_HUNDRED !== current
+    ) {
+      // 総ページ数が100件以上で現在地が100件じゃない場合
+      return [current - 2, current - 1, current, current + 1, current + 2];
     } else if (current !== total && current !== total - 1) {
       // "1,current-1,current,current+1,total"とする
       return [1, current - 1, current, current + 1, total];
@@ -24,20 +32,34 @@ export function useShowItem({ current, total }: Payload) {
     }
   }, [current, total]);
 
-  // totalは表示数超えている前提で、前から2つ目のアイテムが2より大きいかどうか（最初が連続した数字じゃないことをチェック）
-  const showPrevHorizontal = total > MAX_PAGE_ITEM && 2 < displayItem[1];
+  // 総ページ数が6件以上かつ100件以下の場合
+  const showHorizontal =
+    total > DEFAULT_PAGE_ITEM && total <= PAGE_ITEM_ONE_HUNDRED;
 
-  // totalは表示数超えている前提で、後ろから2つ目のアイテムがtotal-1より小さいか（最後が連続した数字じゃないことをチェック）
-  const showNextHorizontal =
-    total > MAX_PAGE_ITEM && displayItem[MAX_PAGE_ITEM - 2] < total - 1;
+  // 総ページ数が3件以上かつ5件以下の場合
+  const hideDisplayItemLevel1 =
+    total > MINIMUM_PAGE_ITEM && total <= DEFAULT_PAGE_ITEM;
 
-  // 総ページ数が5件より大きい場合
-  const hideDisplayItem = total > MAX_PAGE_ITEM;
+  // 総ページ数が6件以上かつ100件未満の場合
+  const hideDisplayItemLevel2 =
+    total > DEFAULT_PAGE_ITEM && total < PAGE_ITEM_ONE_HUNDRED;
+
+  // 総ページ数が100件以上の場合
+  const hideDisplayItemLevel3 = total >= PAGE_ITEM_ONE_HUNDRED;
+
+  // 「前へ」「次へ」アイコンの表示条件
+  const showPrevNext = hideDisplayItemLevel1 || hideDisplayItemLevel2;
+
+  // 「最初へ」「最後へ」アイコンの表示条件
+  const showFirstLast = hideDisplayItemLevel3;
 
   return {
     displayItem,
-    showPrevHorizontal,
-    showNextHorizontal,
-    hideDisplayItem,
+    hideDisplayItemLevel1,
+    hideDisplayItemLevel2,
+    hideDisplayItemLevel3,
+    showHorizontal,
+    showPrevNext,
+    showFirstLast,
   };
 }


### PR DESCRIPTION
### 概要
Paginationコンポーネントの画面要件を再考しました。
ロジックを一部変更しております。
上記に伴い、storybookとテストも修正しました。

### 変更点

#### MenuHorizontal（・・・）ボタン
<img width="360" alt="pagination_menu_horizontal" src="https://user-images.githubusercontent.com/80251820/199128647-3a73aeee-7568-4e69-a2e5-f3e9b1e52207.png">


| ページ数3件以下 | ページ数5以下 | ページ数が6以上 | ページ数が100以上 |
| -------- | -------- | -------- | -------- |
| 非表示     | 非表示     | 表示     | 表示     |


#### 「最初へ」「最後へ」「前へ」「次へ」ボタン
今までは利用者側が表示／非表示を選択できましたが表示に関する処理はSpindle側でハンドリングするように変更。

#### 画面幅360pxから414pxの間
<img width="360" alt="Group 339 (2)" src="https://user-images.githubusercontent.com/80251820/199129275-3c86ab2d-7209-4238-aaf9-0d8dbb1efbea.png">

| ページ数3件以下 | ページ数5以下 | ページ数が6以上 | ページ数が100以上 |
| -------- | -------- | -------- | -------- |
| 「最初へ」「最後へ」非表示     | 「最初へ」「最後へ」非表示     | 「最初へ」「最後へ」非表示     | 「最初へ」「最後へ」表示     |
| 「前へ」「次へ」表示   | 「前へ」「次へ」表示     | 「前へ」「次へ」表示     | 「前へ」「次へ」非表示     |
| ページ番号は基本的に表示   |  -  | - | - |


#### 画面幅360px以下
<img width="276" alt="Group 339" src="https://user-images.githubusercontent.com/80251820/199129086-d8994970-ffcc-4e29-946b-60421e160430.png">

| ページ数3件以下 | ページ数5以下 | ページ数が6以上 | ページ数が100以上 |
| -------- | -------- | -------- | -------- |
| 「最初へ」「最後へ」非表示     | 「最初へ」「最後へ」非表示     | 「最初へ」「最後へ」非表示    | 「最初へ」「最後へ」表示|
| 「前へ」「次へ」表示   | 「前へ」「次へ」表示    | 「前へ」「次へ」表示     | 「前へ」「次へ」は非表示  |
| ページ番号は基本的に表示   | 最初と最後のページ番号が非表示    | 現在のページに対して前後のページ番号が非表示     | 最初と最後のページ番号が非表示  |