### PR TITLE
chore: improve text linting

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,5 +1,12 @@
 {
   "rules": {
     "preset-ameba": true
+  },
+  "plugins": {
+    "@textlint/markdown": {
+      "extensions": [
+        ".mdx"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "lint:script": "eslint --cache 'packages/**/src/**/*.{js,ts,tsx}'",
     "lint:yaml": "yamllint .github/workflows/*.yml",
     "lint:packages": "lerna run lint",
+    "lint:text": "textlint .",
     "format": "prettier --check 'packages/**/src/**/*.{js,ts,tsx}'",
     "fix": "run-p fix:*",
     "fix:script": "eslint . --fix",
     "fix:packages": "lerna run format",
     "fix:format": "prettier --write '**/*.{js,ts,tsx}'",
+    "fix:text": "textlint --fix .",
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "prepare": "is-ci || husky install"


### PR DESCRIPTION
[textlintが効いていない気がしたので](https://github.com/openameba/spindle/pull/610#discussion_r1057459617)textlint周りの環境を整えました。

新たに対象となったファイルやこれまでも対象であったが手動での実行でないと検出されていなかったものが検出されるようになったため、CIは一部失敗していますが、一旦はこれでマージをして文章の修正は別のPRでするのが良いかなと思っています。