### PR TITLE
Revert "ci: use npx with lerna publish"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         id: extract_branch
       - name: Releaseing with lerna
         # also see some options in lerna.json
-        run: npx lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
+        run: yarn lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Create Pull Request


### PR DESCRIPTION
Reverts openameba/spindle#584

CIのlerna publishが落ちる問題の調査で`npx`を使用していたのを元に戻しました