### PR TITLE
fix(spindle-ui): wider acceptance of InlineNotification props

### DIFF
--- a/packages/spindle-ui/src/InlineNotification/InlineNotification.stories.mdx
+++ b/packages/spindle-ui/src/InlineNotification/InlineNotification.stories.mdx
@@ -41,6 +41,15 @@ InlineNotificationコンポーネントは、ユーザーのアクションに�
 ## アクセシビリティ
 コンポーネントからはアプリケーション内での使われ方や重要度がわからないため、aria-*属性やrole属性は付与していません。そのため、コンポーネント利用時には適宜付与して支援技術に通知してください。
 
+<Source
+  code={`
+<InlineNotification.Frame role="alert" variant='error' visible>
+  <InlineNotification.Icon><ExclamationmarkCircleFill aria-hidden="true"/></InlineNotification.Icon>
+  <InlineNotification.Text>ファイル形式が正しくありません</InlineNotification.Text>
+</InlineNotification.Frame>
+  `}
+/>
+
 Avatar画像に関してはalt属性をPropsとして提供しているため、必要に応じて指定してください。何も指定しなかった場合は`alt=""`が設定されます。
 
 ## Variant

--- a/packages/spindle-ui/src/InlineNotification/InlineNotification.tsx
+++ b/packages/spindle-ui/src/InlineNotification/InlineNotification.tsx
@@ -20,7 +20,7 @@ type Props = {
   emphasis?: boolean;
   layout?: Layout;
   visible?: boolean;
-};
+} & Omit<React.HTMLAttributes<HTMLDivElement>, 'className'>;
 
 const BLOCK_NAME = 'spui-InlineNotification';
 const DEFAULT_VARIANT = 'information';
@@ -48,6 +48,7 @@ const Frame: FC<Props> = ({
   emphasis = DEFAULT_EMPHASIS,
   layout = DEFAULT_LAYOUT,
   visible = DEFAULT_VISIBLE,
+  ...rest
 }) => {
   return (
     <div
@@ -60,6 +61,7 @@ const Frame: FC<Props> = ({
         .filter(Boolean)
         .join(' ')}
       hidden={!visible}
+      {...rest}
     >
       <div className={`${BLOCK_NAME}-content`}>
         {Children.map(children, (child) =>


### PR DESCRIPTION
## 概要
InlineNotificationコンポーネントでは、下記のようなアクセシビリティ方針を定めています

> コンポーネントからはアプリケーション内での使われ方や重要度がわからないため、aria-*属性やrole属性は付与していません。そのため、コンポーネント利用時には適宜付与して支援技術に通知してください。

にも関わらず、`InlineNotification.Frame`が`role`属性等を受け取れない実装になっていたため、修正しました 🙏🏻 
また、それに伴いドキュメントにも実装例を追加しています 📝