### PR TITLE
fix(spindle-ui): scrollIntoView caused the breadcrumbs to come to the top of the page.

### DIFF
--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.stories.mdx
@@ -185,6 +185,8 @@ Standard variantにwrapオプションを指定すると、画面幅に入り切
 
 ## Scroll Management
 
+### Last Item
+
 コンテンツが長く、見切れた場合にはcurrent指定されているアイテムが画面内に表示されるようにスクロールします。
 
 <Preview withSource="open">
@@ -205,6 +207,36 @@ Standard variantにwrapオプションを指定すると、画面幅に入り切
   <BreadcrumbItem href="#">Ameヨコ (アメヨコ)</BreadcrumbItem>
   <BreadcrumbItem href="#">福利厚生・社内制度</BreadcrumbItem>
   <BreadcrumbItem href="#" current>「わたしたち、育休取得した経営陣です！」育休が2秒で快諾される、"取るのが当たり前"な環境とは</BreadcrumbItem>
+</BreadcrumbList>
+  `}
+/>
+
+### Middle Item
+
+中間のカテゴリにも同様にスクロールが適用されます。
+
+<Preview withSource="open">
+  <Story name="Standard Overflow Middle Item">
+    <BreadcrumbList variant="standard">
+      <BreadcrumbItem href="#">Amebaとは</BreadcrumbItem>
+      <BreadcrumbItem href="#" current>Ameヨコ (アメヨコ)</BreadcrumbItem>
+      <BreadcrumbItem href="#">福利厚生・社内制度</BreadcrumbItem>
+      <BreadcrumbItem href="#">
+        「わたしたち、育休取得した経営陣です！」育休が2秒で快諾される、"取るのが当たり前"な環境とは
+      </BreadcrumbItem>
+    </BreadcrumbList>
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<BreadcrumbList variant="standard">
+  <BreadcrumbItem href="#">Amebaとは</BreadcrumbItem>
+  <BreadcrumbItem href="#" current>Ameヨコ (アメヨコ)</BreadcrumbItem>
+  <BreadcrumbItem href="#">福利厚生・社内制度</BreadcrumbItem>
+  <BreadcrumbItem href="#" >
+    「わたしたち、育休取得した経営陣です！」育休が2秒で快諾される、"取るのが当たり前"な環境とは
+  </BreadcrumbItem>
 </BreadcrumbList>
   `}
 />

--- a/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/BreadcrumbList.tsx
@@ -15,10 +15,13 @@ const BLOCK_NAME = 'spui-Breadcrumb';
 
 export const BreadcrumbList = (props: Props) => {
   const { children, className, variant = 'standard', wrap, ...rest } = props;
+  const navRef = useRef<HTMLElement>(null);
   const currentRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
-    currentRef.current?.scrollIntoView();
+    navRef.current?.scrollTo({
+      left: currentRef.current?.offsetLeft,
+    });
   }, []);
 
   return (
@@ -34,6 +37,7 @@ export const BreadcrumbList = (props: Props) => {
         .join(' ')
         .trim()}
       {...rest}
+      ref={navRef}
     >
       <ol className={`${BLOCK_NAME}-list`}>
         {React.Children.map(children, (child) => {


### PR DESCRIPTION
# 修正内容

## 項目1
scrollIntoViewではなく、通常のscrollを使用して、

> コンテンツが長く、見切れた場合にはcurrent指定されているアイテムが画面内に表示されるようにスクロールします。

という仕様を満たすように修正しました。

## 項目2
中カテゴリがcurrentになっていた場合、横スクロールがその指定したcurrentになっていることが確認できるようにstoryを追加しました。


# 修正した背景
`scrollIntoView` を使用すると、refで指定された要素が一番上に来るようになってしまっていました。

https://user-images.githubusercontent.com/87469023/215321012-c12508ad-3c51-4085-80ee-b11afbcd3c75.mp4

# 実装画面

https://user-images.githubusercontent.com/87469023/215321200-5027fc30-0b53-4ea5-a46e-cdaadf33267d.mp4

