### PR TITLE
ci: fix to build spindle-hooks in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-v2
       - run: yarn install --frozen-lockfile
       - run: npx lerna bootstrap -- --frozen-lockfile
+      - run: yarn lerna run --scope @openameba/spindle-hooks build
       - name: Set git user
         run: |
           git config --global user.email "<>"


### PR DESCRIPTION
## 概要

[こちらのPRで更新されたREADME](https://github.com/openameba/spindle/pull/549/files#diff-94c99b905e8a1e53cf0266baf773d2becaed6017a0a1fed31275f7b02e6541e6)の通り、`spindle-ui`のビルドには事前に`spindle-hooks`のビルドをしておく必要がありました

これがリリースワークフローで漏れており、ジョブが失敗していました

## 変更内容

リリースワークフローに`spindle-hooks`をビルドするstepを追加しました

## 実行結果

- 以前失敗したジョブ：https://github.com/openameba/spindle/actions/runs/3468636795/jobs/5794675007#step:10:38
- 今回成功したジョブ：https://github.com/openameba/spindle/actions/runs/3562325341