### PR TITLE
fix(spindle-ui): support for iOS14

### DIFF
--- a/packages/spindle-ui/src/Modal/SemiModal.css
+++ b/packages/spindle-ui/src/Modal/SemiModal.css
@@ -1,5 +1,5 @@
+@import '../IconButton/IconButton.css';
 /*
- /*
  * SemiModal
  * NOTE: Styles can be overridden with "--SemiModal-*" variables
 */
@@ -23,6 +23,7 @@
 
 .spui-SemiModal[data-type='sheet'] {
   border-radius: 20px 20px 0 0;
+  bottom: 0;
   margin: auto auto 0;
   transform: translateY(100%);
   will-change: translate;

--- a/packages/spindle-ui/src/Modal/SemiModal.tsx
+++ b/packages/spindle-ui/src/Modal/SemiModal.tsx
@@ -48,13 +48,21 @@ const Frame = forwardRef<DialogHTMLElement, SemiModalProps>(function SemiModal(
   };
 
   // backdropを押した時
-  const handleDialogClick = (
-    event: React.SyntheticEvent<DialogHTMLElement>,
-  ) => {
-    setClosing(false);
+  const handleDialogClick = (event: React.MouseEvent<DialogHTMLElement>) => {
     // Detect backdrop click
     if (event.target === dialogEl.current) {
       onClose?.(event);
+    }
+  };
+
+  //EscKeyを押したとき
+  const handleDialogClose = (
+    event: React.SyntheticEvent<DialogHTMLElement>,
+  ) => {
+    // Detect escape key type
+    if (event.target === dialogEl.current) {
+      onClose?.(event);
+      setClosing(false);
     }
   };
 
@@ -109,7 +117,7 @@ const Frame = forwardRef<DialogHTMLElement, SemiModalProps>(function SemiModal(
         .trim()}
       ref={mergeRefs([dialogEl, ref])}
       onClick={handleDialogClick}
-      onClose={handleDialogClick}
+      onClose={handleDialogClose}
       data-type={type}
       data-size={size}
       {...rest}


### PR DESCRIPTION
## 概要
SemiModalにて
- backdropをダブルクリックするとモーダルが閉じない
- Reactを使ったプロジェクトでIconButtonのカスタムプロパティが使えない
- iOS14にてSheetModalの位置がずれる

バグを発見したため修正しました。
