### PR TITLE
fix(spindle-ui): remove closing className

### DIFF
--- a/packages/spindle-ui/src/Dialog/Dialog.tsx
+++ b/packages/spindle-ui/src/Dialog/Dialog.tsx
@@ -41,6 +41,23 @@ const Frame = forwardRef<DialogHTMLElement, DialogProps>(function Dialog(
     typeof onClose === 'function' && onClose(event);
   };
 
+  const handleDialogClick = (event: React.MouseEvent<DialogHTMLElement>) => {
+    // Detect backdrop click
+    if (event.target === dialogEl.current) {
+      onClose && onClose(event);
+    }
+  };
+
+  const handleDialogClose = (
+    event: React.SyntheticEvent<DialogHTMLElement>,
+  ) => {
+    // Detect escape key type
+    if (event.target === dialogEl.current) {
+      onClose && onClose(event);
+      setClosing(false);
+    }
+  };
+
   const handleAnimationEnd = useCallback(
     (event: AnimationEvent) => {
       if (
@@ -91,6 +108,8 @@ const Frame = forwardRef<DialogHTMLElement, DialogProps>(function Dialog(
         .filter(Boolean)
         .join(' ')
         .trim()}
+      onClick={handleDialogClick}
+      onClose={handleDialogClose}
       {...rest}
     >
       <form method="dialog" onSubmit={handleFormSubmit}>

--- a/packages/spindle-ui/src/Modal/AppealModal.tsx
+++ b/packages/spindle-ui/src/Modal/AppealModal.tsx
@@ -49,6 +49,16 @@ const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
       }
     };
 
+    const handleDialogClose = (
+      event: React.SyntheticEvent<DialogHTMLElement>,
+    ) => {
+      // Detect escape key type
+      if (event.target === dialogEl.current) {
+        onClose && onClose(event);
+        setClosing(false);
+      }
+    };
+
     const handleAnimationEnd = useCallback(
       (event: AnimationEvent) => {
         if (
@@ -57,7 +67,6 @@ const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
           !event.pseudoElement // To exclude ::backdrop
         ) {
           dialogEl.current.close && dialogEl.current.close();
-          setClosing(false);
         }
       },
       [dialogEl],
@@ -107,6 +116,7 @@ const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
           .trim()}
         ref={mergeRefs([dialogEl, ref])}
         onClick={handleDialogClick}
+        onClose={handleDialogClose}
         {...rest}
       >
         <form


### PR DESCRIPTION
## 概要
AppealModalコンポーネントをEscキーで閉じた後、再度開いた際に正常に表示されない挙動を修正しました。

### 原因
- `.spui-spui-AppealModal--closing`がModalを閉じた後も残ったままだった。
  - 同classNameの付与を担うclosingフラグが更新されていなかった。

### 修正内容
- dialog要素のonCloseにclosingを更新する`setClosing(false)`を渡し、Modalを閉じた後に必ず`closing === false`になるようにしました。