### PR TITLE
ci: fix ui-catalog and hooks-catalog tasks

### DIFF
--- a/.github/workflows/deploy-hooks-catalog.yml
+++ b/.github/workflows/deploy-hooks-catalog.yml
@@ -30,4 +30,4 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
           yarn lerna run --scope @openameba/spindle-hooks storybook:build
-          yarn lerna run --scope @openameba/spindle-hooks storybook:deploy -- --token $FIREBASE_TOKEN
+          npx lerna run --scope @openameba/spindle-hooks storybook:deploy -- --token $FIREBASE_TOKEN

--- a/.github/workflows/deploy-ui-catalog.yml
+++ b/.github/workflows/deploy-ui-catalog.yml
@@ -31,4 +31,4 @@ jobs:
         run: |
           yarn lerna run --scope @openameba/spindle-hooks build
           yarn lerna run --scope @openameba/spindle-ui storybook:build
-          yarn lerna run --scope @openameba/spindle-ui storybook:deploy -- --token $FIREBASE_TOKEN
+          npx lerna run --scope @openameba/spindle-ui storybook:deploy -- --token $FIREBASE_TOKEN


### PR DESCRIPTION
### 概要
`lerna run` コマンドの仕様が変わったのか `--` が使えなくなったみたいで `yarn` から `npx` に乗り換えてみました。