### PR TITLE
ci: use npx with lerna publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         id: extract_branch
       - name: Releaseing with lerna
         # also see some options in lerna.json
-        run: yarn lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
+        run: npx lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Create Pull Request


### PR DESCRIPTION
CIリリースフローの`lerna publish`がうまく動作しないことがあるため、スクリプトを以前の`npx`を使う形に戻しました

ref; https://github.com/openameba/spindle/pull/581#issuecomment-1314976132