### PR TITLE
chore: update setup node v3

### DIFF
--- a/.github/workflows/build-icon-from-figma.yml
+++ b/.github/workflows/build-icon-from-figma.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: restore lerna

--- a/.github/workflows/build-icon.yml
+++ b/.github/workflows/build-icon.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: restore lerna

--- a/.github/workflows/build-tokens.yml
+++ b/.github/workflows/build-tokens.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: restore lerna

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: restore lerna

--- a/.github/workflows/deploy-highlightjs-styles-preview.yml
+++ b/.github/workflows/deploy-highlightjs-styles-preview.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: ./packages/spindle-highlightjs-themes/
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/deploy-highlightjs-styles.yml
+++ b/.github/workflows/deploy-highlightjs-styles.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: ./packages/spindle-highlightjs-themes/
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/deploy-hooks-catalog.yml
+++ b/.github/workflows/deploy-hooks-catalog.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: restore lerna

--- a/.github/workflows/deploy-hoooks-preview.yml
+++ b/.github/workflows/deploy-hoooks-preview.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: ./packages/spindle-hooks/
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/deploy-theme-switch.yml
+++ b/.github/workflows/deploy-theme-switch.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: ./packages/spindle-theme-switch/
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/deploy-ui-catalog.yml
+++ b/.github/workflows/deploy-ui-catalog.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: restore lerna

--- a/.github/workflows/deploy-ui-preview.yml
+++ b/.github/workflows/deploy-ui-preview.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       # Bootstrap lerna for building app before publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: restore lerna


### PR DESCRIPTION
### 概要
いつからか[deploy UI catalog](https://github.com/openameba/spindle/actions/workflows/deploy-ui-catalog.yml)のワークフローが失敗する状態になっていました。
エラー内容は

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-node@v2-beta

node12サポートしてないよ。みたいな感じでした。
調べてみたらsetup-nodeのバージョンあげると解決しそう？

おもむろにv3にあげてみました。

### 関連するリンク
[Release v3.0.0 · actions/setup-node](https://github.com/actions/setup-node/releases/tag/v3.0.0)