### PR TITLE
fix(spindle-ui): change show item logic

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -93,12 +93,6 @@
   margin-left: 10px;
 }
 
-@media screen and (max-width: 414px) {
-  .spui-Pagination-item--hidden {
-    display: none;
-  }
-}
-
 @media screen and (max-width: 360px) {
   .spui-Pagination-item--first,
   .spui-Pagination-item--last {

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -34,6 +34,7 @@ export const Pagination = (props: Props) => {
   const displayItem = useShowItem({
     current,
     total,
+    showItemSize: 5,
     totalThreshold: TOTAL_THRESHOLD,
   });
 

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -19,6 +19,8 @@ const BLOCK_NAME = 'spui-Pagination';
 
 // ページ総数の閾値
 const TOTAL_THRESHOLD = 100;
+// 表示出来る数字（アイテム）の最大数
+const MAX_SHOW_ITEM_SIZE = 5;
 
 export const Pagination = (props: Props) => {
   const {
@@ -31,9 +33,11 @@ export const Pagination = (props: Props) => {
     ...rest
   } = props;
 
-  const { displayItem, hideDisplayItem } = useShowItem({
+  const displayItem = useShowItem({
     current,
     total,
+    totalThreshold: TOTAL_THRESHOLD,
+    maxShowItemSize: MAX_SHOW_ITEM_SIZE,
   });
 
   const handleClick = useCallback(
@@ -79,10 +83,6 @@ export const Pagination = (props: Props) => {
         )}
         {displayItem.map((pageNumber, index) => {
           const isCurrent = current === pageNumber;
-          const isHidden =
-            showPrevNext &&
-            hideDisplayItem &&
-            (current - 1 === pageNumber || current + 1 === pageNumber);
           const hasRelAttribute = current === pageNumber + 1;
 
           // 数字が隣接していない場合に表示
@@ -91,12 +91,7 @@ export const Pagination = (props: Props) => {
 
           return (
             <li
-              className={[
-                `${BLOCK_NAME}-item`,
-                isHidden && `${BLOCK_NAME}-item--hidden`,
-              ]
-                .filter(Boolean)
-                .join(' ')}
+              className={`${BLOCK_NAME}-item`}
               key={`pagination-item-${pageNumber}`}
             >
               <a

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -19,8 +19,6 @@ const BLOCK_NAME = 'spui-Pagination';
 
 // ページ総数の閾値
 const TOTAL_THRESHOLD = 100;
-// 表示出来る数字（アイテム）の最大数
-const MAX_SHOW_ITEM_SIZE = 5;
 
 export const Pagination = (props: Props) => {
   const {
@@ -37,7 +35,6 @@ export const Pagination = (props: Props) => {
     current,
     total,
     totalThreshold: TOTAL_THRESHOLD,
-    maxShowItemSize: MAX_SHOW_ITEM_SIZE,
   });
 
   const handleClick = useCallback(

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
@@ -4,7 +4,417 @@ import { useShowItem } from './useShowItem';
 // ページ総数の閾値
 const TOTAL_THRESHOLD = 100;
 
-describe('useShowItem()', () => {
+describe('3 item size useShowItem()', () => {
+  it('use show item current 1 total 1', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1,
+        total: 1,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1]);
+  });
+  it('use show item current 1 total 2', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1,
+        total: 2,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2]);
+  });
+  it('use show item current 2 total 2', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 2,
+        total: 2,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2]);
+  });
+  it('use show item current 1 total 3', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1,
+        total: 3,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 2 total 3', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 2,
+        total: 3,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 3 total 3', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 3,
+        total: 3,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 1 total 4', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1,
+        total: 4,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 2 total 4', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 2,
+        total: 4,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 3 total 4', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 3,
+        total: 4,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([2, 3, 4]);
+  });
+  it('use show item current 4 total 4', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 4,
+        total: 4,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([2, 3, 4]);
+  });
+  it('use show item current 1 total 5', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1,
+        total: 5,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 2 total 5', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 2,
+        total: 5,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 3 total 5', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 3,
+        total: 5,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([2, 3, 4]);
+  });
+  it('use show item current 4 total 5', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 4,
+        total: 5,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([3, 4, 5]);
+  });
+  it('use show item current 5 total 5', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 5,
+        total: 5,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([3, 4, 5]);
+  });
+  it('use show item current 1 total 6', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1,
+        total: 6,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 6]);
+  });
+  it('use show item current 2 total 6', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 2,
+        total: 6,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 6]);
+  });
+  it('use show item current 3 total 6', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 3,
+        total: 6,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 3, 6]);
+  });
+  it('use show item current 4 total 6', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 4,
+        total: 6,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 4, 6]);
+  });
+  it('use show item current 5 total 6', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 5,
+        total: 6,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 5, 6]);
+  });
+  it('use show item current 6 total 6', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 6,
+        total: 6,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 5, 6]);
+  });
+  it('use show item current 1 total 7', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1,
+        total: 7,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 7]);
+  });
+  it('use show item current 2 total 7', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 2,
+        total: 7,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 7]);
+  });
+  it('use show item current 3 total 7', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 3,
+        total: 7,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 3, 7]);
+  });
+  it('use show item current 4 total 7', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 4,
+        total: 7,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 4, 7]);
+  });
+  it('use show item current 5 total 7', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 5,
+        total: 7,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 5, 7]);
+  });
+  it('use show item current 6 total 7', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 6,
+        total: 7,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 6, 7]);
+  });
+  it('use show item current 7 total 7', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 7,
+        total: 7,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 6, 7]);
+  });
+  it('use show item current 1 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 2 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 2,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+  it('use show item current 3 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 3,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([2, 3, 4]);
+  });
+  it('use show item current 4 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 4,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([3, 4, 5]);
+  });
+  it('use show item current 5 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 5,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([4, 5, 6]);
+  });
+  it('use show item current 200 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 200,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([199, 200, 201]);
+  });
+  it('use show item current 998 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 998,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([997, 998, 999]);
+  });
+  it('use show item current 999 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 999,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([998, 999, 1000]);
+  });
+  it('use show item current 1000 total 1000', () => {
+    const { result } = renderHook(() =>
+      useShowItem({
+        current: 1000,
+        total: 1000,
+        showItemSize: 3,
+        totalThreshold: TOTAL_THRESHOLD,
+      }),
+    );
+    expect(result.current).toEqual([998, 999, 1000]);
+  });
+});
+
+describe('5 item size useShowItem()', () => {
   it('use show item current 1 total 1', () => {
     const { result } = renderHook(() =>
       useShowItem({

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
@@ -3,68 +3,47 @@ import { useShowItem } from './useShowItem';
 
 // ページ総数の閾値
 const TOTAL_THRESHOLD = 100;
-// 表示出来る数字(アイテム)の最大数
-const MAX_SHOW_ITEM_SIZE = 5;
 
 describe('useShowItem()', () => {
   it('use show item current 1 total 1', () => {
-    const current = 1;
-    const total = 1;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1,
+        total: 1,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1]);
   });
 
   it('use show item current 1 total 2', () => {
-    const current = 1;
-    const total = 2;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1,
+        total: 2,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2]);
   });
 
   it('use show item current 2 total 2', () => {
-    const current = 2;
-    const total = 2;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 2,
+        total: 2,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2]);
   });
 
   it('use show item current 1 total 3', () => {
-    const current = 1;
-    const total = 3;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1,
+        total: 3,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
 
@@ -72,530 +51,365 @@ describe('useShowItem()', () => {
   });
 
   it('use show item current 2 total 3', () => {
-    const current = 2;
-    const total = 3;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 2,
+        total: 3,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3]);
   });
 
   it('use show item current 3 total 3', () => {
-    const current = 3;
-    const total = 3;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 3,
+        total: 3,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3]);
   });
 
   it('use show item current 1 total 4', () => {
-    const current = 1;
-    const total = 4;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1,
+        total: 4,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4]);
   });
 
   it('use show item current 2 total 4', () => {
-    const current = 2;
-    const total = 4;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 2,
+        total: 4,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4]);
   });
 
   it('use show item current 3 total 4', () => {
-    const current = 3;
-    const total = 4;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 3,
+        total: 4,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4]);
   });
 
   it('use show item current 4 total 4', () => {
-    const current = 4;
-    const total = 4;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 4,
+        total: 4,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4]);
   });
 
   it('use show item current 1 total 5', () => {
-    const current = 1;
-    const total = 5;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1,
+        total: 5,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('use show item current 2 total 5', () => {
-    const current = 2;
-    const total = 5;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 2,
+        total: 5,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('use show item current 3 total 5', () => {
-    const current = 3;
-    const total = 5;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 3,
+        total: 5,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('use show item current 4 total 5', () => {
-    const current = 4;
-    const total = 5;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 4,
+        total: 5,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('use show item current 5 total 5', () => {
-    const current = 5;
-    const total = 5;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 5,
+        total: 5,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('use show item current 1 total 6', () => {
-    const current = 1;
-    const total = 6;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1,
+        total: 6,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 6]);
   });
 
   it('use show item current 2 total 6', () => {
-    const current = 2;
-    const total = 6;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 2,
+        total: 6,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 6]);
   });
 
   it('use show item current 3 total 6', () => {
-    const current = 3;
-    const total = 6;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 3,
+        total: 6,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
-    expect(result.current).toEqual([1, 3, 4, 5, 6]);
+    expect(result.current).toEqual([1, 2, 3, 4, 6]);
   });
 
   it('use show item current 4 total 6', () => {
-    const current = 4;
-    const total = 6;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 4,
+        total: 6,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 3, 4, 5, 6]);
   });
 
   it('use show item current 5 total 6', () => {
-    const current = 5;
-    const total = 6;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 5,
+        total: 6,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 3, 4, 5, 6]);
   });
 
   it('use show item current 6 total 6', () => {
-    const current = 6;
-    const total = 6;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 6,
+        total: 6,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 3, 4, 5, 6]);
   });
 
   it('use show item current 1 total 7', () => {
-    const current = 1;
-    const total = 7;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1,
+        total: 7,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 7]);
   });
 
   it('use show item current 2 total 7', () => {
-    const current = 2;
-    const total = 7;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 2,
+        total: 7,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 7]);
   });
 
   it('use show item current 3 total 7', () => {
-    const current = 3;
-    const total = 7;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 3,
+        total: 7,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
-    expect(result.current).toEqual([1, 3, 4, 5, 7]);
+    expect(result.current).toEqual([1, 2, 3, 4, 7]);
   });
 
   it('use show item current 4 total 7', () => {
-    const current = 4;
-    const total = 7;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 4,
+        total: 7,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
-    expect(result.current).toEqual([1, 4, 5, 6, 7]);
+    expect(result.current).toEqual([1, 3, 4, 5, 7]);
   });
 
   it('use show item current 5 total 7', () => {
-    const current = 5;
-    const total = 7;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 5,
+        total: 7,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 4, 5, 6, 7]);
   });
 
   it('use show item current 6 total 7', () => {
-    const current = 6;
-    const total = 7;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 6,
+        total: 7,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 4, 5, 6, 7]);
   });
 
   it('use show item current 7 total 7', () => {
-    const current = 7;
-    const total = 7;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 7,
+        total: 7,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 4, 5, 6, 7]);
   });
 
   it('use show item current 1 total 1000', () => {
-    const current = 1;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('use show item current 2 total 1000', () => {
-    const current = 2;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 2,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('use show item current 3 total 1000', () => {
-    const current = 3;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 3,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('use show item current 4 total 1000', () => {
-    const current = 4;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 4,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([2, 3, 4, 5, 6]);
   });
 
   it('use show item current 5 total 1000', () => {
-    const current = 5;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 5,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([3, 4, 5, 6, 7]);
   });
 
   it('use show item current 200 total 1000', () => {
-    const current = 200;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 200,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([198, 199, 200, 201, 202]);
   });
 
   it('use show item current 998 total 1000', () => {
-    const current = 998;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 998,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([996, 997, 998, 999, 1000]);
   });
 
   it('use show item current 999 total 1000', () => {
-    const current = 999;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 999,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([996, 997, 998, 999, 1000]);
   });
 
   it('use show item current 1000 total 1000', () => {
-    const current = 1000;
-    const total = 1000;
-
     const { result } = renderHook(() =>
       useShowItem({
-        current,
-        total,
+        current: 1000,
+        total: 1000,
         totalThreshold: TOTAL_THRESHOLD,
-        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
       }),
     );
-
     expect(result.current).toEqual([996, 997, 998, 999, 1000]);
   });
 });

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
@@ -1,44 +1,601 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useShowItem } from './useShowItem';
 
+// ページ総数の閾値
+const TOTAL_THRESHOLD = 100;
+// 表示出来る数字(アイテム)の最大数
+const MAX_SHOW_ITEM_SIZE = 5;
+
 describe('useShowItem()', () => {
-  it('should return show props', () => {
-    const current = 8;
-    const total = 20;
-
-    const { result } = renderHook(() => useShowItem({ current, total }));
-
-    expect(result.current.displayItem).toEqual([1, 7, 8, 9, 20]);
-    expect(result.current.hideDisplayItem).toEqual(true);
-  });
-
-  it('should return show props is current first', () => {
+  it('use show item current 1 total 1', () => {
     const current = 1;
-    const total = 20;
+    const total = 1;
 
-    const { result } = renderHook(() => useShowItem({ current, total }));
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
 
-    expect(result.current.displayItem).toEqual([1, 2, 3, 4, 20]);
-    expect(result.current.hideDisplayItem).toEqual(true);
+    expect(result.current).toEqual([1]);
   });
 
-  it('should return show props is current last', () => {
-    const current = 20;
-    const total = 20;
+  it('use show item current 1 total 2', () => {
+    const current = 1;
+    const total = 2;
 
-    const { result } = renderHook(() => useShowItem({ current, total }));
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
 
-    expect(result.current.displayItem).toEqual([1, 17, 18, 19, 20]);
-    expect(result.current.hideDisplayItem).toEqual(true);
+    expect(result.current).toEqual([1, 2]);
   });
 
-  it('should return show props is total is less than max page item', () => {
+  it('use show item current 2 total 2', () => {
+    const current = 2;
+    const total = 2;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2]);
+  });
+
+  it('use show item current 1 total 3', () => {
+    const current = 1;
+    const total = 3;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+
+  it('use show item current 2 total 3', () => {
     const current = 2;
     const total = 3;
 
-    const { result } = renderHook(() => useShowItem({ current, total }));
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
 
-    expect(result.current.displayItem).toEqual([1, 2, 3]);
-    expect(result.current.hideDisplayItem).toEqual(false);
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+
+  it('use show item current 3 total 3', () => {
+    const current = 3;
+    const total = 3;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3]);
+  });
+
+  it('use show item current 1 total 4', () => {
+    const current = 1;
+    const total = 4;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4]);
+  });
+
+  it('use show item current 2 total 4', () => {
+    const current = 2;
+    const total = 4;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4]);
+  });
+
+  it('use show item current 3 total 4', () => {
+    const current = 3;
+    const total = 4;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4]);
+  });
+
+  it('use show item current 4 total 4', () => {
+    const current = 4;
+    const total = 4;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4]);
+  });
+
+  it('use show item current 1 total 5', () => {
+    const current = 1;
+    const total = 5;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('use show item current 2 total 5', () => {
+    const current = 2;
+    const total = 5;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('use show item current 3 total 5', () => {
+    const current = 3;
+    const total = 5;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('use show item current 4 total 5', () => {
+    const current = 4;
+    const total = 5;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('use show item current 5 total 5', () => {
+    const current = 5;
+    const total = 5;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('use show item current 1 total 6', () => {
+    const current = 1;
+    const total = 6;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 6]);
+  });
+
+  it('use show item current 2 total 6', () => {
+    const current = 2;
+    const total = 6;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 6]);
+  });
+
+  it('use show item current 3 total 6', () => {
+    const current = 3;
+    const total = 6;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 3, 4, 5, 6]);
+  });
+
+  it('use show item current 4 total 6', () => {
+    const current = 4;
+    const total = 6;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 3, 4, 5, 6]);
+  });
+
+  it('use show item current 5 total 6', () => {
+    const current = 5;
+    const total = 6;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 3, 4, 5, 6]);
+  });
+
+  it('use show item current 6 total 6', () => {
+    const current = 6;
+    const total = 6;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 3, 4, 5, 6]);
+  });
+
+  it('use show item current 1 total 7', () => {
+    const current = 1;
+    const total = 7;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 7]);
+  });
+
+  it('use show item current 2 total 7', () => {
+    const current = 2;
+    const total = 7;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 7]);
+  });
+
+  it('use show item current 3 total 7', () => {
+    const current = 3;
+    const total = 7;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 3, 4, 5, 7]);
+  });
+
+  it('use show item current 4 total 7', () => {
+    const current = 4;
+    const total = 7;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 4, 5, 6, 7]);
+  });
+
+  it('use show item current 5 total 7', () => {
+    const current = 5;
+    const total = 7;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 4, 5, 6, 7]);
+  });
+
+  it('use show item current 6 total 7', () => {
+    const current = 6;
+    const total = 7;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 4, 5, 6, 7]);
+  });
+
+  it('use show item current 7 total 7', () => {
+    const current = 7;
+    const total = 7;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 4, 5, 6, 7]);
+  });
+
+  it('use show item current 1 total 1000', () => {
+    const current = 1;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('use show item current 2 total 1000', () => {
+    const current = 2;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('use show item current 3 total 1000', () => {
+    const current = 3;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('use show item current 4 total 1000', () => {
+    const current = 4;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([2, 3, 4, 5, 6]);
+  });
+
+  it('use show item current 5 total 1000', () => {
+    const current = 5;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([3, 4, 5, 6, 7]);
+  });
+
+  it('use show item current 200 total 1000', () => {
+    const current = 200;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([198, 199, 200, 201, 202]);
+  });
+
+  it('use show item current 998 total 1000', () => {
+    const current = 998;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([996, 997, 998, 999, 1000]);
+  });
+
+  it('use show item current 999 total 1000', () => {
+    const current = 999;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([996, 997, 998, 999, 1000]);
+  });
+
+  it('use show item current 1000 total 1000', () => {
+    const current = 1000;
+    const total = 1000;
+
+    const { result } = renderHook(() =>
+      useShowItem({
+        current,
+        total,
+        totalThreshold: TOTAL_THRESHOLD,
+        maxShowItemSize: MAX_SHOW_ITEM_SIZE,
+      }),
+    );
+
+    expect(result.current).toEqual([996, 997, 998, 999, 1000]);
   });
 });

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.test.ts
@@ -10,6 +10,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1,
         total: 1,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -21,6 +22,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1,
         total: 2,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -32,6 +34,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 2,
         total: 2,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -43,6 +46,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1,
         total: 3,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -55,6 +59,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 2,
         total: 3,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -66,6 +71,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 3,
         total: 3,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -77,6 +83,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1,
         total: 4,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -88,6 +95,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 2,
         total: 4,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -99,6 +107,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 3,
         total: 4,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -110,6 +119,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 4,
         total: 4,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -121,6 +131,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1,
         total: 5,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -132,6 +143,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 2,
         total: 5,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -143,6 +155,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 3,
         total: 5,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -154,6 +167,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 4,
         total: 5,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -165,6 +179,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 5,
         total: 5,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -176,6 +191,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1,
         total: 6,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -187,6 +203,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 2,
         total: 6,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -198,6 +215,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 3,
         total: 6,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -209,6 +227,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 4,
         total: 6,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -220,6 +239,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 5,
         total: 6,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -231,6 +251,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 6,
         total: 6,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -242,6 +263,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1,
         total: 7,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -253,6 +275,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 2,
         total: 7,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -264,6 +287,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 3,
         total: 7,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -275,6 +299,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 4,
         total: 7,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -286,6 +311,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 5,
         total: 7,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -297,6 +323,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 6,
         total: 7,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -308,6 +335,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 7,
         total: 7,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -319,6 +347,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -330,6 +359,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 2,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -341,6 +371,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 3,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -352,6 +383,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 4,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -363,6 +395,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 5,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -374,6 +407,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 200,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -385,6 +419,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 998,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -396,6 +431,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 999,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );
@@ -407,6 +443,7 @@ describe('useShowItem()', () => {
       useShowItem({
         current: 1000,
         total: 1000,
+        showItemSize: 5,
         totalThreshold: TOTAL_THRESHOLD,
       }),
     );

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -8,19 +8,31 @@ type Payload = {
 // 表示出来る数字（アイテム）の最大数
 const MAX_SHOW_ITEM_SIZE = 5;
 
+/**
+ * useShowItem分岐条件
+ * 1.総ページ数が表示したいアイテム数以下の場合、総ページ数と同じアイテム数を返す
+ * 2.総ページ数がアイテムの表示最大数以下、または総ページ数が閾値以上の場合
+ *   1.現在のページ数が中央値 + 1より小さい場合、表示したいアイテム数を最初のページから返す
+ *   2.現在のページ数が総ページ数 - 中央値より大きい場合、総ページ数からさかのぼった表示したいアイテム数を返す
+ *   3.現在のページ数と前後に表示したいアイテム数を返す
+ * 3.上記に該当しない場合は以下の処理を行う
+ *   1.現在のページ数が中央値 + 1より小さい場合、表示したいアイテム数を最初のページから返し最後は総ページ数を返す
+ *   2.現在のページ数が総ページ数 - 中央値より大きい場合、最初のページとtotalまでの表示したいアイテム数を返す
+ *   3.最初のアイテムは1を最後のアイテムは総ページ数を返すとともにlengthが3の場合は現在のページ数のみでlengthが5の場合は現在のページ数とその前後のアイテム数を返す
+ */
 export function useShowItem({
   current,
   total,
   showItemSize,
   totalThreshold,
 }: Payload) {
-  // 総数が表示したいアイテム数に満たない場合
   if (total <= showItemSize) {
     return Array.from({ length: total }, (_e, index) => index + 1);
   }
+
   // 中央値（少数の切り捨て）
   const median = (showItemSize / 2) | 0;
-  // 総数がアイテムの表示最大数に満たない、または総数が閾値を超える場合
+
   if (total <= MAX_SHOW_ITEM_SIZE || total >= totalThreshold) {
     if (current < 1 + median) {
       return Array.from({ length: showItemSize }, (_e, index) => index + 1);
@@ -36,14 +48,12 @@ export function useShowItem({
       (_e, index) => current - median + index,
     );
   }
-  // 総数がアイテムの表示最大数以上の場合
   if (current < 1 + median) {
     return [
       ...Array.from({ length: showItemSize - 1 }, (_e, index) => index + 1),
       total,
     ];
   }
-  // 総数がアイテムの表示最大数以下の場合
   if (current > total - median) {
     return [
       1,

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -2,15 +2,12 @@ type Payload = {
   current: number;
   total: number;
   totalThreshold: number;
-  maxShowItemSize: number;
 };
 
-export function useShowItem({
-  current,
-  total,
-  totalThreshold,
-  maxShowItemSize,
-}: Payload) {
+// 表示出来る数字（アイテム）の最大数
+const MAX_SHOW_ITEM_SIZE = 5;
+
+export function useShowItem({ current, total, totalThreshold }: Payload) {
   const showItemSize = 5;
 
   // 総数が表示したいアイテム数に満たない場合
@@ -20,7 +17,7 @@ export function useShowItem({
   // 中央値（少数の切り捨て）
   const median = (showItemSize / 2) | 0;
   // 総数がアイテムの表示最大数に満たない、または総数がしきい値を超える場合
-  if (total <= maxShowItemSize || total >= totalThreshold) {
+  if (total <= MAX_SHOW_ITEM_SIZE || total >= totalThreshold) {
     if (current < 1 + median) {
       return Array.from({ length: showItemSize }, (_e, index) => index + 1);
     }

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -33,8 +33,8 @@ export function useShowItem({
     }
     return Array.from(
       { length: showItemSize },
-      (_e, index) => current - (index - median),
-    ).reverse();
+      (_e, index) => current - median + index,
+    );
   }
   // 総数がアイテムの表示最大数以上の場合
   if (current < 1 + median) {
@@ -57,8 +57,8 @@ export function useShowItem({
     1,
     ...Array.from(
       { length: showItemSize - 2 },
-      (_e, index) => current - (index + 1 - median),
-    ).reverse(),
+      (_e, index) => current - (median - 1) + index,
+    ),
     total,
   ];
 }

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -1,15 +1,14 @@
 type Payload = {
   current: number;
   total: number;
+  showItemSize: 3 | 5;
   totalThreshold: number;
 };
 
 // 表示出来る数字（アイテム）の最大数
 const MAX_SHOW_ITEM_SIZE = 5;
 
-export function useShowItem({ current, total, totalThreshold }: Payload) {
-  const showItemSize = 5;
-
+export function useShowItem({ current, total, showItemSize, totalThreshold }: Payload) {
   // 総数が表示したいアイテム数に満たない場合
   if (total <= showItemSize) {
     return Array.from({ length: total }, (_e, index) => index + 1);

--- a/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
+++ b/packages/spindle-ui/src/Pagination/hooks/useShowItem.ts
@@ -8,14 +8,19 @@ type Payload = {
 // 表示出来る数字（アイテム）の最大数
 const MAX_SHOW_ITEM_SIZE = 5;
 
-export function useShowItem({ current, total, showItemSize, totalThreshold }: Payload) {
+export function useShowItem({
+  current,
+  total,
+  showItemSize,
+  totalThreshold,
+}: Payload) {
   // 総数が表示したいアイテム数に満たない場合
   if (total <= showItemSize) {
     return Array.from({ length: total }, (_e, index) => index + 1);
   }
   // 中央値（少数の切り捨て）
   const median = (showItemSize / 2) | 0;
-  // 総数がアイテムの表示最大数に満たない、または総数がしきい値を超える場合
+  // 総数がアイテムの表示最大数に満たない、または総数が閾値を超える場合
   if (total <= MAX_SHOW_ITEM_SIZE || total >= totalThreshold) {
     if (current < 1 + median) {
       return Array.from({ length: showItemSize }, (_e, index) => index + 1);
@@ -38,6 +43,7 @@ export function useShowItem({ current, total, showItemSize, totalThreshold }: Pa
       total,
     ];
   }
+  // 総数がアイテムの表示最大数以下の場合
   if (current > total - median) {
     return [
       1,
@@ -51,7 +57,7 @@ export function useShowItem({ current, total, showItemSize, totalThreshold }: Pa
     1,
     ...Array.from(
       { length: showItemSize - 2 },
-      (_e, index) => current - (index - median),
+      (_e, index) => current - (index + 1 - median),
     ).reverse(),
     total,
   ];


### PR DESCRIPTION
### 概要
Paginationコンポーネントの

- ページ番号表示ロジック
- テストパターンの追加

をおこないました。

### リリースまで
いくつかPull requestを分けて `fix/pagination` ブランチにマージしていき最終的に`main`ブランチからリリースしたいと思います。

- [x] リンクのpadding値を修正
- [x] showCountをShowTotalに変更
- [x] 「次へ」「前へ」周りの改修
- [x] 「最初へ」「最後へ」周りの改修
  - [x] propsが変化したことによるstory bookの精査
- [x] ellipsisの表示条件修正
- [x] onPageChangeを任意に変更
  - [x] propsが変化したことによるstory bookの修正
- [x] テスト追加
- [x] ページ番号表示ロジック
- [ ] orientationchange（画面幅）を考慮した処理の追加