### PR TITLE
fix(spindle-ui): change the button width of the InlineNotification

### DIFF
--- a/packages/spindle-ui/src/InlineNotification/InlineNotification.css
+++ b/packages/spindle-ui/src/InlineNotification/InlineNotification.css
@@ -94,7 +94,6 @@
   flex: none;
   margin-left: 16px;
   padding: 2px 0;
-  width: 60px;
 }
 
 /* icon, text, button が並ぶ場合のみpaddingを調整 */

--- a/packages/spindle-ui/src/InlineNotification/InlineNotification.stories.mdx
+++ b/packages/spindle-ui/src/InlineNotification/InlineNotification.stories.mdx
@@ -331,27 +331,27 @@ Avatar画像に関してはalt属性をPropsとして提供しているため、
     <InlineNotification.Frame variant='information' emphasis visible>
       <InlineNotification.Icon><Information aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>ブログの管理者が承認するまで、コメントが反映されない場合があります</InlineNotification.Text>
-      <InlineNotification.Button>確認</InlineNotification.Button>
+      <InlineNotification.Button>詳細へ</InlineNotification.Button>
     </InlineNotification.Frame>
     <InlineNotification.Frame variant='confirmation' visible>
       <InlineNotification.Icon><Information aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>コメントが投稿されました</InlineNotification.Text>
-      <InlineNotification.Button>確認</InlineNotification.Button>
+      <InlineNotification.Button>確認する</InlineNotification.Button>
     </InlineNotification.Frame>
     <InlineNotification.Frame variant='confirmation' emphasis visible>
       <InlineNotification.Icon><Information aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>コメントが投稿されました</InlineNotification.Text>
-      <InlineNotification.Button>確認</InlineNotification.Button>
+      <InlineNotification.Button>投稿を確認</InlineNotification.Button>
     </InlineNotification.Frame>
     <InlineNotification.Frame variant='error' visible>
       <InlineNotification.Icon><ExclamationmarkCircleFill aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>ファイル形式が正しくありません</InlineNotification.Text>
-      <InlineNotification.Button>確認</InlineNotification.Button>
+      <InlineNotification.Button>再アップロード</InlineNotification.Button>
     </InlineNotification.Frame>
     <InlineNotification.Frame variant='error' emphasis visible>
       <InlineNotification.Icon><ExclamationmarkCircleFill aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>ファイル形式が正しくありません</InlineNotification.Text>
-      <InlineNotification.Button>確認</InlineNotification.Button>
+      <InlineNotification.Button>画像をアップロード</InlineNotification.Button>
     </InlineNotification.Frame>
   </Story>
 </Preview>

--- a/packages/spindle-ui/src/InlineNotification/InlineNotification.tsx
+++ b/packages/spindle-ui/src/InlineNotification/InlineNotification.tsx
@@ -123,12 +123,7 @@ const Button: FC<
   const buttonVariant: ButtonVariant = computedButtonVariant(variant, emphasis);
   return (
     <div className={`${BLOCK_NAME}-button`}>
-      <SpindleButton
-        layout="fullWidth"
-        variant={buttonVariant}
-        size="small"
-        {...props}
-      >
+      <SpindleButton variant={buttonVariant} size="small" {...props}>
         {children}
       </SpindleButton>
     </div>


### PR DESCRIPTION
InlineNotificationコンポーネントで、右側にButtonがくるパターンがあります👇

![スクリーンショット 2023-02-02 16 21 53](https://user-images.githubusercontent.com/42470015/216258098-79aff7df-12da-4429-9ebd-2729add7019e.png)

このボタンのwrap部分に対して`width: 60px`が当たっていたため、ボタンのラベルが3文字以上の場合に表示崩れしていました 👀 

<img width="150" alt="スクリーンショット 2023-02-02 1 24 09" src="https://user-images.githubusercontent.com/42470015/216257762-9b9a9fbf-f075-431b-a00a-185e896378a6.png">

よって`width` -> `min-width`に変更し、修正しました 🚀 

<img width="150" alt="スクリーンショット 2023-02-02 1 24 32" src="https://user-images.githubusercontent.com/42470015/216257759-8b329db6-01e6-4d75-9dee-8db706cfeea7.png">

