### PR TITLE
fix(spindle-ui): pagination prev next

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -81,7 +81,7 @@
   }
 }
 
-.spui-Pagination-count {
+.spui-Pagination-total {
   color: var(--color-text-low-emphasis);
   font-size: 0.8125em;
   line-height: 1.3;

--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -49,7 +49,7 @@
   line-height: 1.3;
   margin: 0;
   min-width: 40px;
-  padding: 0 4px;
+  padding: 0 10px;
   position: relative;
   -webkit-tap-highlight-color: var(--Pagination-tapHighlightColor);
   text-decoration: none;

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -47,9 +47,6 @@ import { Pagination } from './Pagination';
   - `showCount`(任意): ページのカウントを表示したい場合は、指定することができます。デフォルト値はfalseです。
 </Description>
 <Description>
-  - `showPrevNext`(任意): 「前へ」「次へ」アイコンを表示したい場合は、指定することができます。デフォルト値はtrueです。
-</Description>
-<Description>
   - `showFirstLast`(任意): 「最初へ」「最後へ」アイコンを表示したい場合は、指定することができます。デフォルト値はfalseです。
 </Description>
 <Description>
@@ -58,21 +55,6 @@ import { Pagination } from './Pagination';
 <Description>
   - `createUrl`(必須): リンクのhrefとなる値を指定してください。
 </Description>
-
-## レスポンシブデザイン
-
-<Description>Paginationは画面幅によりレイアウトが変化します。</Description>
-
-- showPrevNext
-- showFirstLast
-
-<Description>上記、オプショナルなプロパティの存在有無に限らず「ページの前後」「ページの最初と最後」への移動が可能となります。</Description>
-
-<Description>例えば、showFirstLastがfalseの場合は最初と最後をページ番号で担保します。</Description>
-
-<Description>showPrevNextがtrueの場合、現在のページ数に対してその前後に値するページ番号がブレイクポイント（414px以下）により非表示になります。</Description>
-
-<Description>例えば、1・2・3（current）・4・5とした場合、2と4が非表示になります。</Description>
 
 export const url = '/detail/CURRENT.html';
 export const pageNumber = 1;
@@ -85,7 +67,6 @@ export const pageNumber = 1;
       total={5}
       current={3}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -94,7 +75,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 1 total 1
@@ -105,7 +86,6 @@ export const pageNumber = 1;
       total={1}
       current={1}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -114,7 +94,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={1} current={1} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={1} current={1} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 2
@@ -125,7 +105,6 @@ export const pageNumber = 1;
       total={2}
       current={2}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -134,7 +113,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={2} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={2} current={2} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 3
@@ -145,7 +124,6 @@ export const pageNumber = 1;
       total={3}
       current={2}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -154,7 +132,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={3} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={3} current={2} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 4
@@ -165,7 +143,6 @@ export const pageNumber = 1;
       total={4}
       current={2}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -174,7 +151,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={4} current={2} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={4} current={2} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 8 total 20
@@ -185,7 +162,6 @@ export const pageNumber = 1;
       total={20}
       current={8}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -194,7 +170,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 900 total 999
@@ -205,7 +181,6 @@ export const pageNumber = 1;
       total={999}
       current={900}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -214,7 +189,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={999} current={900} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={999} current={900} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 10000 total 20000
@@ -229,7 +204,6 @@ export const pageNumber = 1;
       total={20000}
       current={10000}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -238,7 +212,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20000} current={10000} showCount={true} showPrevNext={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20000} current={10000} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## showFirstLast props false
@@ -257,7 +231,6 @@ export const pageNumber = 1;
       total={20}
       current={8}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -266,7 +239,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## showPrevNext props false
@@ -285,7 +258,6 @@ export const pageNumber = 1;
       total={20}
       current={8}
       showCount={true}
-      showPrevNext={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -294,7 +266,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## showPrevNext showFirstLast props false
@@ -313,7 +285,6 @@ export const pageNumber = 1;
       total={20}
       current={8}
       showCount={true}
-      showPrevNext={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -322,7 +293,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## create url function
@@ -333,7 +304,6 @@ export const pageNumber = 1;
       total={20}
       current={8}
       showCount={true}
-      showPrevNext={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -342,7 +312,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showPrevNext={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## リンク動作のカスタマイズ

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -25,9 +25,7 @@ import { Pagination } from './Pagination';
 
 <Description>Paginationはページの移動を目的として利用します。</Description>
 
-<Description>
-  ページの前後に移動することができます。
-</Description>
+<Description>ページの前後に移動することができます。</Description>
 
 <Description>デフォルトではアンカー要素を使用します。</Description>
 
@@ -37,20 +35,19 @@ import { Pagination } from './Pagination';
 
 ## 指定できるプロパティ
 
+<Description>- `current`(必須): 現在のページ数を指定してください。</Description>
+<Description>- `total`(必須): 総ページ数を指定してください。</Description>
 <Description>
-  - `current`(必須): 現在のページ数を指定してください。
+  - `showTotal`(任意):
+  現在のページ数と総ページ数を表示します。デフォルト値はfalseです。
 </Description>
 <Description>
-  - `total`(必須): 総ページ数を指定してください。
+  - `showFirstLast`(任意):
+  「最初へ」「最後へ」アイコンを表示したい場合は、指定することができます。デフォルト値はfalseです。
 </Description>
 <Description>
-  - `showTotal`(任意): 現在のページ数と総ページ数を表示します。デフォルト値はfalseです。
-</Description>
-<Description>
-  - `showFirstLast`(任意): 「最初へ」「最後へ」アイコンを表示したい場合は、指定することができます。デフォルト値はfalseです。
-</Description>
-<Description>
-  - `onPageChange`(必須): リンクをクリック後に処理をしたい場合に利用することができます。
+  - `onPageChange`(必須):
+  リンクをクリック後に処理をしたい場合に利用することができます。
 </Description>
 <Description>
   - `createUrl`(必須): リンクのhrefとなる値を指定してください。
@@ -66,7 +63,6 @@ export const pageNumber = 1;
     <Pagination
       total={5}
       current={3}
-      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -75,7 +71,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## current 1 total 1
@@ -85,7 +83,6 @@ export const pageNumber = 1;
     <Pagination
       total={1}
       current={1}
-      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -94,7 +91,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={1} current={1} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={1} current={1} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## current 2 total 2
@@ -104,7 +103,6 @@ export const pageNumber = 1;
     <Pagination
       total={2}
       current={2}
-      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -113,7 +111,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={2} current={2} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={2} current={2} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## current 2 total 3
@@ -123,7 +123,6 @@ export const pageNumber = 1;
     <Pagination
       total={3}
       current={2}
-      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -132,7 +131,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={3} current={2} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={3} current={2} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## current 2 total 4
@@ -142,7 +143,6 @@ export const pageNumber = 1;
     <Pagination
       total={4}
       current={2}
-      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -151,7 +151,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={4} current={2} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={4} current={2} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## current 8 total 20
@@ -161,7 +163,6 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -170,7 +171,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={20} current={8} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## current 900 total 999
@@ -180,7 +183,6 @@ export const pageNumber = 1;
     <Pagination
       total={999}
       current={900}
-      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -189,7 +191,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={999} current={900} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={999} current={900} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## current 10000 total 20000
@@ -203,7 +207,6 @@ export const pageNumber = 1;
     <Pagination
       total={20000}
       current={10000}
-      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -212,7 +215,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20000} current={10000} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={20000} current={10000} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## showTotal props true
@@ -235,7 +240,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showTotal={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={20} current={8} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## showFirstLast props false
@@ -253,7 +260,6 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -262,7 +268,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showTotal={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={20} current={8} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## create url function
@@ -272,7 +280,6 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -281,7 +288,9 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showTotal={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={
+    '<Pagination total={20} current={8} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+  }
 />
 
 ## リンク動作のカスタマイズ

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -44,7 +44,7 @@ import { Pagination } from './Pagination';
   - `total`(必須): 総ページ数を指定してください。
 </Description>
 <Description>
-  - `showCount`(任意): ページのカウントを表示したい場合は、指定することができます。デフォルト値はfalseです。
+  - `showTotal`(任意): 現在のページ数と総ページ数を表示します。デフォルト値はfalseです。
 </Description>
 <Description>
   - `showFirstLast`(任意): 「最初へ」「最後へ」アイコンを表示したい場合は、指定することができます。デフォルト値はfalseです。
@@ -66,7 +66,7 @@ export const pageNumber = 1;
     <Pagination
       total={5}
       current={3}
-      showCount={true}
+      showTotal={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -75,7 +75,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 1 total 1
@@ -85,7 +85,7 @@ export const pageNumber = 1;
     <Pagination
       total={1}
       current={1}
-      showCount={true}
+      showTotal={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -94,7 +94,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={1} current={1} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={1} current={1} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 2
@@ -104,7 +104,7 @@ export const pageNumber = 1;
     <Pagination
       total={2}
       current={2}
-      showCount={true}
+      showTotal={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -113,7 +113,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={2} current={2} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={2} current={2} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 3
@@ -123,7 +123,7 @@ export const pageNumber = 1;
     <Pagination
       total={3}
       current={2}
-      showCount={true}
+      showTotal={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -132,7 +132,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={3} current={2} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={3} current={2} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 4
@@ -142,7 +142,7 @@ export const pageNumber = 1;
     <Pagination
       total={4}
       current={2}
-      showCount={true}
+      showTotal={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -151,7 +151,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={4} current={2} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={4} current={2} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 8 total 20
@@ -161,7 +161,7 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showCount={true}
+      showTotal={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -170,7 +170,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 900 total 999
@@ -180,7 +180,7 @@ export const pageNumber = 1;
     <Pagination
       total={999}
       current={900}
-      showCount={true}
+      showTotal={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -189,7 +189,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={999} current={900} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={999} current={900} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 10000 total 20000
@@ -203,7 +203,7 @@ export const pageNumber = 1;
     <Pagination
       total={20000}
       current={10000}
-      showCount={true}
+      showTotal={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -212,7 +212,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20000} current={10000} showCount={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20000} current={10000} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## showFirstLast props false
@@ -230,7 +230,7 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showCount={true}
+      showTotal={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -239,7 +239,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## showPrevNext props false
@@ -257,7 +257,7 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showCount={true}
+      showTotal={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -266,7 +266,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## showPrevNext showFirstLast props false
@@ -284,7 +284,7 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showCount={true}
+      showTotal={true}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -293,7 +293,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## create url function
@@ -303,7 +303,7 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showCount={true}
+      showTotal={true}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -312,7 +312,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showCount={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## リンク動作のカスタマイズ

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -66,7 +66,7 @@ export const pageNumber = 1;
     <Pagination
       total={5}
       current={3}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -75,7 +75,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 1 total 1
@@ -85,7 +85,7 @@ export const pageNumber = 1;
     <Pagination
       total={1}
       current={1}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -94,7 +94,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={1} current={1} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={1} current={1} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 2
@@ -104,7 +104,7 @@ export const pageNumber = 1;
     <Pagination
       total={2}
       current={2}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -113,7 +113,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={2} current={2} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={2} current={2} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 3
@@ -123,7 +123,7 @@ export const pageNumber = 1;
     <Pagination
       total={3}
       current={2}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -132,7 +132,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={3} current={2} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={3} current={2} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 2 total 4
@@ -142,7 +142,7 @@ export const pageNumber = 1;
     <Pagination
       total={4}
       current={2}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -151,7 +151,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={4} current={2} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={4} current={2} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 8 total 20
@@ -161,7 +161,7 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -170,7 +170,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 900 total 999
@@ -180,7 +180,7 @@ export const pageNumber = 1;
     <Pagination
       total={999}
       current={900}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -189,7 +189,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={999} current={900} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={999} current={900} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## current 10000 total 20000
@@ -203,7 +203,7 @@ export const pageNumber = 1;
     <Pagination
       total={20000}
       current={10000}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -212,7 +212,30 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20000} current={10000} showTotal={true} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20000} current={10000} showTotal={false} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+/>
+
+## showTotal props true
+
+<Description>
+  `showTotal`プロパティは`true`にすることで、現在のページ数と総ページ数を表示することができます。
+</Description>
+
+<Preview withSource="open">
+  <Story name="showTotal props true">
+    <Pagination
+      total={20}
+      current={8}
+      showTotal={true}
+      showFirstLast={false}
+      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      {...actions('onClick')}
+    />
+  </Story>
+</Preview>
+
+<Source
+  code={'<Pagination total={20} current={8} showTotal={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## showFirstLast props false
@@ -230,7 +253,7 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -239,61 +262,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
-/>
-
-## showPrevNext props false
-
-<Description>
-  `showPrevNext`プロパティは`false`にすることで、「前へ」と「次へ」アイコンを非表示にできます。
-</Description>
-
-<Description>
-  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
-</Description>
-
-<Preview withSource="open">
-  <Story name="showPrevNext props false">
-    <Pagination
-      total={20}
-      current={8}
-      showTotal={true}
-      showFirstLast={true}
-      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
-      {...actions('onClick')}
-    />
-  </Story>
-</Preview>
-
-<Source
-  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
-/>
-
-## showPrevNext showFirstLast props false
-
-<Description>
-  `showPrevNext`と`showFirstLast`プロパティは`false`にすることで、全てのアイコンを非表示にできます。
-</Description>
-
-<Description>
-  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
-</Description>
-
-<Preview withSource="open">
-  <Story name="showPrevNext showFirstLast props false">
-    <Pagination
-      total={20}
-      current={8}
-      showTotal={true}
-      showFirstLast={false}
-      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
-      {...actions('onClick')}
-    />
-  </Story>
-</Preview>
-
-<Source
-  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showTotal={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## create url function
@@ -303,7 +272,7 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showTotal={true}
+      showTotal={false}
       showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
@@ -312,7 +281,7 @@ export const pageNumber = 1;
 </Preview>
 
 <Source
-  code={'<Pagination total={20} current={8} showTotal={true} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
+  code={'<Pagination total={20} current={8} showTotal={false} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'}
 />
 
 ## リンク動作のカスタマイズ

--- a/packages/spindle-ui/src/Pagination/Pagination.test.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.test.tsx
@@ -14,7 +14,7 @@ describe('<Pagination />', () => {
       <Pagination
         total={20}
         current={8}
-        showCount={true}
+        showTotal={true}
         showFirstLast={true}
         createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
         onPageChange={onClick}

--- a/packages/spindle-ui/src/Pagination/Pagination.test.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.test.tsx
@@ -15,7 +15,6 @@ describe('<Pagination />', () => {
         total={20}
         current={8}
         showCount={true}
-        showPrevNext={true}
         showFirstLast={true}
         createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
         onPageChange={onClick}

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -7,7 +7,7 @@ import { useShowItem } from './hooks/useShowItem';
 interface Props extends React.HTMLAttributes<HTMLElement> {
   current: number;
   total: number;
-  showCount?: boolean;
+  showTotal?: boolean;
   showFirstLast?: boolean;
   onPageChange: (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
@@ -25,7 +25,7 @@ export const Pagination = (props: Props) => {
   const {
     current,
     total,
-    showCount = false,
+    showTotal = false,
     showFirstLast = false,
     onPageChange,
     createUrl,
@@ -159,9 +159,9 @@ export const Pagination = (props: Props) => {
           </li>
         )}
       </ul>
-      {showCount && (
+      {showTotal && (
         <p
-          className={`${BLOCK_NAME}-count`}
+          className={`${BLOCK_NAME}-total`}
           aria-label={`${total}ページ中の${current}ページ目`}
         >
           {current}/{total}ページ

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -8,7 +8,6 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
   current: number;
   total: number;
   showCount?: boolean;
-  showPrevNext?: boolean;
   showFirstLast?: boolean;
   onPageChange: (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
@@ -19,12 +18,14 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
 
 const BLOCK_NAME = 'spui-Pagination';
 
+// 表示仕様が変わる桁の閾値
+const DIGIT_THRESHOLD = 100;
+
 export const Pagination = (props: Props) => {
   const {
     current,
     total,
     showCount = false,
-    showPrevNext = true,
     showFirstLast = false,
     onPageChange,
     createUrl,
@@ -51,6 +52,7 @@ export const Pagination = (props: Props) => {
     },
     [onPageChange],
   );
+  const showPrevNext = total < DIGIT_THRESHOLD;
 
   return (
     <nav

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -18,8 +18,8 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
 
 const BLOCK_NAME = 'spui-Pagination';
 
-// 表示仕様が変わる桁の閾値
-const DIGIT_THRESHOLD = 100;
+// ページ総数の閾値
+const TOTAL_THRESHOLD = 100;
 
 export const Pagination = (props: Props) => {
   const {
@@ -52,7 +52,7 @@ export const Pagination = (props: Props) => {
     },
     [onPageChange],
   );
-  const showPrevNext = total < DIGIT_THRESHOLD;
+  const showPrevNext = total < TOTAL_THRESHOLD;
 
   return (
     <nav


### PR DESCRIPTION
### 概要
Paginationコンポーネントの

- リンクのpadding値を修正
- showCountをShowTotalに変更
- 「次へ」「前へ」周りの改修

を対応しました。padding値とshowCountは修正の粒度が小さめだったためこのPull requestに混ぜさせてもらった形です。

#### リンクのpadding値を修正
値を4pxから10pxに変更しました。
デザインフィードバックの対応になります。

#### showCountをShowTotalに変更
名前がTotalの方がわかりやすいという意見を受け変更しました。
表示仕様は下記の通りです。

#### 「次へ」「前へ」周りの改修
今までは利用者側が表示／非表示を選択できましたが表示に関する処理はSpindle側でハンドリングするように変更しました。

| 総ページ数が100件未満の場合 | 総ページ数が100件以上の場合 |
| -------- | -------- |
| 表示     | 非表示     | 

### リリースまで
いくつかPull requestを分けて `fix/pagination` ブランチにマージしていき最終的に`main`ブランチからリリースしたいと思います。

- [x] リンクのpadding値を修正
- [x] showCountをShowTotalに変更
- [x] 「次へ」「前へ」周りの改修
- [ ] 「最初へ」「最後へ」周りの改修
- [ ] propsの精査（必須／任意の変更分）
- [ ] propsが変化したことによるstory bookの精査
- [ ] テスト追加
- [ ] ページ番号表示ロジック
- [ ] orientationchange（画面幅）を考慮した処理の追加