### PR TITLE
fix(spindle-ui): pagination first last

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -42,10 +42,6 @@ import { Pagination } from './Pagination';
   現在のページ数と総ページ数を表示します。デフォルト値はfalseです。
 </Description>
 <Description>
-  - `showFirstLast`(任意):
-  「最初へ」「最後へ」アイコンを表示したい場合は、指定することができます。デフォルト値はfalseです。
-</Description>
-<Description>
   - `onPageChange`(必須):
   リンクをクリック後に処理をしたい場合に利用することができます。
 </Description>
@@ -63,7 +59,6 @@ export const pageNumber = 1;
     <Pagination
       total={5}
       current={3}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -72,7 +67,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination url="/article/page-PAGE_NUMBER.html" total={5} current={3} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -83,7 +78,6 @@ export const pageNumber = 1;
     <Pagination
       total={1}
       current={1}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -92,7 +86,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={1} current={1} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={1} current={1} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -103,7 +97,6 @@ export const pageNumber = 1;
     <Pagination
       total={2}
       current={2}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -112,7 +105,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={2} current={2} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={2} current={2} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -123,7 +116,6 @@ export const pageNumber = 1;
     <Pagination
       total={3}
       current={2}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -132,7 +124,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={3} current={2} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={3} current={2} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -143,7 +135,6 @@ export const pageNumber = 1;
     <Pagination
       total={4}
       current={2}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -152,7 +143,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={4} current={2} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={4} current={2} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -163,7 +154,6 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -172,7 +162,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={20} current={8} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -183,7 +173,6 @@ export const pageNumber = 1;
     <Pagination
       total={999}
       current={900}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -192,7 +181,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={999} current={900} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={999} current={900} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -207,7 +196,6 @@ export const pageNumber = 1;
     <Pagination
       total={20000}
       current={10000}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -216,7 +204,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={20000} current={10000} showFirstLast={true} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={20000} current={10000} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -232,7 +220,6 @@ export const pageNumber = 1;
       total={20}
       current={8}
       showTotal={true}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -241,7 +228,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={20} current={8} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -260,7 +247,6 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showFirstLast={false}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -269,7 +255,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={20} current={8} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 
@@ -280,7 +266,6 @@ export const pageNumber = 1;
     <Pagination
       total={20}
       current={8}
-      showFirstLast={true}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
       {...actions('onClick')}
     />
@@ -289,7 +274,7 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={20} current={8} showFirstLast={false} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
   }
 />
 

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -232,33 +232,6 @@ export const pageNumber = 1;
   }
 />
 
-## showFirstLast props false
-
-<Description>
-  `showFirstLast`プロパティは`false`にすることで、「最初へ」と「最後へ」アイコンを非表示にできます。
-</Description>
-
-<Description>
-  その場合、ページ番号にて前後と最初と最後のリンクを担保します。
-</Description>
-
-<Preview withSource="open">
-  <Story name="showFirstLast props false">
-    <Pagination
-      total={20}
-      current={8}
-      createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
-      {...actions('onClick')}
-    />
-  </Story>
-</Preview>
-
-<Source
-  code={
-    '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
-  }
-/>
-
 ## create url function
 
 <Preview withSource="open">

--- a/packages/spindle-ui/src/Pagination/Pagination.test.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.test.tsx
@@ -15,7 +15,6 @@ describe('<Pagination />', () => {
         total={20}
         current={8}
         showTotal={true}
-        showFirstLast={true}
         createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
         onPageChange={onClick}
       />,

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -8,7 +8,6 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
   current: number;
   total: number;
   showTotal?: boolean;
-  showFirstLast?: boolean;
   onPageChange: (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
     pageNumber: number,
@@ -26,7 +25,6 @@ export const Pagination = (props: Props) => {
     current,
     total,
     showTotal = false,
-    showFirstLast = false,
     onPageChange,
     createUrl,
     className,
@@ -53,6 +51,7 @@ export const Pagination = (props: Props) => {
     [onPageChange],
   );
   const showPrevNext = total < TOTAL_THRESHOLD;
+  const showFirstLast = total >= TOTAL_THRESHOLD;
 
   return (
     <nav


### PR DESCRIPTION
### 概要
Paginationコンポーネントの「最初へ」「最後へ」周りの改修をおこないました。
主な変更内容は下記の通りです。

- 表示条件変更
- props廃止に伴う項目削除
- props廃止に伴うstorybookとテストコード削除


#### 「最初へ」「最後へ」の表示条件変更
今までは利用者側が表示／非表示を選択できましたが表示に関する処理はSpindle側でハンドリングするように変更しました。
変更の仕様は下記になります。

| 総ページ数が100件未満の場合 | 総ページ数が100件以上の場合 |
| -------- | -------- |
| 非表示     | 表示     | 

### リリースまで
いくつかPull requestを分けて `fix/pagination` ブランチにマージしていき最終的に`main`ブランチからリリースしたいと思います。

- [x] リンクのpadding値を修正
- [x] showCountをShowTotalに変更
- [x] 「次へ」「前へ」周りの改修
- [x] 「最初へ」「最後へ」周りの改修
  - [x] propsが変化したことによるstory bookの精査
- [ ] ellipsisの表示条件修正
- [ ] onPageChangeを任意に変更
  - [ ] propsが変化したことによるstory bookの修正
- [ ] テスト追加
- [ ] ページ番号表示ロジック
- [ ] orientationchange（画面幅）を考慮した処理の追加