### PR TITLE
fix(spindle-ui): fix TextLink and TextButton

### DIFF
--- a/packages/spindle-ui/src/TextButton/TextButton.css
+++ b/packages/spindle-ui/src/TextButton/TextButton.css
@@ -21,6 +21,7 @@
   font-family: inherit;
   font-size: 1em;
   font-weight: var(--TextButton-fontWeight);
+  line-height: 1.3;
   margin: 0;
   padding: 0;
   -webkit-tap-highlight-color: var(--TextButton-tapHighlightColor);

--- a/packages/spindle-ui/src/TextButton/TextButton.stories.mdx
+++ b/packages/spindle-ui/src/TextButton/TextButton.stories.mdx
@@ -7,7 +7,7 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Meta title="TextButton" component={TextButton} />
 
-![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
+![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
 
 <Source
   language='javascript'

--- a/packages/spindle-ui/src/TextButton/TextButton.stories.mdx
+++ b/packages/spindle-ui/src/TextButton/TextButton.stories.mdx
@@ -1,7 +1,7 @@
 import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { TextButton } from './TextButton';
-import { ChevronRightBold, CameraFill } from '../Icon';
+import { ChevronRightBold, CameraFill, PencilAdd } from '../Icon';
 
 # TextButton
 
@@ -28,20 +28,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Normal">
-    <TextButton {...actions('onClick', 'onMouseOver')}>Text Button</TextButton>
+    <TextButton {...actions('onClick', 'onMouseOver')}>もっと見る</TextButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextButton>Text Button</TextButton>
+<TextButton>もっと見る</TextButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-TextButton">Text Button</a>
+<a class="spui-TextButton">もっと見る</a>
   `}
 />
 
@@ -49,20 +49,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="NormalWithIcon">
-    <TextButton icon={<CameraFill aria-label="カメラ" />} iconPosition="start" {...actions('onClick', 'onMouseOver')}>Text Button</TextButton>
+    <TextButton icon={<PencilAdd aria-hidden="true" />} iconPosition="start" {...actions('onClick', 'onMouseOver')}>ブログを書く</TextButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextButton icon={<CameraFill aria-label="カメラ" />} iconPosition="start" />Text Button</TextButton>
+<TextButton icon={<PencilAdd aria-hidden="true" />} iconPosition="start" />ブログを書く</TextButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-TextButton spui-TextButton--hasIcon spui-TextButton--iconstart"><span class="spui-TextButton-icon"><svg>...</svg></span>Text Button</button>
+<button class="spui-TextButton spui-TextButton--hasIcon spui-TextButton--iconstart"><span class="spui-TextButton-icon"><svg>...</svg></span>ブログを書く</button>
   `}
 />
 
@@ -70,20 +70,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Subtle">
-    <TextButton variant="subtle" {...actions('onClick', 'onMouseOver')}>Text Button</TextButton>
+    <TextButton variant="subtle" {...actions('onClick', 'onMouseOver')}>もっと見る</TextButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextButton variant="subtle" />}>Text Button</TextButton>
+<TextButton variant="subtle" />}>もっと見る</TextButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-TextButton spui-TextButton--subtle">Text Button</button>
+<button class="spui-TextButton spui-TextButton--subtle">もっと見る</button>
   `}
 />
 
@@ -91,20 +91,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="SubtleWithIcon">
-    <TextButton variant="subtle" icon={<ChevronRightBold aria-hidden="true" />} iconPosition="end" {...actions('onClick', 'onMouseOver')}>Text Button</TextButton>
+    <TextButton variant="subtle" icon={<ChevronRightBold aria-hidden="true" />} iconPosition="end" {...actions('onClick', 'onMouseOver')}>もっと見る</TextButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextButton variant="subtle" icon={<ChevronRightBold aria-hidden="true" />} iconPosition="end">Text Button</TextButton>
+<TextButton variant="subtle" icon={<ChevronRightBold aria-hidden="true" />} iconPosition="end">もっと見る</TextButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-TextButton spui-TextButton--subtle spui-TextButton--hasIcon spui-TextButton--iconend"><span class="spui-TextButton-icon"><svg>...</svg></span>Text Button</button>
+<button class="spui-TextButton spui-TextButton--subtle spui-TextButton--hasIcon spui-TextButton--iconend"><span class="spui-TextButton-icon"><svg>...</svg></span>もっと見る</button>
   `}
 />
 
@@ -120,20 +120,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="UnderlineHover">
-    <TextButton underline="hover" {...actions('onClick', 'onMouseOver')}>Text Button</TextButton>
+    <TextButton underline="hover" {...actions('onClick', 'onMouseOver')}>もっと見る</TextButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextButton underline="hover">Text Button</TextButton>
+<TextButton underline="hover">もっと見る</TextButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-TextButton spui-TextButton--underlinehover">Text Button</button>
+<button class="spui-TextButton spui-TextButton--underlinehover">もっと見る</button>
   `}
 />
 
@@ -151,7 +151,7 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 </style>
 <div class="container">
 <ul>
-  <li><button class="spui-TextButton" href="#">Text Button</button></li>
+  <li><button class="spui-TextButton" href="#">もっと見る</button></li>
 </ul>
 </div>
   `}

--- a/packages/spindle-ui/src/TextLink/TextLink.css
+++ b/packages/spindle-ui/src/TextLink/TextLink.css
@@ -18,6 +18,7 @@
   color: var(--TextLink-color);
   font-family: inherit;
   font-weight: var(--TextLink-fontWeight);
+  line-height: 1.3;
   -webkit-tap-highlight-color: var(--TextLink-tapHighlightColor);
 }
 

--- a/packages/spindle-ui/src/TextLink/TextLink.stories.mdx
+++ b/packages/spindle-ui/src/TextLink/TextLink.stories.mdx
@@ -1,7 +1,7 @@
 import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { TextLink } from './TextLink';
-import { ChevronRightBold, CameraFill } from '../Icon';
+import { ChevronRightBold, CameraFill, PencilAdd } from '../Icon';
 
 # TextLink
 
@@ -28,20 +28,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Normal">
-    <TextLink href="#" {...actions('onMouseOver')}>Text Link</TextLink>
+    <TextLink href="#" {...actions('onMouseOver')}>もっと見る</TextLink>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextLink href="#">Text Link</TextLink>
+<TextLink href="#">もっと見る</TextLink>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-TextLink" href="#">TextLink</a>
+<a class="spui-TextLink" href="#">もっと見る</a>
   `}
 />
 
@@ -49,20 +49,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="NormalWithIcon">
-    <TextLink href="#" icon={<CameraFill aria-label="カメラ" />} iconPosition="start" {...actions('onMouseOver')}>Text Link</TextLink>
+    <TextLink href="#" icon={<PencilAdd aria-hidden="true" />} iconPosition="start" {...actions('onMouseOver')}>ブログを書く</TextLink>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextLink href="#" icon={<CameraFill aria-label="カメラ" />} iconPosition="start" />Text Link</TextLink>
+<TextLink href="#" icon={<PencilAdd aria-hidden="true" />} iconPosition="start" />ブログを書く</TextLink>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a href="#" class="spui-TextLink spui-TextLink--hasIcon spui-TextLink--iconstart"><span class="spui-TextLink-icon"><svg>...</svg></span>TextLink</a>
+<a href="#" class="spui-TextLink spui-TextLink--hasIcon spui-TextLink--iconstart"><span class="spui-TextLink-icon"><svg>...</svg></span>ブログを書く</a>
   `}
 />
 
@@ -70,20 +70,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Subtle">
-    <TextLink href="#" variant="subtle" {...actions('onMouseOver')}>Text Link</TextLink>
+    <TextLink href="#" variant="subtle" {...actions('onMouseOver')}>もっと見る</TextLink>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextLink href="#" variant="subtle" />}>Text Link</TextLink>
+<TextLink href="#" variant="subtle" />}>もっと見る</TextLink>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a href="#" class="spui-TextLink spui-TextLink--subtle">TextLink</a>
+<a href="#" class="spui-TextLink spui-TextLink--subtle">もっと見る</a>
   `}
 />
 
@@ -91,20 +91,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="SubtleWithIcon">
-    <TextLink href="#" variant="subtle" icon={<ChevronRightBold aria-hidden="true" />} iconPosition="end" {...actions('onMouseOver')}>Text Link</TextLink>
+    <TextLink href="#" variant="subtle" icon={<ChevronRightBold aria-hidden="true" />} iconPosition="end" {...actions('onMouseOver')}>もっと見る</TextLink>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextLink href="#" icon={<ChevronRightBold aria-hidden="true" />} iconPosition="end">Text Link</TextLink>
+<TextLink href="#" icon={<ChevronRightBold aria-hidden="true" />} iconPosition="end">もっと見る</TextLink>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a href="#" class="spui-TextLink spui-TextLink--subtle spui-TextLink--hasIcon spui-TextLink--iconend"><span class="spui-TextLink-icon"><svg>...</svg></span>TextLink</a>
+<a href="#" class="spui-TextLink spui-TextLink--subtle spui-TextLink--hasIcon spui-TextLink--iconend"><span class="spui-TextLink-icon"><svg>...</svg></span>もっと見る</a>
   `}
 />
 
@@ -120,20 +120,20 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="UnderlineHover">
-    <TextLink href="#" underline="hover" {...actions('onMouseOver')}>Text Link</TextLink>
+    <TextLink href="#" underline="hover" {...actions('onMouseOver')}>もっと見る</TextLink>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextLink href="#" underline="hover">Text Link</TextLink>
+<TextLink href="#" underline="hover">もっと見る</TextLink>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a href="#" class="spui-TextLink spui-TextLink--underlinehover">TextLink</a>
+<a href="#" class="spui-TextLink spui-TextLink--underlinehover">もっと見る</a>
   `}
 />
 
@@ -151,7 +151,7 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 </style>
 <div class="container">
 <ul>
-  <li><a class="spui-TextLink" href="#">Text Link</a></li>
+  <li><a class="spui-TextLink" href="#">もっと見る</a></li>
 </ul>
 </div>
   `}

--- a/packages/spindle-ui/src/TextLink/TextLink.stories.mdx
+++ b/packages/spindle-ui/src/TextLink/TextLink.stories.mdx
@@ -7,7 +7,7 @@ import { ChevronRightBold, CameraFill } from '../Icon';
 
 <Meta title="TextLink" component={TextLink} />
 
-![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
+![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
 
 <Source
   language='javascript'


### PR DESCRIPTION
# 概要
TextLinkとTextButtonに対して、軽微な修正を行いました 🚀 
- TextLinkとTextButtonに、`line-height: 1.3`が足りなかったため追加 https://github.com/openameba/spindle/commit/995e06bacf24e8989be6425c0f8452672ef7160a
- stabilityを（テストも書かれているし本番運用も問題なくされているので）`unstable`から`stable`に変更 https://github.com/openameba/spindle/commit/0b2a658a47cbb81f397d10441fe9ee2fd81d7d09
- Storybookに表示されるサンプルのラベル名を、英語から日本語に変更（Ref. [StorybookのUIのラベルを日本語にする](https://github.com/openameba/spindle/issues/162)） https://github.com/openameba/spindle/commit/3a7d1b6879dcf1d47cd4b69dffffacb869d83705