### PR TITLE
fix(spindle-ui): semiModal styles

### DIFF
--- a/packages/spindle-ui/src/Modal/SemiModal.css
+++ b/packages/spindle-ui/src/Modal/SemiModal.css
@@ -3,6 +3,11 @@
  * SemiModal
  * NOTE: Styles can be overridden with "--SemiModal-*" variables
 */
+:root {
+  --SemiModal-footer-justifyContent: right;
+  --SemiModal-footer-button-minWidth: 160px;
+  --SemiModal-sp-footer-justifyContent: center;
+}
 
 .spui-SemiModal {
   background: var(--color-surface-primary);
@@ -28,21 +33,21 @@
 .spui-SemiModal[data-type='popup'][open]:not(.spui-SemiModal--closing),
 .spui-SemiModal[data-type='popup'][open]:not(.spui-SemiModal--closing).spui-SemiModal::backdrop,
 .spui-SemiModal[data-type='sheet'][open]:not(.spui-SemiModal--closing).spui-SemiModal::backdrop {
-  animation: 0.5s cubic-bezier(0, 0, 0, 1) spui-SemiModal-fade-in;
+  animation: 350ms cubic-bezier(0, 0, 0, 1) spui-SemiModal-fade-in;
 }
 
 .spui-SemiModal--closing.spui-SemiModal[data-type='popup'],
 .spui-SemiModal--closing[data-type='popup'].spui-SemiModal::backdrop,
 .spui-SemiModal--closing[data-type='sheet'].spui-SemiModal::backdrop {
-  animation: 0.3s cubic-bezier(0, 0, 0, 1) spui-SemiModal-fade-out;
+  animation: 350ms cubic-bezier(0, 0, 0, 1) spui-SemiModal-fade-out;
 }
 
 .spui-SemiModal[data-type='sheet'][open]:not(.spui-SemiModal--closing, button) {
-  animation: both 0.5s cubic-bezier(0, 0, 0, 1) spui-SemiModal-slide-in;
+  animation: both 350ms cubic-bezier(0, 0, 0, 1) spui-SemiModal-slide-in;
 }
 
 .spui-SemiModal--closing.spui-SemiModal[data-type='sheet'] {
-  animation: both 0.3s cubic-bezier(0, 0, 0, 1) spui-SemiModal-slide-out;
+  animation: both 350ms cubic-bezier(0, 0, 0, 1) spui-SemiModal-slide-out;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -147,6 +152,7 @@ html.spui-SemiModal--open {
 }
 
 .spui-SemiModal-contents {
+  line-height: 1.6;
   overflow: hidden scroll;
 }
 
@@ -168,6 +174,7 @@ html.spui-SemiModal--open {
 .spui-SemiModal-footer {
   background-color: var(--color-surface-primary);
   bottom: 0;
+  display: flex;
   padding: 24px 20px 0 0;
 }
 
@@ -205,6 +212,14 @@ html.spui-SemiModal--open {
 
   .spui-SemiModal[data-type='sheet'][data-size='large'] .spui-SemiModal-frame {
     max-width: 1024px;
+  }
+
+  .spui-SemiModal-footer {
+    justify-content: var(--SemiModal-footer-justifyContent);
+  }
+
+  .spui-SemiModal-footer :is(.spui-Button, .spui-LinkButton) {
+    min-width: var(--SemiModal-footer-button-minWidth);
   }
 }
 
@@ -244,7 +259,13 @@ html.spui-SemiModal--open {
   }
 
   .spui-SemiModal-footer {
+    justify-content: var(--SemiModal-sp-footer-justifyContent);
     padding: 16px 0 0;
+  }
+
+  .spui-SemiModal-footer :is(.spui-Button, .spui-LinkButton) {
+    max-width: 360px;
+    width: 100%;
   }
 }
 

--- a/packages/spindle-ui/src/Modal/SemiModal.stories.example.tsx
+++ b/packages/spindle-ui/src/Modal/SemiModal.stories.example.tsx
@@ -44,7 +44,7 @@ export function PopupModalExample() {
           AmebaはAmebaブログをはじめ、最新の芸能人ニュースやマンガ・占いなど生きたコンテンツが集結した月間7,500万人が利用する国民的メディアサービスです。
         </SemiModal.Contents>
         <SemiModal.Footer>
-          <Button layout="fullWidth">確認する</Button>
+          <Button>確認する</Button>
         </SemiModal.Footer>
       </SemiModal.Frame>
     </>
@@ -81,7 +81,7 @@ export function SheetModalExample() {
           AmebaはAmebaブログをはじめ、最新の芸能人ニュースやマンガ・占いなど生きたコンテンツが集結した月間7,500万人が利用する国民的メディアサービスです。
         </SemiModal.Contents>
         <SemiModal.Footer>
-          <Button layout="fullWidth">確認する</Button>
+          <Button>確認する</Button>
         </SemiModal.Footer>
       </SemiModal.Frame>
     </>


### PR DESCRIPTION
#494 で作成したSemiModalのデザインチェック修正PRです。

## 変更(デザイナー依頼)
- [x] `SemiModal.Content`にline-heihgt: 160% 指定
- [x] Footerのレイアウト
  - [x] PC: デフォルト右寄せ（利用側から変更可）
  - [x] SP: デフォルト中央寄せ（利用側から変更可）
- [x] Footer内ボタンの横幅
  - [x] PC: `width: fit-content`, `min-width: 160px`(Labelに応じてサイズ可変)
  - [x] SP: `width: 100%`, `max-width: 360px`(Labelに応じてサイズ可変)
- [x] Animate DurationをPopup, Sheet共に350msに変更(Open, Close問わず)
