### PR TITLE
fix(spindle-ui): pagination breakpoint

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -9,7 +9,7 @@
       "maxSize": "1.1 kB"
     },
     {
-      "path": "./dist/!(Icon|Toast|DropdownMenu|Modal|SnackBar|StackNotificationManager)/*.mjs",
+      "path": "./dist/!(Icon|Toast|DropdownMenu|Pagination|Modal|SnackBar|StackNotificationManager)/*.mjs",
       "maxSize": "1.1 kB"
     },
     {
@@ -26,6 +26,10 @@
     },
     {
       "path": "./dist/DropdownMenu/*.mjs",
+      "maxSize": "1.5 kB"
+    },
+    {
+      "path": "./dist/Pagination/*.mjs",
       "maxSize": "1.5 kB"
     },
     {

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import MenuHorizontal from '../Icon/MenuHorizontal';
 
 import PaginationItem from './PaginationItem';
@@ -31,10 +31,29 @@ export const Pagination = (props: Props) => {
     ...rest
   } = props;
 
+  const handleMatchMedia =
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(max-width: 360px)')
+      : undefined;
+
+  const isMobile = useRef(handleMatchMedia);
+  const [matches, setMatches] = useState(() =>
+    isMobile.current ? isMobile.current.matches : false,
+  );
+
+  const onOrientationchange = useCallback(() => {
+    const isMobile = handleMatchMedia;
+    setMatches(isMobile && isMobile.matches ? isMobile.matches : false);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('orientationchange', onOrientationchange, false);
+  }, []);
+
   const displayItem = useShowItem({
     current,
     total,
-    showItemSize: 5,
+    showItemSize: matches ? 3 : 5,
     totalThreshold: TOTAL_THRESHOLD,
   });
 

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -20,6 +20,9 @@ const BLOCK_NAME = 'spui-Pagination';
 // ページ総数の閾値
 const TOTAL_THRESHOLD = 100;
 
+// ウィンドウリサイズ時の間引き処理時間
+const RESIZE_DELAY_TIME = 800;
+
 export const Pagination = (props: Props) => {
   const {
     current,
@@ -49,6 +52,17 @@ export const Pagination = (props: Props) => {
   useEffect(() => {
     window.addEventListener('orientationchange', onOrientationchange, false);
   }, [onOrientationchange]);
+
+  const onResizeView = useCallback(() => {
+    setTimeout(() => {
+      const isMobile = handleMatchMedia;
+      setMatches(isMobile && isMobile.matches ? isMobile.matches : false);
+    }, RESIZE_DELAY_TIME);
+  }, [handleMatchMedia]);
+
+  useEffect(() => {
+    window.addEventListener('resize', onResizeView, false);
+  }, [onResizeView]);
 
   const displayItem = useShowItem({
     current,

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -44,11 +44,11 @@ export const Pagination = (props: Props) => {
   const onOrientationchange = useCallback(() => {
     const isMobile = handleMatchMedia;
     setMatches(isMobile && isMobile.matches ? isMobile.matches : false);
-  }, []);
+  }, [handleMatchMedia]);
 
   useEffect(() => {
     window.addEventListener('orientationchange', onOrientationchange, false);
-  }, []);
+  }, [onOrientationchange]);
 
   const displayItem = useShowItem({
     current,

--- a/packages/spindle-ui/src/Pagination/Pagination.tsx
+++ b/packages/spindle-ui/src/Pagination/Pagination.tsx
@@ -39,29 +39,37 @@ export const Pagination = (props: Props) => {
       ? window.matchMedia('(max-width: 360px)')
       : undefined;
 
-  const isMobile = useRef(handleMatchMedia);
+  const isMatchMedia = useRef(handleMatchMedia);
   const [matches, setMatches] = useState(() =>
-    isMobile.current ? isMobile.current.matches : false,
+    isMatchMedia.current ? isMatchMedia.current.matches : false,
   );
 
-  const onOrientationchange = useCallback(() => {
-    const isMobile = handleMatchMedia;
-    setMatches(isMobile && isMobile.matches ? isMobile.matches : false);
+  const onChangeView = useCallback(() => {
+    const isMatchMedia = handleMatchMedia;
+    setMatches(
+      isMatchMedia && isMatchMedia.matches ? isMatchMedia.matches : false,
+    );
   }, [handleMatchMedia]);
+
+  const onOrientationchange = useCallback(() => {
+    onChangeView();
+  }, [onChangeView]);
 
   useEffect(() => {
     window.addEventListener('orientationchange', onOrientationchange, false);
+    return () =>
+      window.removeEventListener('orientationchange', onOrientationchange);
   }, [onOrientationchange]);
 
   const onResizeView = useCallback(() => {
     setTimeout(() => {
-      const isMobile = handleMatchMedia;
-      setMatches(isMobile && isMobile.matches ? isMobile.matches : false);
+      onChangeView();
     }, RESIZE_DELAY_TIME);
-  }, [handleMatchMedia]);
+  }, [onChangeView]);
 
   useEffect(() => {
     window.addEventListener('resize', onResizeView, false);
+    return () => window.removeEventListener('resize', onResizeView);
   }, [onResizeView]);
 
   const displayItem = useShowItem({


### PR DESCRIPTION
### 概要
Paginationコンポーネントのブレイクポイントによっての表示アイテム数の対応をおこないました。
端末の向きが変わった際を考慮して `orientationchange` の処理も追加しています。
また、Paginationのbundlesizeあげております。

### リリースまで
いくつかPull requestを分けて `fix/pagination` ブランチにマージしていき最終的に`main`ブランチからリリースしたいと思います。

- [x] リンクのpadding値を修正
- [x] showCountをShowTotalに変更
- [x] 「次へ」「前へ」周りの改修
- [x] 「最初へ」「最後へ」周りの改修
  - [x] propsが変化したことによるstory bookの精査
- [x] ellipsisの表示条件修正
- [x] onPageChangeを任意に変更
  - [x] propsが変化したことによるstory bookの修正
- [x] テスト追加
- [x] ページ番号表示ロジック
- [x] orientationchange（画面幅）を考慮した処理の追加
- [ ] storybookにパターンを追加

### 確認方法
storybookで画面幅など含めご確認いただければと！