### PR TITLE
fix(spindle-ui): on page change props

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -255,16 +255,11 @@ export const handleClick = (event, pageNumber) => {
 </Preview>
 
 <Source
-  code={`
-    function Component({children, url = '', external, ref, ...rest}) {
-      const handleClick = (event, pageNumber) => {
-        event.preventDefault();
-        router.push(pageNumber);
-      };
-      return (
-    ` + 
-        '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} onPageChange={(event, pageNumber) => { handleClick(event, pageNumber); }} />'
-    + `);
-    }
-  `}
+code={`
+  const handleClick = (event, pageNumber) => {
+    event.preventDefault();
+    // router.push などで遷移処理を記述
+};
+` +'<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} onPageChange={(event, pageNumber) => { handleClick(event, pageNumber); }} />'+ `
+`}
 />

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -234,6 +234,10 @@ export const pageNumber = 1;
 
 ## on page change function
 
+<Description>
+  各サービスでルーティングを利用したい場合は、onPageChangeの第一引数にあるeventを利用してください。
+</Description>
+
 export const handleClick = (event, pageNumber) => {
   event.preventDefault();
 };
@@ -251,26 +255,16 @@ export const handleClick = (event, pageNumber) => {
 </Preview>
 
 <Source
-  code={
-    '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} onPageChange={(event, pageNumber) => { handleClick(event, pageNumber); }} />'
-  }
-/>
-
-### リンク動作のカスタマイズ
-
-<Description>
-  各サービスでルーティングを利用したい場合は、onPageChangeの第一引数にあるeventを利用してください。
-</Description>
-
-<Source
-  code={`function Component({children, url = '', external, ref, ...rest}) {
-    const handleClick = (event, pageNumber) => {
-      event.preventDefault();
-      router.push(pageNumber);
-    };
-    return (
-      <Pagination onPageChange={(event, pageNumber) => { handleClick(event, pageNumber); }} />
-    );
-  }
-`}
+  code={`
+    function Component({children, url = '', external, ref, ...rest}) {
+      const handleClick = (event, pageNumber) => {
+        event.preventDefault();
+        router.push(pageNumber);
+      };
+      return (
+    ` + 
+        '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} onPageChange={(event, pageNumber) => { handleClick(event, pageNumber); }} />'
+    + `);
+    }
+  `}
 />

--- a/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
+++ b/packages/spindle-ui/src/Pagination/Pagination.stories.mdx
@@ -42,7 +42,7 @@ import { Pagination } from './Pagination';
   現在のページ数と総ページ数を表示します。デフォルト値はfalseです。
 </Description>
 <Description>
-  - `onPageChange`(必須):
+  - `onPageChange`(任意):
   リンクをクリック後に処理をしたい場合に利用することができます。
 </Description>
 <Description>
@@ -232,14 +232,19 @@ export const pageNumber = 1;
   }
 />
 
-## create url function
+## on page change function
+
+export const handleClick = (event, pageNumber) => {
+  event.preventDefault();
+};
 
 <Preview withSource="open">
-  <Story name="create url function">
+  <Story name="on page change function">
     <Pagination
       total={20}
       current={8}
       createUrl={(pageNumber) => `/detail/${pageNumber}.html`}
+      onPageChange={(event, pageNumber) => { handleClick(event, pageNumber); }}
       {...actions('onClick')}
     />
   </Story>
@@ -247,11 +252,11 @@ export const pageNumber = 1;
 
 <Source
   code={
-    '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} />'
+    '<Pagination total={20} current={8} createUrl={(pageNumber) => `/detail/${pageNumber}.html`} onPageChange={(event, pageNumber) => { handleClick(event, pageNumber); }} />'
   }
 />
 
-## リンク動作のカスタマイズ
+### リンク動作のカスタマイズ
 
 <Description>
   各サービスでルーティングを利用したい場合は、onPageChangeの第一引数にあるeventを利用してください。

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -8,7 +8,7 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
   current: number;
   total: number;
   showTotal?: boolean;
-  onPageChange: (
+  onPageChange?: (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
     pageNumber: number,
   ) => void;


### PR DESCRIPTION
### 概要
PaginationコンポーネントのonPageChange周りの改修をおこないました。
主な変更内容は下記の通りです。

- onPageChangeを必須から任意に変更
- storybook
  - createUrlは元々必須で他の箇所で定義されているので `create url function ` のstoryは削除
  - 新たに `on page change` のstoryを追加

### リリースまで
いくつかPull requestを分けて `fix/pagination` ブランチにマージしていき最終的に`main`ブランチからリリースしたいと思います。

- [x] リンクのpadding値を修正
- [x] showCountをShowTotalに変更
- [x] 「次へ」「前へ」周りの改修
- [x] 「最初へ」「最後へ」周りの改修
  - [x] propsが変化したことによるstory bookの精査
- [x] ellipsisの表示条件修正
- [x] onPageChangeを任意に変更
  - [x] propsが変化したことによるstory bookの修正
- [ ] テスト追加
- [ ] ページ番号表示ロジック
- [ ] orientationchange（画面幅）を考慮した処理の追加