### PR TITLE
chore(spindle-ui): remove bundle size for `index.css`

### DIFF
--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -47,10 +47,6 @@
     {
       "path": "./dist/SnackBar/!(index).css",
       "maxSize": "2.1 kB"
-    },
-    {
-      "path": "./dist/index.css",
-      "maxSize": "9.0 kB"
     }
   ]
 }


### PR DESCRIPTION
## 概要
bundle sizeでCIコケるPRがチラホラ出現しているので、`dist/index.css`のbundle sizeを上げました 🚀
本当は、キリないので消してもいい（管理しなくて良い）のでは？と思っているものの、勇気が出ないので一旦上げました🙏🏻