### PR TITLE
fix(spindle-ui): avoid running dialog showModal() twice in Strict Mode

### DIFF
--- a/packages/spindle-ui/src/Dialog/Dialog.tsx
+++ b/packages/spindle-ui/src/Dialog/Dialog.tsx
@@ -72,7 +72,9 @@ const Frame = forwardRef<DialogHTMLElement, DialogProps>(function Dialog(
     const classNameToStopScrollBehindDialog = `${BLOCK_NAME}--open`;
 
     if (open) {
-      dialogEl.current.showModal && dialogEl.current.showModal();
+      !dialogEl.current.open &&
+        dialogEl.current.showModal &&
+        dialogEl.current.showModal();
       document.documentElement.classList.add(classNameToStopScrollBehindDialog);
     } else {
       dialogEl.current?.open && setClosing(true);

--- a/packages/spindle-ui/src/Dialog/Dialog.tsx
+++ b/packages/spindle-ui/src/Dialog/Dialog.tsx
@@ -64,7 +64,8 @@ const Frame = forwardRef<DialogHTMLElement, DialogProps>(function Dialog(
   }, [dialogEl, handleAnimationEnd]);
 
   useEffect(() => {
-    if (!dialogEl.current) {
+    const dialog = dialogEl.current;
+    if (!dialog) {
       return;
     }
 
@@ -72,12 +73,10 @@ const Frame = forwardRef<DialogHTMLElement, DialogProps>(function Dialog(
     const classNameToStopScrollBehindDialog = `${BLOCK_NAME}--open`;
 
     if (open) {
-      !dialogEl.current.open &&
-        dialogEl.current.showModal &&
-        dialogEl.current.showModal();
+      !dialog.open && dialog.showModal?.();
       document.documentElement.classList.add(classNameToStopScrollBehindDialog);
     } else {
-      dialogEl.current?.open && setClosing(true);
+      dialog?.open && setClosing(true);
       // Always remove this class to avoid unexpected scroll stopping
       document.documentElement.classList.remove(
         classNameToStopScrollBehindDialog,

--- a/packages/spindle-ui/src/Modal/AppealModal.tsx
+++ b/packages/spindle-ui/src/Modal/AppealModal.tsx
@@ -72,7 +72,8 @@ const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
     }, [dialogEl, handleAnimationEnd]);
 
     useEffect(() => {
-      if (!dialogEl.current) {
+      const dialog = dialogEl.current;
+      if (!dialog) {
         return;
       }
 
@@ -80,14 +81,12 @@ const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
       const classNameToStopScrollBehindDialog = `${BLOCK_NAME}--open`;
 
       if (open) {
-        !dialogEl.current.open &&
-          dialogEl.current.showModal &&
-          dialogEl.current.showModal();
+        !dialog.open && dialog.showModal?.();
         document.documentElement.classList.add(
           classNameToStopScrollBehindDialog,
         );
       } else {
-        dialogEl.current?.open && setClosing(true);
+        dialog?.open && setClosing(true);
         // Always remove this class to avoid unexpected scroll stopping
         document.documentElement.classList.remove(
           classNameToStopScrollBehindDialog,

--- a/packages/spindle-ui/src/Modal/AppealModal.tsx
+++ b/packages/spindle-ui/src/Modal/AppealModal.tsx
@@ -80,7 +80,9 @@ const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
       const classNameToStopScrollBehindDialog = `${BLOCK_NAME}--open`;
 
       if (open) {
-        dialogEl.current.showModal && dialogEl.current.showModal();
+        !dialogEl.current.open &&
+          dialogEl.current.showModal &&
+          dialogEl.current.showModal();
         document.documentElement.classList.add(
           classNameToStopScrollBehindDialog,
         );


### PR DESCRIPTION
React v18のStrict Modeを有効にしている場合に`dialog`要素の`showModal`関数が正しく機能せずエラーになる問題を修正しました

エラー文：
```
InvalidStateError: Failed to execute 'showModal' on 'HTMLDialogElement': The element already has an 'open' attribute, and therefore cannot be opened modally.
```

## 関連 
- Issue：https://github.com/facebook/react/issues/24399#issuecomment-1104191934
- Docs：https://reactjs.org/blog/2022/03/29/react-v18.html#new-strict-mode-behaviors