### PR TITLE
fix(spindle-ui): show ellipsis logic

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -89,7 +89,6 @@
   padding: 0;
 }
 
-.spui-Pagination-ellipsis + .spui-Pagination-link,
 .spui-Pagination-link + .spui-Pagination-ellipsis {
   margin-left: 10px;
 }

--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -32,7 +32,7 @@
   margin: 0;
 }
 
-.spui-Pagination-horizontal {
+.spui-Pagination-ellipsis {
   color: var(--color-object-low-emphasis);
 }
 
@@ -89,8 +89,8 @@
   padding: 0;
 }
 
-.spui-Pagination-horizontal + .spui-Pagination-link,
-.spui-Pagination-link + .spui-Pagination-horizontal {
+.spui-Pagination-ellipsis + .spui-Pagination-link,
+.spui-Pagination-link + .spui-Pagination-ellipsis {
   margin-left: 8px;
 }
 

--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -91,7 +91,7 @@
 
 .spui-Pagination-ellipsis + .spui-Pagination-link,
 .spui-Pagination-link + .spui-Pagination-ellipsis {
-  margin-left: 8px;
+  margin-left: 10px;
 }
 
 @media screen and (max-width: 414px) {

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -31,12 +31,7 @@ export const Pagination = (props: Props) => {
     ...rest
   } = props;
 
-  const {
-    displayItem,
-    showPrevHorizontal,
-    showNextHorizontal,
-    hideDisplayItem,
-  } = useShowItem({
+  const { displayItem, hideDisplayItem } = useShowItem({
     current,
     total,
   });
@@ -89,9 +84,10 @@ export const Pagination = (props: Props) => {
             hideDisplayItem &&
             (current - 1 === pageNumber || current + 1 === pageNumber);
           const hasRelAttribute = current === pageNumber + 1;
-          const showPrevMenuHorizontal = index === 0 && showPrevHorizontal;
-          const showNextMenuHorizontal =
-            index === displayItem.length - 1 && showNextHorizontal;
+
+          // 数字が隣接していない場合に表示
+          const showEllipsis =
+            !!displayItem[index + 1] && displayItem[index + 1] - pageNumber > 1;
 
           return (
             <li
@@ -103,12 +99,6 @@ export const Pagination = (props: Props) => {
                 .join(' ')}
               key={`pagination-item-${pageNumber}`}
             >
-              {showNextMenuHorizontal && (
-                <MenuHorizontal
-                  aria-hidden="true"
-                  className={`${BLOCK_NAME}-horizontal`}
-                />
-              )}
               <a
                 className={`${BLOCK_NAME}-link`}
                 rel={hasRelAttribute ? undefined : 'nofollow'}
@@ -126,10 +116,10 @@ export const Pagination = (props: Props) => {
               >
                 {pageNumber}
               </a>
-              {showPrevMenuHorizontal && (
+              {showEllipsis && (
                 <MenuHorizontal
                   aria-hidden="true"
-                  className={`${BLOCK_NAME}-horizontal`}
+                  className={`${BLOCK_NAME}-ellipsis`}
                 />
               )}
             </li>

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
@@ -9,8 +9,6 @@ describe('useShowItem()', () => {
     const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 7, 8, 9, 20]);
-    expect(result.current.showPrevHorizontal).toEqual(true);
-    expect(result.current.showNextHorizontal).toEqual(true);
     expect(result.current.hideDisplayItem).toEqual(true);
   });
 
@@ -21,8 +19,6 @@ describe('useShowItem()', () => {
     const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 2, 3, 4, 20]);
-    expect(result.current.showPrevHorizontal).toEqual(false);
-    expect(result.current.showNextHorizontal).toEqual(true);
     expect(result.current.hideDisplayItem).toEqual(true);
   });
 
@@ -33,8 +29,6 @@ describe('useShowItem()', () => {
     const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 17, 18, 19, 20]);
-    expect(result.current.showPrevHorizontal).toEqual(true);
-    expect(result.current.showNextHorizontal).toEqual(false);
     expect(result.current.hideDisplayItem).toEqual(true);
   });
 
@@ -45,8 +39,6 @@ describe('useShowItem()', () => {
     const { result } = renderHook(() => useShowItem({ current, total }));
 
     expect(result.current.displayItem).toEqual([1, 2, 3]);
-    expect(result.current.showPrevHorizontal).toEqual(false);
-    expect(result.current.showNextHorizontal).toEqual(false);
     expect(result.current.hideDisplayItem).toEqual(false);
   });
 });

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -24,20 +24,11 @@ export function useShowItem({ current, total }: Payload) {
     }
   }, [current, total]);
 
-  // totalは表示数超えている前提で、前から2つ目のアイテムが2より大きいかどうか（最初が連続した数字じゃないことをチェック）
-  const showPrevHorizontal = total > MAX_PAGE_ITEM && 2 < displayItem[1];
-
-  // totalは表示数超えている前提で、後ろから2つ目のアイテムがtotal-1より小さいか（最後が連続した数字じゃないことをチェック）
-  const showNextHorizontal =
-    total > MAX_PAGE_ITEM && displayItem[MAX_PAGE_ITEM - 2] < total - 1;
-
   // 総ページ数が5件より大きい場合
   const hideDisplayItem = total > MAX_PAGE_ITEM;
 
   return {
     displayItem,
-    showPrevHorizontal,
-    showNextHorizontal,
     hideDisplayItem,
   };
 }


### PR DESCRIPTION
### 概要
PaginationコンポーネントのEllipsis（...）周りの改修をおこないました。
主な変更内容は下記の通りです。

- Ellipsisの表示条件を `数字が隣接していない場合に表示` に変更
- class名をhorizontalからellipsisに変更
- useShowItem側で定義していた処理とテストコードが不要になったため削除

#### Ellipsisの表示条件変更
```
// 数字が隣接していない場合に表示
const showEllipsis = !!displayItem[index + 1] && displayItem[index + 1] - pageNumber > 1;

{showEllipsis && (
  <MenuHorizontal
    aria-hidden="true"
    className={`${BLOCK_NAME}-ellipsis`}
  />
)}
```

### リリースまで
いくつかPull requestを分けて `fix/pagination` ブランチにマージしていき最終的に`main`ブランチからリリースしたいと思います。

- [x] リンクのpadding値を修正
- [x] showCountをShowTotalに変更
- [x] 「次へ」「前へ」周りの改修
- [x] 「最初へ」「最後へ」周りの改修
  - [x] propsが変化したことによるstory bookの精査
- [x] ellipsisの表示条件修正
- [ ] onPageChangeを任意に変更
  - [ ] propsが変化したことによるstory bookの修正
- [ ] テスト追加
- [ ] ページ番号表示ロジック
- [ ] orientationchange（画面幅）を考慮した処理の追加