### PR TITLE
docs(spindle-ui): change documentation to Japanese

### DIFF
--- a/packages/spindle-ui/src/BottomButton/BottomButton.stories.mdx
+++ b/packages/spindle-ui/src/BottomButton/BottomButton.stories.mdx
@@ -28,7 +28,7 @@ import { BottomButton } from './BottomButton';
   <Story name="Fixed Position">
     <div style={{ ["--BottomButton-z-index"]: 2 }}>
       <BottomButton position="fixed">
-        <Button size="large" variant="contained" layout="fullWidth">fixed button</Button>
+        <Button size="large" variant="contained" layout="fullWidth">新規登録</Button>
       </BottomButton>
     </div>
   </Story>
@@ -37,7 +37,7 @@ import { BottomButton } from './BottomButton';
 <Source
   code={`
 <BottomButton position="fixed">
-  <Button size="large" variant="contained" layout="fullWidth">fixed button</Button>
+  <Button size="large" variant="contained" layout="fullWidth">新規登録</Button>
 </BottomButton>
   `}
 />
@@ -47,7 +47,7 @@ import { BottomButton } from './BottomButton';
   code={`
 <div class="spui-BottomButton spui-BottomButton--fixed">
   <div class="spui-BottomButton-wrap">
-    <button class="spui-Button spui-Button--large spui-Button--contained">fixed button</button>
+    <button class="spui-Button spui-Button--large spui-Button--contained">新規登録</button>
   </div>
 </div>
   `}
@@ -59,7 +59,7 @@ import { BottomButton } from './BottomButton';
 <Preview withSource="open">
   <Story name="Sticky Position">
     <BottomButton position="sticky">
-      <Button size="large" variant="contained" layout="fullWidth">sticky button</Button>
+      <Button size="large" variant="contained" layout="fullWidth">新規登録</Button>
     </BottomButton>
   </Story>
 </Preview>
@@ -67,7 +67,7 @@ import { BottomButton } from './BottomButton';
 <Source
   code={`
 <BottomButton position="sticky">
-  <Button size="large" variant="contained" layout="fullWidth">sticky button</Button>
+  <Button size="large" variant="contained" layout="fullWidth">新規登録</Button>
 </BottomButton>
   `}
 />
@@ -77,7 +77,7 @@ import { BottomButton } from './BottomButton';
   code={`
 <div class="spui-BottomButton spui-BottomButton--sticky">
   <div class="spui-BottomButton-wrap">
-    <button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained">sticky button</button>
+    <button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained">新規登録</button>
   </div>
 </div>
   `}

--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -1,7 +1,7 @@
 import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { Button } from './Button';
-import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
+import { PlusBold, Link, FileAdd } from '../Icon';
 
 # Button
 
@@ -26,29 +26,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Large">
-    <Button size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button size="large" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+    <Button size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>申請する</Button>
+    <Button size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
+    <Button size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
+    <Button size="large" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button size="large" variant="contained">Contained</Button>
-<Button size="large" variant="outlined">Outlined</Button>
-<Button size="large" variant="neutral">Neutral</Button>
-<Button size="large" variant="danger">Danger</Button>
+<Button size="large" variant="contained">申請する</Button>
+<Button size="large" variant="outlined">選択する</Button>
+<Button size="large" variant="neutral">修正する</Button>
+<Button size="large" variant="danger">削除する</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
-<button class="spui-Button spui-Button--large spui-Button--outlined">Outlined</button>
-<button class="spui-Button spui-Button--large spui-Button--neutral">Neutral</button>
-<button class="spui-Button spui-Button--large spui-Button--danger">Danger</button>
+<button class="spui-Button spui-Button--large spui-Button--contained">申請する</button>
+<button class="spui-Button spui-Button--large spui-Button--outlined">選択する</button>
+<button class="spui-Button spui-Button--large spui-Button--neutral">修正する</button>
+<button class="spui-Button spui-Button--large spui-Button--danger">削除する</button>
   `}
 />
 
@@ -56,29 +56,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Large Full Width">
-    <Button layout="fullWidth" size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button layout="fullWidth" size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button layout="fullWidth" size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button layout="fullWidth" size="large" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+    <Button layout="fullWidth" size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>申請する</Button>
+    <Button layout="fullWidth" size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
+    <Button layout="fullWidth" size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
+    <Button layout="fullWidth" size="large" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button layout="fullWidth" size="large" variant="contained">Contained</Button>
-<Button layout="fullWidth" size="large" variant="outlined">Outlined</Button>
-<Button layout="fullWidth" size="large" variant="neutral">Neutral</Button>
-<Button layout="fullWidth" size="large" variant="danger">Danger</Button>
+<Button layout="fullWidth" size="large" variant="contained">申請する</Button>
+<Button layout="fullWidth" size="large" variant="outlined">選択する</Button>
+<Button layout="fullWidth" size="large" variant="neutral">修正する</Button>
+<Button layout="fullWidth" size="large" variant="danger">削除する</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained">Contained</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--outlined">Outlined</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--neutral">Neutral</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--danger">Danger</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained">申請する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--outlined">選択する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--neutral">修正する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--danger">削除する</button>
   `}
 />
 
@@ -86,29 +86,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Medium">
-    <Button size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+    <Button size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>申請する</Button>
+    <Button size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
+    <Button size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
+    <Button size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button size="medium" variant="contained">Contained</Button>
-<Button size="medium" variant="outlined">Outlined</Button>
-<Button size="medium" variant="neutral">Neutral</Button>
-<Button size="medium" variant="danger">Danger</Button>
+<Button size="medium" variant="contained">申請する</Button>
+<Button size="medium" variant="outlined">選択する</Button>
+<Button size="medium" variant="neutral">修正する</Button>
+<Button size="medium" variant="danger">削除する</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
-<button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
-<button class="spui-Button spui-Button--medium spui-Button--neutral">Neutral</button>
-<button class="spui-Button spui-Button--medium spui-Button--danger">Danger</button>
+<button class="spui-Button spui-Button--medium spui-Button--contained">申請する</button>
+<button class="spui-Button spui-Button--medium spui-Button--outlined">選択する</button>
+<button class="spui-Button spui-Button--medium spui-Button--neutral">修正する</button>
+<button class="spui-Button spui-Button--medium spui-Button--danger">削除する</button>
   `}
 />
 
@@ -116,29 +116,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Medium Full Width">
-    <Button layout="fullWidth" size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button layout="fullWidth" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button layout="fullWidth" size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button layout="fullWidth" size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+    <Button layout="fullWidth" size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>申請する</Button>
+    <Button layout="fullWidth" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
+    <Button layout="fullWidth" size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
+    <Button layout="fullWidth" size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button layout="fullWidth" size="medium" variant="contained">Contained</Button>
-<Button layout="fullWidth" size="medium" variant="outlined">Outlined</Button>
-<Button layout="fullWidth" size="medium" variant="neutral">Neutral</Button>
-<Button layout="fullWidth" size="medium" variant="danger">Danger</Button>
+<Button layout="fullWidth" size="medium" variant="contained">申請する</Button>
+<Button layout="fullWidth" size="medium" variant="outlined">選択する</Button>
+<Button layout="fullWidth" size="medium" variant="neutral">修正する</Button>
+<Button layout="fullWidth" size="medium" variant="danger">削除する</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--contained">Contained</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined">Outlined</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral">Neutral</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger">Danger</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--contained">申請する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined">選択する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral">修正する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger">削除する</button>
   `}
 />
 
@@ -146,29 +146,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Small">
-    <Button size="small" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button size="small" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+    <Button size="small" variant="contained" {...actions('onClick', 'onMouseOver')}>申請する</Button>
+    <Button size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
+    <Button size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
+    <Button size="small" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button size="small" variant="contained">Contained</Button>
-<Button size="small" variant="outlined">Outlined</Button>
-<Button size="small" variant="neutral">Neutral</Button>
-<Button size="small" variant="danger">Danger</Button>
+<Button size="small" variant="contained">申請する</Button>
+<Button size="small" variant="outlined">選択する</Button>
+<Button size="small" variant="neutral">修正する</Button>
+<Button size="small" variant="danger">削除する</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
-<button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
-<button class="spui-Button spui-Button--small spui-Button--neutral">Neutral</button>
-<button class="spui-Button spui-Button--small spui-Button--danger">Danger</button>
+<button class="spui-Button spui-Button--small spui-Button--contained">申請する</button>
+<button class="spui-Button spui-Button--small spui-Button--outlined">選択する</button>
+<button class="spui-Button spui-Button--small spui-Button--neutral">修正する</button>
+<button class="spui-Button spui-Button--small spui-Button--danger">削除する</button>
   `}
 />
 
@@ -176,29 +176,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Small Full Width">
-    <Button layout="fullWidth" size="small" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button layout="fullWidth" size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button layout="fullWidth" size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button layout="fullWidth" size="small" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+    <Button layout="fullWidth" size="small" variant="contained" {...actions('onClick', 'onMouseOver')}>申請する</Button>
+    <Button layout="fullWidth" size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
+    <Button layout="fullWidth" size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
+    <Button layout="fullWidth" size="small" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button layout="fullWidth" size="small" variant="contained">Contained</Button>
-<Button layout="fullWidth" size="small" variant="outlined">Outlined</Button>
-<Button layout="fullWidth" size="small" variant="neutral">Neutral</Button>
-<Button layout="fullWidth" size="small" variant="danger">Danger</Button>
+<Button layout="fullWidth" size="small" variant="contained">申請する</Button>
+<Button layout="fullWidth" size="small" variant="outlined">選択する</Button>
+<Button layout="fullWidth" size="small" variant="neutral">修正する</Button>
+<Button layout="fullWidth" size="small" variant="danger">削除する</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--contained">Contained</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--outlined">Outlined</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral">Neutral</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--danger">Danger</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--contained">申請する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--outlined">選択する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral">修正する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--danger">削除する</button>
   `}
 />
 
@@ -206,29 +206,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Disabled">
-    <Button disabled size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button disabled size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+    <Button disabled size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>申請する</Button>
+    <Button disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
+    <Button disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
+    <Button disabled size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button disabled size="medium" variant="contained">Contained</Button>
-<Button disabled size="medium" variant="outlined">Outlined</Button>
-<Button disabled size="medium" variant="neutral">Neutral</Button>
-<Button disabled size="medium" variant="danger">Danger</Button>
+<Button disabled size="medium" variant="contained">申請する</Button>
+<Button disabled size="medium" variant="outlined">選択する</Button>
+<Button disabled size="medium" variant="neutral">修正する</Button>
+<Button disabled size="medium" variant="danger">削除する</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--medium spui-Button--contained" disabled>Contained</button>
-<button class="spui-Button spui-Button--medium spui-Button--outlined" disabled>Outlined</button>
-<button class="spui-Button spui-Button--medium spui-Button--neutral" disabled>Neutral</button>
-<button class="spui-Button spui-Button--medium spui-Button--danger" disabled>Danger</button>
+<button class="spui-Button spui-Button--medium spui-Button--contained" disabled>申請する</button>
+<button class="spui-Button spui-Button--medium spui-Button--outlined" disabled>選択する</button>
+<button class="spui-Button spui-Button--medium spui-Button--neutral" disabled>修正する</button>
+<button class="spui-Button spui-Button--medium spui-Button--danger" disabled>削除する</button>
   `}
 />
 
@@ -236,29 +236,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Disabled Full Width">
-    <Button layout="fullWidth" disabled size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button layout="fullWidth" disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button layout="fullWidth" disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
-    <Button layout="fullWidth" disabled size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>Danger</Button>
+    <Button layout="fullWidth" disabled size="medium" variant="contained" {...actions('onClick', 'onMouseOver')}>申請する</Button>
+    <Button layout="fullWidth" disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
+    <Button layout="fullWidth" disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
+    <Button layout="fullWidth" disabled size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button layout="fullWidth" disabled size="medium" variant="contained">Contained</Button>
-<Button layout="fullWidth" disabled size="medium" variant="outlined">Outlined</Button>
-<Button layout="fullWidth" disabled size="medium" variant="neutral">Neutral</Button>
-<Button layout="fullWidth" disabled size="medium" variant="danger">Danger</Button>
+<Button layout="fullWidth" disabled size="medium" variant="contained">申請する</Button>
+<Button layout="fullWidth" disabled size="medium" variant="outlined">選択する</Button>
+<Button layout="fullWidth" disabled size="medium" variant="neutral">修正する</Button>
+<Button layout="fullWidth" disabled size="medium" variant="danger">削除する</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--contained" disabled>Contained</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined" disabled>Outlined</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral" disabled>Neutral</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger" disabled>Danger</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--contained" disabled>申請する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined" disabled>選択する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral" disabled>修正する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger" disabled>削除する</button>
   `}
 />
 
@@ -266,26 +266,26 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="With Icon">
-    <Button icon={<PlusBold/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button icon={<ArrowRightBold/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button icon={<OpenblankFill/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+    <Button icon={<FileAdd/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>ファイルを選択する</Button>
+    <Button icon={<Link/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>リンクをコピーする</Button>
+    <Button icon={<PlusBold/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>フォローする</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button icon={<PlusBold/>} size="large" variant="contained">Contained</Button>
-<Button icon={<ArrowRightBold/>} size="medium" variant="outlined">Outlined</Button>
-<Button icon={<OpenblankFill/>} size="small" variant="neutral">Neutral</Button>
+<Button icon={<FileAdd/>} size="large" variant="contained">ファイルを選択する</Button>
+<Button icon={<Link/>} size="medium" variant="outlined">リンクをコピーする</Button>
+<Button icon={<PlusBold/>} size="small" variant="neutral">フォローする</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--intrinsic spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>Contained</button>
-<button class="spui-Button spui-Button--intrinsic spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>Outlined</button>
-<button class="spui-Button spui-Button--intrinsic spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>Neutral</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォローする</button>
   `}
 />
 
@@ -293,26 +293,26 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Full Width With Icon">
-    <Button layout="fullWidth" icon={<PlusBold/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>Contained</Button>
-    <Button layout="fullWidth" icon={<ArrowRightBold/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>Outlined</Button>
-    <Button layout="fullWidth" icon={<OpenblankFill/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>Neutral</Button>
+    <Button layout="fullWidth" icon={<FileAdd/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>ファイルを選択する</Button>
+    <Button layout="fullWidth" icon={<Link/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>リンクをコピーする</Button>
+    <Button layout="fullWidth" icon={<PlusBold/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>フォローする</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button layout="fullWidth" icon={<PlusBold/>} size="large" variant="contained">Contained</Button>
-<Button layout="fullWidth" icon={<ArrowRightBold/>} size="medium" variant="outlined">Outlined</Button>
-<Button layout="fullWidth" icon={<OpenblankFill/>} size="small" variant="neutral">Neutral</Button>
+<Button layout="fullWidth" icon={<FileAdd/>} size="large" variant="contained">ファイルを選択する</Button>
+<Button layout="fullWidth" icon={<Link/>} size="medium" variant="outlined">リンクをコピーする</Button>
+<Button layout="fullWidth" icon={<PlusBold/>} size="small" variant="neutral">フォローする</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>Contained</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>Outlined</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>Neutral</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォローする</button>
   `}
 />
 
@@ -320,20 +320,20 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Lighted">
-    <Button size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}>Lighted</Button>
+    <Button size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Button size="large" variant="lighted">Lighted</Button>
+<Button size="large" variant="lighted">フォロー中</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--large spui-Button--lighted">Lighted</button>
+<button class="spui-Button spui-Button--large spui-Button--lighted">フォロー中</button>
   `}
 />
 

--- a/packages/spindle-ui/src/ButtonGroup/ButtonGroup.stories.mdx
+++ b/packages/spindle-ui/src/ButtonGroup/ButtonGroup.stories.mdx
@@ -27,8 +27,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Row Direction with Large Buttons">
     <ButtonGroup direction="row" size="large">
-      <Button size="large" variant="contained">Contained</Button>
-      <Button size="large" variant="outlined">Outlined</Button>
+      <Button size="large" variant="contained">新規登録</Button>
+      <Button size="large" variant="outlined">ログイン</Button>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -36,8 +36,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="row" size="large">
-  <Button size="large" variant="contained">Contained</Button>
-  <Button size="large" variant="outlined">Outlined</Button>
+  <Button size="large" variant="contained">新規登録</Button>
+  <Button size="large" variant="outlined">ログイン</Button>
 </ButtonGroup>
   `}
 />
@@ -46,8 +46,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--row spui-ButtonGroup--large">
-  <button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--large spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--large spui-Button--contained">新規登録</button>
+  <button class="spui-Button spui-Button--large spui-Button--outlined">ログイン</button>
 </div>
   `}
 />
@@ -57,8 +57,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Column Direction with Large Buttons">
     <ButtonGroup direction="column" size="large">
-      <Button variant="contained">Contained</Button>
-      <Button variant="outlined">Outlined</Button>
+      <Button variant="contained">新規登録</Button>
+      <Button variant="outlined">ログイン</Button>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -66,8 +66,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="column" size="large">
-  <Button size="large" variant="contained">Contained</Button>
-  <Button size="large" variant="outlined">Outlined</Button>
+  <Button size="large" variant="contained">新規登録</Button>
+  <Button size="large" variant="outlined">ログイン</Button>
 </ButtonGroup>
   `}
 />
@@ -76,8 +76,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--large">
-  <button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--large spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--large spui-Button--contained">新規登録</button>
+  <button class="spui-Button spui-Button--large spui-Button--outlined">ログイン</button>
 </div>
   `}
 />
@@ -87,8 +87,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Row Direction with Medium Buttons">
     <ButtonGroup direction="row" size="medium">
-      <Button size="medium" variant="contained">Contained</Button>
-      <Button size="medium" variant="outlined">Outlined</Button>
+      <Button size="medium" variant="contained">新規登録</Button>
+      <Button size="medium" variant="outlined">ログイン</Button>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -96,8 +96,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="row" size="medium">
-  <Button size="medium" variant="contained">Contained</Button>
-  <Button size="medium" variant="outlined">Outlined</Button>
+  <Button size="medium" variant="contained">新規登録</Button>
+  <Button size="medium" variant="outlined">ログイン</Button>
 </ButtonGroup>
   `}
 />
@@ -106,8 +106,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--row spui-ButtonGroup--medium">
-  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--medium spui-Button--contained">新規登録</button>
+  <button class="spui-Button spui-Button--medium spui-Button--outlined">ログイン</button>
 </div>
   `}
 />
@@ -117,8 +117,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Column Direction with Medium Buttons">
     <ButtonGroup direction="column" size="medium">
-      <Button size="medium" variant="contained">Contained</Button>
-      <Button size="medium" variant="outlined">Outlined</Button>
+      <Button size="medium" variant="contained">新規登録</Button>
+      <Button size="medium" variant="outlined">ログイン</Button>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -126,8 +126,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="column" size="medium">
-  <Button size="medium" variant="contained">Contained</Button>
-  <Button size="medium" variant="outlined">Outlined</Button>
+  <Button size="medium" variant="contained">新規登録</Button>
+  <Button size="medium" variant="outlined">ログイン</Button>
 </ButtonGroup>
   `}
 />
@@ -136,8 +136,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--medium">
-  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--medium spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--medium spui-Button--contained">新規登録</button>
+  <button class="spui-Button spui-Button--medium spui-Button--outlined">ログイン</button>
 </div>
   `}
 />
@@ -147,8 +147,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Row Direction with Small Buttons">
     <ButtonGroup direction="row" size="small">
-      <Button size="small" variant="contained">Contained</Button>
-      <Button size="small" variant="outlined">Outlined</Button>
+      <Button size="small" variant="contained">新規登録</Button>
+      <Button size="small" variant="outlined">ログイン</Button>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -156,8 +156,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="row" size="small">
-  <Button size="small" variant="contained">Contained</Button>
-  <Button size="small" variant="outlined">Outlined</Button>
+  <Button size="small" variant="contained">新規登録</Button>
+  <Button size="small" variant="outlined">ログイン</Button>
 </ButtonGroup>
   `}
 />
@@ -166,8 +166,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--row spui-ButtonGroup--small">
-  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--small spui-Button--contained">新規登録</button>
+  <button class="spui-Button spui-Button--small spui-Button--outlined">ログイン</button>
 </div>
   `}
 />
@@ -177,8 +177,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Column Direction with Small Buttons">
     <ButtonGroup direction="column" size="small">
-      <Button size="small" variant="contained">Contained</Button>
-      <Button size="small" variant="outlined">Outlined</Button>
+      <Button size="small" variant="contained">新規登録</Button>
+      <Button size="small" variant="outlined">ログイン</Button>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -186,8 +186,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="column" size="small">
-  <Button size="small" variant="contained">Contained</Button>
-  <Button size="small" variant="outlined">Outlined</Button>
+  <Button size="small" variant="contained">新規登録</Button>
+  <Button size="small" variant="outlined">ログイン</Button>
 </ButtonGroup>
   `}
 />
@@ -196,8 +196,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--small">
-  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
-  <button class="spui-Button spui-Button--small spui-Button--outlined">Outlined</button>
+  <button class="spui-Button spui-Button--small spui-Button--contained">新規登録</button>
+  <button class="spui-Button spui-Button--small spui-Button--outlined">ログイン</button>
 </div>
   `}
 />
@@ -207,8 +207,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Column Direction with Large Subtle Button">
     <ButtonGroup direction="column" size="large">
-      <Button variant="contained">Contained</Button>
-      <SubtleButton size="large">Subtle Button</SubtleButton>
+      <Button variant="contained">申請する</Button>
+      <SubtleButton size="large">とじる</SubtleButton>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -216,8 +216,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="column" size="large">
-  <Button size="large" variant="contained">Contained</Button>
-  <SubtleButton size="large">Subtle Button</SubtleButton>
+  <Button size="large" variant="contained">申請する</Button>
+  <SubtleButton size="large">とじる</SubtleButton>
 </ButtonGroup>
   `}
 />
@@ -226,8 +226,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--large">
-  <button class="spui-Button spui-Button--large spui-Button--contained">Contained</button>
-  <button class="spui-SubtleButton spui-SubtleButton--large">Subtle Button</button>
+  <button class="spui-Button spui-Button--large spui-Button--contained">申請する</button>
+  <button class="spui-SubtleButton spui-SubtleButton--large">とじる</button>
 </div>
   `}
 />
@@ -237,8 +237,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Column Direction with Medium Subtle Button">
     <ButtonGroup direction="column" size="medium">
-      <Button size="medium" variant="contained">Contained</Button>
-      <SubtleButton size="medium">Subtle Button</SubtleButton>
+      <Button size="medium" variant="contained">申請する</Button>
+      <SubtleButton size="medium">とじる</SubtleButton>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -246,8 +246,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="column" size="medium">
-  <Button size="medium" variant="contained">Contained</Button>
-  <SubtleButton size="medium">Subtle Button</SubtleButton>
+  <Button size="medium" variant="contained">申請する</Button>
+  <SubtleButton size="medium">とじる</SubtleButton>
 </ButtonGroup>
   `}
 />
@@ -256,8 +256,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--medium">
-  <button class="spui-Button spui-Button--medium spui-Button--contained">Contained</button>
-  <button class="spui-SubtleButton spui-SubtleButton--medium">Subtle Button</button>
+  <button class="spui-Button spui-Button--medium spui-Button--contained">申請する</button>
+  <button class="spui-SubtleButton spui-SubtleButton--medium">とじる</button>
 </div>
   `}
 />
@@ -267,8 +267,8 @@ import { SubtleButton } from '../SubtleButton';
 <Preview withSource="open">
   <Story name="Column Direction with Small Subtle Button">
     <ButtonGroup direction="column" size="small">
-      <Button size="small" variant="contained">Contained</Button>
-      <SubtleButton size="small">Subtle Button</SubtleButton>
+      <Button size="small" variant="contained">申請する</Button>
+      <SubtleButton size="small">とじる</SubtleButton>
     </ButtonGroup>
   </Story>
 </Preview>
@@ -276,8 +276,8 @@ import { SubtleButton } from '../SubtleButton';
 <Source
   code={`
 <ButtonGroup direction="column" size="small">
-  <Button size="small" variant="contained">Contained</Button>
-  <SubtleButton size="small">Subtle Button</SubtleButton>
+  <Button size="small" variant="contained">申請する</Button>
+  <SubtleButton size="small">とじる</SubtleButton>
 </ButtonGroup>
   `}
 />
@@ -286,8 +286,8 @@ import { SubtleButton } from '../SubtleButton';
   language='html'
   code={`
 <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--small">
-  <button class="spui-Button spui-Button--small spui-Button--contained">Contained</button>
-  <button class="spui-SubtleButton spui-SubtleButton--small">Subtle Button</button>
+  <button class="spui-Button spui-Button--small spui-Button--contained">申請する</button>
+  <button class="spui-SubtleButton spui-SubtleButton--small">とじる</button>
 </div>
   `}
 />

--- a/packages/spindle-ui/src/Dialog/Dialog.stories.mdx
+++ b/packages/spindle-ui/src/Dialog/Dialog.stories.mdx
@@ -53,7 +53,7 @@ function DialogExample() {
   }, [dialogRef]);
   return (
     <>
-      <Button aria-haspopup="true" onClick={handleOpenButtonClick} size="medium">Open Dialog</Button>
+      <Button aria-haspopup="true" onClick={handleOpenButtonClick} size="medium" variant="neutral">開く</Button>
       <Dialog.Frame
         aria-describedby="dialog-description"
         aria-labelledby="dialog-title"
@@ -213,7 +213,7 @@ function DialogExample() {
           Spindleをフォローする
         </Button>
         <SubtleButton size="medium">
-          閉じる
+          とじる
         </Button>
       </Dialog.ButtonGroup>
     </Dialog.StyleOnly>
@@ -229,7 +229,7 @@ function DialogExample() {
   <p class="spui-Dialog-body">ここに本文が入りますよ</p>
   <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--medium spui-Dialog-buttonGroup">
     <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--contained" type="button">Spindleをフォローする</button>
-    <button class="spui-SubtleButton spui-SubtleButton--medium">閉じる</button>
+    <button class="spui-SubtleButton spui-SubtleButton--medium">とじる</button>
   </div>
 </div>
   `}

--- a/packages/spindle-ui/src/Dialog/DialogExample.tsx
+++ b/packages/spindle-ui/src/Dialog/DialogExample.tsx
@@ -32,8 +32,9 @@ export function DialogExample() {
         aria-haspopup="true"
         onClick={handleOpenButtonClick}
         size="medium"
+        variant="neutral"
       >
-        Open Dialog
+        開く
       </Button>
       <Dialog.Frame
         aria-describedby="dialog-description"
@@ -114,7 +115,7 @@ export function ButtonColumnWithSubtleButton() {
         <Button layout="fullWidth" size="medium" type="button">
           Spindleをフォローする
         </Button>
-        <SubtleButton size="medium">閉じる</SubtleButton>
+        <SubtleButton size="medium">とじる</SubtleButton>
       </Dialog.ButtonGroup>
     </Dialog.StyleOnly>
   );

--- a/packages/spindle-ui/src/Form/Checkbox.stories.mdx
+++ b/packages/spindle-ui/src/Form/Checkbox.stories.mdx
@@ -25,13 +25,13 @@ import { Checkbox } from './Checkbox';
 
 <Preview withSource="open">
   <Story name="Checkbox">
-    <Checkbox aria-label="Japanese" name="language" value="japanese" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
+    <Checkbox aria-label="Amebaブログ" name="blog" value="amebaBlog" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<Checkbox aria-label="Japanese" name="language" value="japanese" />
+<Checkbox aria-label="Amebaブログ" name="blog" value="amebaBlog" />
   `}
 />
 
@@ -39,7 +39,7 @@ import { Checkbox } from './Checkbox';
   language='html'
   code={`
 <label class="spui-Checkbox-label">
-  <input aria-label="Japanese" class="spui-Checkbox-input" type="checkbox" name="language" value="japanese">
+  <input aria-label="Amebaブログ" class="spui-Checkbox-input" type="checkbox" name="blog" value="amebaBlog">
   <span class="spui-Checkbox-icon"></span>
   <span class="spui-Checkbox-outline"></span>
 </label>
@@ -50,13 +50,13 @@ import { Checkbox } from './Checkbox';
 
 <Preview withSource="open">
   <Story name="Checkbox Disabled">
-    <Checkbox aria-label="Japanese" disabled name="language" value="japanese" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
+    <Checkbox aria-label="Amebaブログ" disabled name="blog" value="amebaBlog" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<Checkbox aria-label="Japanese" disabled name="language" value="japanese" />
+<Checkbox aria-label="Amebaブログ" disabled name="blog" value="amebaBlog" />
   `}
 />
 
@@ -64,7 +64,7 @@ import { Checkbox } from './Checkbox';
   language='html'
   code={`
 <label class="spui-Checkbox-label">
-  <input aria-label="Japanese" class="spui-Checkbox-input" disabled type="checkbox" name="language" value="japanese">
+  <input aria-label="Amebaブログ" class="spui-Checkbox-input" disabled type="checkbox" name="blog" value="amebaBlog">
   <span class="spui-Checkbox-icon"></span>
   <span class="spui-Checkbox-outline"></span>
 </label>
@@ -75,13 +75,13 @@ import { Checkbox } from './Checkbox';
 
 <Preview withSource="open">
   <Story name="Checkbox With Text">
-    <Checkbox name="language" value="japanese" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>Japanese</Checkbox>
+    <Checkbox name="blog" value="amebaBlog" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>Amebaブログ</Checkbox>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Checkbox name="language" value="japanese">Japanese</Checkbox>
+<Checkbox name="blog" value="amebaBlog">Amebaブログ</Checkbox>
   `}
 />
 
@@ -89,10 +89,10 @@ import { Checkbox } from './Checkbox';
   language='html'
   code={`
 <label class="spui-Checkbox-label">
-  <input class="spui-Checkbox-input" type="checkbox" name="language" value="japanese">
+  <input class="spui-Checkbox-input" type="checkbox" name="blog" value="amebaBlog">
   <span class="spui-Checkbox-icon"></span>
   <span class="spui-Checkbox-outline"></span>
-  <span class="spui-Checkbox-text">Japanese</span>
+  <span class="spui-Checkbox-text">Amebaブログ</span>
 </label>
   `}
 />

--- a/packages/spindle-ui/src/Form/DropDown.stories.mdx
+++ b/packages/spindle-ui/src/Form/DropDown.stories.mdx
@@ -27,20 +27,20 @@ import { DropDown } from './DropDown';
 
 <Preview withSource="open">
   <Story name="DropDown">
-    <DropDown aria-label="Fruits" name="fruits" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>
-      <option value="apple">Apple</option>
-      <option value="orange">Orange</option>
-      <option value="melon">Melon</option>
+    <DropDown aria-label="期間を選択" name="term" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>
+      <option value="today">今日</option>
+      <option value="seven_days">7日間</option>
+      <option value="thirty_days">30日間</option>
     </DropDown>
   </Story>
 </Preview>
 
 <Source
   code={`
-<DropDown aria-label="Fruits" name="fruits">
-  <option value="apple">Apple</option>
-  <option value="orange">Orange</option>
-  <option value="melon">Melon</option>
+<DropDown aria-label="期間を選択" name="term">
+  <option value="today">今日</option>
+  <option value="seven_days">7日間</option>
+  <option value="thirty_days">30日間</option>
 </DropDown>
   `}
 />
@@ -49,12 +49,12 @@ import { DropDown } from './DropDown';
   language='html'
   code={`
 <label class="spui-DropDown-label is-active">
-  <span class="spui-DropDown-visual">Orange</span>
+  <span class="spui-DropDown-visual">7日間</span>
   <span class="spui-DropDown-icon"><svg>...</svg></span>
-  <select aria-label="Fruits" class="spui-DropDown-select" name="fruits">
-    <option value="apple">Apple</option>
-    <option value="orange">Orange</option>
-    <option value="melon">Melon</option>
+  <select aria-label="期間を選択" class="spui-DropDown-select" name="term">
+    <option value="today">今日</option>
+    <option value="seven_days">7日間</option>
+    <option value="thirty_days">30日間</option>
   </select>
   <span class="spui-DropDown-outline"></span>
 </label>
@@ -67,20 +67,20 @@ import { DropDown } from './DropDown';
 
 <Preview withSource="open">
   <Story name="DropDown With Selected And Disabled">
-    <DropDown aria-label="Fruits" name="fruits" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>
-      <option value="apple">Apple</option>
-      <option value="orange" selected disabled>Orange</option>
-      <option value="melon">Melon</option>
+    <DropDown aria-label="期間を選択" name="term" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>
+      <option value="today">今日</option>
+      <option value="seven_days" selected disabled>7日間</option>
+      <option value="thirty_days">30日間</option>
     </DropDown>
   </Story>
 </Preview>
 
 <Source
   code={`
-<DropDown aria-label="Fruits" name="fruits">
-  <option value="apple">Apple</option>
-  <option value="orange" selected disabled>Orange</option>
-  <option value="melon">Melon</option>
+<DropDown aria-label="期間を選択" name="term">
+  <option value="today">今日</option>
+  <option value="seven_days" selected disabled>7日間</option>
+  <option value="thirty_days">30日間</option>
 </DropDown>
   `}
 />
@@ -89,12 +89,12 @@ import { DropDown } from './DropDown';
   language='html'
   code={`
 <label class="spui-DropDown-label">
-  <span class="spui-DropDown-visual">Orange</span>
+  <span class="spui-DropDown-visual">7日間</span>
   <span class="spui-DropDown-icon"><svg>...</svg></span>
-  <select aria-label="Fruits" class="spui-DropDown-select" name="fruits">
-    <option value="apple">Apple</option>
-    <option value="orange" selected disabled>Orange</option>
-    <option value="melon">Melon</option>
+  <select aria-label="期間を選択" class="spui-DropDown-select" name="term">
+    <option value="today">今日</option>
+    <option value="seven_days" selected disabled>7日間</option>
+    <option value="thirty_days">30日間</option>
   </select>
   <span class="spui-DropDown-outline"></span>
 </label>
@@ -105,20 +105,20 @@ import { DropDown } from './DropDown';
 
 <Preview withSource="open">
   <Story name="DropDown With Error">
-    <DropDown aria-label="Fruits" hasError name="fruitsWithError" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>
-      <option value="apple">Apple</option>
-      <option value="orange">Orange</option>
-      <option value="melon">Melon</option>
+    <DropDown aria-label="期間を選択" hasError name="termWithError" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>
+      <option value="today">今日</option>
+      <option value="seven_days">7日間</option>
+      <option value="thirty_days">30日間</option>
     </DropDown>
   </Story>
 </Preview>
 
 <Source
   code={`
-<DropDown aria-label="Fruits" hasError name="fruits">
-  <option value="apple">Apple</option>
-  <option value="orange">Orange</option>
-  <option value="melon">Melon</option>
+<DropDown aria-label="期間を選択" hasError name="term">
+  <option value="today">今日</option>
+  <option value="seven_days">7日間</option>
+  <option value="thirty_days">30日間</option>
 </DropDown>
   `}
 />
@@ -127,12 +127,12 @@ import { DropDown } from './DropDown';
   language='html'
   code={`
 <label class="spui-DropDown-label is-active is-error">
-  <span class="spui-DropDown-visual">Orange</span>
+  <span class="spui-DropDown-visual">7日間</span>
   <span class="spui-DropDown-icon"><svg>...</svg></span>
-  <select aria-label="Fruits" class="spui-DropDown-select" name="fruits">
-    <option value="apple">Apple</option>
-    <option value="orange">Orange</option>
-    <option value="melon">Melon</option>
+  <select aria-label="期間を選択" class="spui-DropDown-select" name="term">
+    <option value="today">今日</option>
+    <option value="seven_days">7日間</option>
+    <option value="thirty_days">30日間</option>
   </select>
   <span class="spui-DropDown-outline"></span>
 </label>
@@ -145,10 +145,10 @@ import { DropDown } from './DropDown';
 
 <Source
   code={`
-<DropDown aria-label="Fruits" id="fruits-selection" name="fruits" placeholder="Fruits">
-  <option value="apple">Apple</option>
-  <option value="orange">Orange</option>
-  <option value="melon">Melon</option>
+<DropDown aria-label="期間を選択" id="term-selection" name="term" placeholder="期間を選択">
+  <option value="today">今日</option>
+  <option value="seven_days">7日間</option>
+  <option value="thirty_days">30日間</option>
 </DropDown>
   `}
 />
@@ -156,11 +156,11 @@ import { DropDown } from './DropDown';
 <Source
   code={`
 <>
-  <InputLabel id="fruits-selection">Fruits</InputLabel>
-  <DropDown id="fruits-selection" name="fruits" placeholder="Fruits">
-    <option value="apple">Apple</option>
-    <option value="orange">Orange</option>
-    <option value="melon">Melon</option>
+  <InputLabel id="term-selection">期間を選択</InputLabel>
+  <DropDown id="term-selection" name="term" placeholder="期間を選択">
+    <option value="today">今日</option>
+    <option value="seven_days">7日間</option>
+    <option value="thirty_days">30日間</option>
   </DropDown>
 </>
   `}

--- a/packages/spindle-ui/src/Form/InlineDropDown.stories.mdx
+++ b/packages/spindle-ui/src/Form/InlineDropDown.stories.mdx
@@ -33,23 +33,23 @@ InlineDropDownは試験的なコンポーネントであるため、破壊的な
 <Preview withSource="open">
   <Story name="Medium">
     <InlineDropDown
-      aria-label="Fruits"
-      name="fruits"
+      aria-label="期間を選択"
+      name="term"
       {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}
     >
-      <option value="apple">Apple</option>
-      <option value="green-apple">Green Apple</option>
-      <option value="melon">Melon</option>
+      <option value="today">今日</option>
+      <option value="seven_days">7日間</option>
+      <option value="thirty_days">30日間</option>
     </InlineDropDown>
   </Story>
 </Preview>
 
 <Source
   code={`
-<InlineDropDown aria-label="Fruits" name="fruits">
-  <option value="apple">Apple</option>
-  <option value="orange">Orange</option>
-  <option value="melon">Melon</option>
+<InlineDropDown aria-label="期間を選択" name="term">
+  <option value="today">今日</option>
+  <option value="seven_days">7日間</option>
+  <option value="thirty_days">30日間</option>
 </InlineDropDown>
 `}
 />
@@ -59,14 +59,14 @@ InlineDropDownは試験的なコンポーネントであるため、破壊的な
   code={`
 <label class="spui-InlineDropDown-label is-active">
   <span class="spui-InlineDropDown-visual">
-    <span class="spui-InlineDropDown-text spui-InlineDropDown-text--medium">Apple</span>
+    <span class="spui-InlineDropDown-text spui-InlineDropDown-text--medium">今日</span>
     <span class="spui-InlineDropDown-icon spui-InlineDropDown-icon--medium"><svg/></span>
   </span>
-  <select class="spui-InlineDropDown-select spui-InlineDropDown-select--medium" aria-label="Fruits" name="fruits"
+  <select class="spui-InlineDropDown-select spui-InlineDropDown-select--medium" aria-label="期間を選択" name="term"
   >
-    <option value="apple">Apple</option>
-    <option value="green-apple">Green Apple</option>
-    <option value="melon">Melon</option>
+    <option value="today">今日</option>
+    <option value="seven_days">7日間</option>
+    <option value="thirty_days">30日間</option>
   </select>
   <span class="spui-InlineDropDown-outline"></span>
 </label>
@@ -79,23 +79,23 @@ InlineDropDownは試験的なコンポーネントであるため、破壊的な
   <Story name="Small">
     <InlineDropDown
       visualSize="small"
-      aria-label="Fruits"
-      name="fruits"
+      aria-label="期間を選択"
+      name="term"
       {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}
     >
-      <option value="apple">Apple</option>
-      <option value="green-apple">Green Apple</option>
-      <option value="melon">Melon</option>
+      <option value="today">今日</option>
+      <option value="seven_days">7日間</option>
+      <option value="thirty_days">30日間</option>
     </InlineDropDown>
   </Story>
 </Preview>
 
 <Source
   code={`
-<InlineDropDown visualSize="small" aria-label="Fruits" name="fruits">
-  <option value="apple">Apple</option>
-  <option value="orange">Orange</option>
-  <option value="melon">Melon</option>
+<InlineDropDown visualSize="small" aria-label="期間を選択" name="term">
+  <option value="today">今日</option>
+  <option value="seven_days">7日間</option>
+  <option value="thirty_days">30日間</option>
 </InlineDropDown>
 `}
 />
@@ -105,14 +105,14 @@ InlineDropDownは試験的なコンポーネントであるため、破壊的な
   code={`
 <label class="spui-InlineDropDown-label is-active">
   <span class="spui-InlineDropDown-visual">
-    <span class="spui-InlineDropDown-text spui-InlineDropDown-text--small">Apple</span>
+    <span class="spui-InlineDropDown-text spui-InlineDropDown-text--small">今日</span>
     <span class="spui-InlineDropDown-icon spui-InlineDropDown-icon--small"><svg/></span>
   </span>
-  <select class="spui-InlineDropDown-select spui-InlineDropDown-select--small" aria-label="Fruits" name="fruits"
+  <select class="spui-InlineDropDown-select spui-InlineDropDown-select--small" aria-label="期間を選択" name="term"
   >
-    <option value="apple">Apple</option>
-    <option value="green-apple">Green Apple</option>
-    <option value="melon">Melon</option>
+    <option value="today">今日</option>
+    <option value="seven_days">7日間</option>
+    <option value="thirty_days">30日間</option>
   </select>
   <span class="spui-InlineDropDown-outline"></span>
 </label>
@@ -127,10 +127,10 @@ InlineDropDownは試験的なコンポーネントであるため、破壊的な
 
 <Source
   code={`
-<InlineDropDown aria-label="Fruits" id="fruits-selection" name="fruits" placeholder="Fruits">
-  <option value="apple">Apple</option>
-  <option value="orange">Orange</option>
-  <option value="melon">Melon</option>
+<InlineDropDown aria-label="期間を選択" id="term-selection" name="term" placeholder="期間を選択">
+  <option value="today">今日</option>
+  <option value="seven_days">7日間</option>
+  <option value="thirty_days">30日間</option>
 </InlineDropDown>
   `}
 />
@@ -138,11 +138,11 @@ InlineDropDownは試験的なコンポーネントであるため、破壊的な
 <Source
   code={`
 <>
-  <InputLabel id="fruits-selection">Fruits</InputLabel>
-  <InlineDropDown id="fruits-selection" name="fruits" placeholder="Fruits">
-    <option value="apple">Apple</option>
-    <option value="orange">Orange</option>
-    <option value="melon">Melon</option>
+  <InputLabel id="term-selection">期間を選択</InputLabel>
+  <InlineDropDown id="term-selection" name="term" placeholder="期間を選択">
+    <option value="today">今日</option>
+    <option value="seven_days">7日間</option>
+    <option value="thirty_days">30日間</option>
   </InlineDropDown>
 </>
   `}

--- a/packages/spindle-ui/src/Form/InputLabel.stories.mdx
+++ b/packages/spindle-ui/src/Form/InputLabel.stories.mdx
@@ -24,19 +24,19 @@ import { InputLabel } from './InputLabel';
 
 <Preview withSource="open">
   <Story name="Input Label">
-    <InputLabel id="interest">Your Interest</InputLabel>
+    <InputLabel id="comment">コメントを入力</InputLabel>
   </Story>
 </Preview>
 
 <Source
   code={`
-<InputLabel id="interest">Your Interest</InputLabel>
+<InputLabel id="comment">コメントを入力</InputLabel>
   `}
 />
 
 <Source
   language='html'
   code={`
-<label class="spui-InputLabel" for="interest">Your Interest</label>
+<label class="spui-InputLabel" for="comment">コメントを入力</label>
   `}
 />

--- a/packages/spindle-ui/src/Form/InvalidMessage.stories.mdx
+++ b/packages/spindle-ui/src/Form/InvalidMessage.stories.mdx
@@ -24,13 +24,13 @@ import { InvalidMessage } from './InvalidMessage';
 
 <Preview withSource="open">
   <Story name="Invalid Message">
-    <InvalidMessage visible>Please input your mail address</InvalidMessage>
+    <InvalidMessage visible>ファイル形式が正しくありません</InvalidMessage>
   </Story>
 </Preview>
 
 <Source
   code={`
-<InvalidMessage visible>Please input your mail address</InvalidMessage>
+<InvalidMessage visible>ファイル形式が正しくありません</InvalidMessage>
   `}
 />
 
@@ -39,7 +39,7 @@ import { InvalidMessage } from './InvalidMessage';
   code={`
 <p class="spui-InvalidMessage">
   <span class="spui-InvalidMessage-icon"><svg>...</svg></span>
-  Please input your mail address
+  <span class="spui-InvalidMessage-body">ファイル形式が正しくありません</span>
 </p>
   `}
 />
@@ -50,6 +50,6 @@ import { InvalidMessage } from './InvalidMessage';
 
 <Source
   code={`
-<InvalidMessage role="alert" visible>Please input your mail address</InvalidMessage>
+<InvalidMessage role="alert" visible>ファイル形式が正しくありません</InvalidMessage>
   `}
 />

--- a/packages/spindle-ui/src/Form/Radio.stories.mdx
+++ b/packages/spindle-ui/src/Form/Radio.stories.mdx
@@ -25,21 +25,21 @@ import { Radio } from './Radio';
 
 <Preview withSource="open">
   <Story name="Radio">
-    <Radio aria-label="asia" id="asia" name="area" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
+    <Radio aria-label="Amebaブログ" id="normal" name="blog" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<Radio aria-label="asia" id="asia" name="area" />
+<Radio aria-label="Amebaブログ" id="normal" name="blog" />
   `}
 />
 
 <Source
   language='html'
   code={`
-<label class="spui-Radio-label" for="asia">
-  <input aria-label="asia" class="spui-Radio-input" id="asia" type="radio" name="area">
+<label class="spui-Radio-label" for="normal">
+  <input aria-label="Amebaブログ" class="spui-Radio-input" id="normal" type="radio" name="blog">
   <span class="spui-Radio-icon"></span>
   <span class="spui-Radio-outline"></span>
 </label>
@@ -50,21 +50,21 @@ import { Radio } from './Radio';
 
 <Preview withSource="open">
   <Story name="Radio Disabled">
-    <Radio  aria-label="asia" disabled id="asiaDisabled" name="asia" />
+    <Radio aria-label="Amebaブログ" disabled id="disabled" name="blog" />
   </Story>
 </Preview>
 
 <Source
   code={`
-<Radio  aria-label="asia" disabled id="asia" name="area" />
+<Radio aria-label="Amebaブログ" disabled id="disabled" name="blog" />
   `}
 />
 
 <Source
   language='html'
   code={`
-<label class="spui-Radio-label" for="asia">
-  <input aria-label="asia" class="spui-Radio-input" disabled id="asia" type="radio" name="area">
+<label class="spui-Radio-label" for="disabled">
+  <input aria-label="Amebaブログ" class="spui-Radio-input" disabled id="disabled" type="radio" name="blog">
   <span class="spui-Radio-icon"></span>
   <span class="spui-Radio-outline"></span>
 </label>
@@ -75,24 +75,24 @@ import { Radio } from './Radio';
 
 <Preview withSource="open">
   <Story name="Radio With Text">
-    <Radio id="asiaWithText" name="area" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>Asia</Radio>
+    <Radio id="withText" name="blog" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>Amebaブログ</Radio>
   </Story>
 </Preview>
 
 <Source
   code={`
-<Radio id="asiaWithText" name="area">Asia</Radio>
+<Radio id="withText" name="blog">Amebaブログ</Radio>
   `}
 />
 
 <Source
   language='html'
   code={`
-<label class="spui-Radio-label" for="asia">
-  <input class="spui-Radio-input" id="asiaWithText" type="radio" name="area">
+<label class="spui-Radio-label" for="withText">
+  <input class="spui-Radio-input" id="withText" type="radio" name="blog">
   <span class="spui-Radio-icon"></span>
   <span class="spui-Radio-outline"></span>
-  <span class="spui-Radio-text">Asia</span>
+  <span class="spui-Radio-text">Amebaブログ</span>
 </label>
   `}
 />

--- a/packages/spindle-ui/src/Form/TextArea.stories.mdx
+++ b/packages/spindle-ui/src/Form/TextArea.stories.mdx
@@ -25,20 +25,20 @@ import { TextArea } from './TextArea';
 
 <Preview withSource="open">
   <Story name="Text Area">
-    <TextArea aria-label="Text area" id="TextArea" placeholder="How are you feeling?" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}></TextArea>
+    <TextArea id="TextArea" placeholder="ブログを読んで感じたことを伝えましょう" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}></TextArea>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextArea aria-label="Text area" id="TextArea"></TextArea>
+<TextArea placeholder="ブログを読んで感じたことを伝えましょう" id="TextArea"></TextArea>
   `}
 />
 
 <Source
   language='html'
   code={`
-<textarea aria-label="Text area" class="spui-TextArea" id="TextArea"></textarea>
+<textarea placeholder="ブログを読んで感じたことを伝えましょう" class="spui-TextArea" id="TextArea"></textarea>
   `}
 />
 
@@ -46,19 +46,19 @@ import { TextArea } from './TextArea';
 
 <Preview withSource="open">
   <Story name="Text Area With Error">
-    <TextArea aria-label="Text area" hasError id="TextAreaWithError" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}></TextArea>
+    <TextArea placeholder="ブログを読んで感じたことを伝えましょう" hasError id="TextAreaWithError" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}></TextArea>
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextArea aria-label="Text area" hasError id="TextAreaWithError"></TextArea>
+<TextArea placeholder="ブログを読んで感じたことを伝えましょう" hasError id="TextAreaWithError"></TextArea>
   `}
 />
 
 <Source
   language='html'
   code={`
-<textarea aria-label="Text area" class="spui-TextArea is-error" id="TextAreaWithError"></textarea>
+<textarea placeholder="ブログを読んで感じたことを伝えましょう" class="spui-TextArea is-error" id="TextAreaWithError"></textarea>
   `}
 />

--- a/packages/spindle-ui/src/Form/TextField.stories.mdx
+++ b/packages/spindle-ui/src/Form/TextField.stories.mdx
@@ -25,20 +25,20 @@ import { TextField } from './TextField';
 
 <Preview withSource="open">
   <Story name="Large">
-    <TextField aria-label="Text field" id="TextField" placeholder="How are you feeling?" variant="large" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
+    <TextField id="TextField" placeholder="ameba-blog" variant="large" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextField aria-label="Text field" id="TextField" variant="large" />
+<TextField placeholder="ameba-blog" id="TextField" variant="large" />
   `}
 />
 
 <Source
   language='html'
   code={`
-<input aria-label="Text field" class="spui-TextField spui-TextField--large" id="TextField" />
+<input placeholder="ameba-blog" class="spui-TextField spui-TextField--large" id="TextField" />
   `}
 />
 
@@ -46,20 +46,20 @@ import { TextField } from './TextField';
 
 <Preview withSource="open">
   <Story name="Large With Error">
-    <TextField aria-label="Text field" hasError id="TextFieldWithError" variant="large" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
+    <TextField placeholder="ameba-blog" hasError id="TextFieldWithError" variant="large" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextField aria-label="Text field" hasError id="TextFieldWithError" variant="large" />
+<TextField placeholder="ameba-blog" hasError id="TextFieldWithError" variant="large" />
   `}
 />
 
 <Source
   language='html'
   code={`
-<input aria-label="Text field" class="spui-TextField spui-TextField--large is-error" id="TextFieldWithError" />
+<input placeholder="ameba-blog" class="spui-TextField spui-TextField--large is-error" id="TextFieldWithError" />
   `}
 />
 
@@ -67,20 +67,20 @@ import { TextField } from './TextField';
 
 <Preview withSource="open">
   <Story name="Medium">
-    <TextField aria-label="Text field" id="TextField" placeholder="How are you feeling?" variant="medium" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
+    <TextField placeholder="ameba-blog" id="TextField" variant="medium" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextField aria-label="Text field" id="TextField" variant="medium" />
+<TextField placeholder="ameba-blog" id="TextField" variant="medium" />
   `}
 />
 
 <Source
   language='html'
   code={`
-<input aria-label="Text field" class="spui-TextField spui-TextField--medium" id="TextField" />
+<input placeholder="ameba-blog" class="spui-TextField spui-TextField--medium" id="TextField" />
   `}
 />
 
@@ -88,19 +88,19 @@ import { TextField } from './TextField';
 
 <Preview withSource="open">
   <Story name="Medium With Error">
-    <TextField aria-label="Text field" hasError id="TextFieldWithError" variant="medium" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
+    <TextField placeholder="ameba-blog" hasError id="TextFieldWithError" variant="medium" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<TextField aria-label="Text field" hasError id="TextFieldWithError" variant="medium" />
+<TextField placeholder="ameba-blog" hasError id="TextFieldWithError" variant="medium" />
   `}
 />
 
 <Source
   language='html'
   code={`
-<input aria-label="Text field" class="spui-TextField spui-TextField--medium is-error" id="TextFieldWithError" />
+<input placeholder="ameba-blog" class="spui-TextField spui-TextField--medium is-error" id="TextFieldWithError" />
   `}
 />

--- a/packages/spindle-ui/src/Form/ToggleSwitch.stories.mdx
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.stories.mdx
@@ -25,13 +25,13 @@ import { ToggleSwitch } from './ToggleSwitch';
 
 <Preview withSource="open">
   <Story name="Toggle Switch">
-    <ToggleSwitch aria-label="Toggle switch" id="toggle" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
+    <ToggleSwitch aria-label="自動で挿入する" id="toggle" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />
   </Story>
 </Preview>
 
 <Source
   code={`
-<ToggleSwitch aria-label="Toggle switch" id="toggle" />
+<ToggleSwitch aria-label="自動で挿入する" id="toggle" />
   `}
 />
 
@@ -39,7 +39,7 @@ import { ToggleSwitch } from './ToggleSwitch';
   language='html'
   code={`
 <label class="spui-ToggleSwitch">
-  <input aria-label="Toggle switch" class="spui-ToggleSwitch-input" id="toddle" type="checkbox">
+  <input aria-label="自動で挿入する" class="spui-ToggleSwitch-input" id="toggle" type="checkbox">
   <span class="spui-ToggleSwitch-visual"></span>
   <span class="spui-ToggleSwitch-outline"></span>
 </label>
@@ -50,13 +50,13 @@ import { ToggleSwitch } from './ToggleSwitch';
 
 <Preview withSource="open">
   <Story name="Toggle Switch Disabled">
-    <ToggleSwitch aria-label="Toggle switch" disabled id="toggleDisabled" />
+    <ToggleSwitch aria-label="自動で挿入する" disabled id="toggleDisabled" />
   </Story>
 </Preview>
 
 <Source
   code={`
-<ToggleSwitch aria-label="Toggle switch" disabled id="toggleDisabled" />
+<ToggleSwitch aria-label="自動で挿入する" disabled id="toggleDisabled" />
   `}
 />
 
@@ -64,7 +64,7 @@ import { ToggleSwitch } from './ToggleSwitch';
   language='html'
   code={`
 <label class="spui-ToggleSwitch">
-  <input class="spui-ToggleSwitch-input" disabled id="toddle" type="checkbox">
+  <input aria-label="自動で挿入する" class="spui-ToggleSwitch-input" disabled id="toggle" type="checkbox">
   <span class="spui-ToggleSwitch-visual"></span>
   <span class="spui-ToggleSwitch-outline"></span>
 </label>

--- a/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
@@ -1,7 +1,7 @@
 import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { LinkButton } from './LinkButton';
-import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
+import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, PencilAdd } from '../Icon';
 
 # LinkButton
 
@@ -26,29 +26,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Large">
-    <LinkButton href="#" size="large" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
-    <LinkButton href="#" size="large" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
-    <LinkButton href="#" size="large" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
-    <LinkButton href="#" size="large" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+    <LinkButton href="#" size="large" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
+    <LinkButton href="#" size="large" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
+    <LinkButton href="#" size="large" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
+    <LinkButton href="#" size="large" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" size="large" variant="contained">Contained</LinkButton>
-<LinkButton href="#" size="large" variant="outlined">Outlined</LinkButton>
-<LinkButton href="#" size="large" variant="neutral">Neutral</LinkButton>
-<LinkButton href="#" size="large" variant="danger">Danger</LinkButton>
+<LinkButton href="#" size="large" variant="contained">応援を送る</LinkButton>
+<LinkButton href="#" size="large" variant="outlined">ブログを書く</LinkButton>
+<LinkButton href="#" size="large" variant="neutral">詳細を見る</LinkButton>
+<LinkButton href="#" size="large" variant="danger">削除する</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--contained" href="#">Contained</a>
-<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--outlined" href="#">Outlined</a>
-<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--neutral" href="#">Neutral</a>
-<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--danger" href="#">Danger</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--contained" href="#">応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--outlined" href="#">ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--neutral" href="#">詳細を見る</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--danger" href="#">削除する</a>
   `}
 />
 
@@ -56,29 +56,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Large Full Width">
-    <LinkButton href="#" layout="fullWidth" size="large" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="large" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="large" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="large" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="large" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="large" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="large" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="large" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" layout="fullWidth" size="large" variant="contained">Contained</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="large" variant="outlined">Outlined</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="large" variant="neutral">Neutral</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="large" variant="danger">Danger</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="large" variant="contained">応援を送る</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="large" variant="outlined">ブログを書く</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="large" variant="neutral">詳細を見る</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="large" variant="danger">削除する</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained" href="#">Contained</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--outlined" href="#">Outlined</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--neutral" href="#">Neutral</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--danger" href="#">Danger</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained" href="#">応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--outlined" href="#">ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--neutral" href="#">詳細を見る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--danger" href="#">削除する</a>
   `}
 />
 
@@ -86,29 +86,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Medium">
-    <LinkButton href="#" size="medium" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
-    <LinkButton href="#" size="medium" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
-    <LinkButton href="#" size="medium" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
-    <LinkButton href="#" size="medium" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+    <LinkButton href="#" size="medium" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
+    <LinkButton href="#" size="medium" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
+    <LinkButton href="#" size="medium" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
+    <LinkButton href="#" size="medium" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" size="medium" variant="contained">Contained</LinkButton>
-<LinkButton href="#" size="medium" variant="outlined">Outlined</LinkButton>
-<LinkButton href="#" size="medium" variant="neutral">Neutral</LinkButton>
-<LinkButton href="#" size="medium" variant="danger">Danger</LinkButton>
+<LinkButton href="#" size="medium" variant="contained">応援を送る</LinkButton>
+<LinkButton href="#" size="medium" variant="outlined">ブログを書く</LinkButton>
+<LinkButton href="#" size="medium" variant="neutral">詳細を見る</LinkButton>
+<LinkButton href="#" size="medium" variant="danger">削除する</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--contained" href="#">Contained</a>
-<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--outlined" href="#">Outlined</a>
-<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--neutral" href="#">Neutral</a>
-<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--danger" href="#">Danger</a>
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--contained" href="#">応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--outlined" href="#">ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--neutral" href="#">詳細を見る</a>
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--danger" href="#">削除する</a>
   `}
 />
 
@@ -116,29 +116,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Medium Full Width">
-    <LinkButton href="#" layout="fullWidth" size="medium" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="medium" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="medium" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="medium" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" layout="fullWidth" size="medium" variant="contained">Contained</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="medium" variant="outlined">Outlined</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="medium" variant="neutral">Neutral</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="medium" variant="danger">Danger</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="medium" variant="contained">応援を送る</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="medium" variant="outlined">ブログを書く</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="medium" variant="neutral">詳細を見る</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="medium" variant="danger">削除する</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--contained" href="#">Contained</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#">Outlined</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--neutral" href="#">Neutral</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--danger" href="#">Danger</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--contained" href="#">応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#">ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--neutral" href="#">詳細を見る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--danger" href="#">削除する</a>
   `}
 />
 
@@ -146,29 +146,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Small">
-    <LinkButton href="#" size="small" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
-    <LinkButton href="#" size="small" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
-    <LinkButton href="#" size="small" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
-    <LinkButton href="#" size="small" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+    <LinkButton href="#" size="small" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
+    <LinkButton href="#" size="small" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
+    <LinkButton href="#" size="small" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
+    <LinkButton href="#" size="small" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" size="small" variant="contained">Contained</LinkButton>
-<LinkButton href="#" size="small" variant="outlined">Outlined</LinkButton>
-<LinkButton href="#" size="small" variant="neutral">Neutral</LinkButton>
-<LinkButton href="#" size="small" variant="danger">Danger</LinkButton>
+<LinkButton href="#" size="small" variant="contained">応援を送る</LinkButton>
+<LinkButton href="#" size="small" variant="outlined">ブログを書く</LinkButton>
+<LinkButton href="#" size="small" variant="neutral">詳細を見る</LinkButton>
+<LinkButton href="#" size="small" variant="danger">削除する</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--contained" href="#">Contained</a>
-<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--outlined" href="#">Outlined</a>
-<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--neutral" href="#">Neutral</a>
-<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--danger" href="#">Danger</a>
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--contained" href="#">応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--outlined" href="#">ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--neutral" href="#">詳細を見る</a>
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--danger" href="#">削除する</a>
   `}
 />
 
@@ -176,29 +176,29 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Small Full Width">
-    <LinkButton href="#" layout="fullWidth" size="small" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="small" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="small" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
-    <LinkButton href="#" layout="fullWidth" size="small" variant="danger" {...actions('onMouseOver')}>Danger</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="small" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="small" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="small" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="small" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" layout="fullWidth" size="small" variant="contained">Contained</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="small" variant="outlined">Outlined</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="small" variant="neutral">Neutral</LinkButton>
-<LinkButton href="#" layout="fullWidth" size="small" variant="danger">Danger</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="small" variant="contained">応援を送る</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="small" variant="outlined">ブログを書く</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="small" variant="neutral">詳細を見る</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="small" variant="danger">削除する</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--contained" href="#">Contained</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--outlined" href="#">Outlined</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#">Neutral</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--danger" href="#">Danger</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--contained" href="#">応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--outlined" href="#">ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#">詳細を見る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--danger" href="#">削除する</a>
   `}
 />
 
@@ -206,26 +206,26 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="With Icon">
-    <LinkButton href="#" icon={<PlusBold/>} size="large" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
-    <LinkButton href="#" icon={<ArrowRightBold/>} size="medium" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
-    <LinkButton href="#" icon={<OpenblankFill/>} size="small" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+    <LinkButton href="#" icon={<Present/>} size="large" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
+    <LinkButton href="#" icon={<PencilAdd/>} size="medium" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
+    <LinkButton href="#" icon={<GraphBar/>} size="small" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" icon={<PlusBold/>} size="large" variant="contained">Contained</LinkButton>
-<LinkButton href="#" icon={<ArrowRightBold/>} size="medium" variant="outlined">Outlined</LinkButton>
-<LinkButton href="#" icon={<OpenblankFill/>} size="small" variant="neutral">Neutral</LinkButton>
+<LinkButton href="#" icon={<Present/>} size="large" variant="contained">応援を送る</LinkButton>
+<LinkButton href="#" icon={<PencilAdd/>} size="medium" variant="outlined">ブログを書く</LinkButton>
+<LinkButton href="#" icon={<GraphBar/>} size="small" variant="neutral">詳細を見る</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>Contained</a>
-<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>Outlined</a>
-<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>Neutral</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>詳細を見る</a>
   `}
 />
 
@@ -233,26 +233,26 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Full Width With Icon">
-    <LinkButton href="#" layout="fullWidth" icon={<PlusBold/>} size="large" variant="contained" {...actions('onMouseOver')}>Contained</LinkButton>
-    <LinkButton href="#" layout="fullWidth" icon={<ArrowRightBold/>} size="medium" variant="outlined" {...actions('onMouseOver')}>Outlined</LinkButton>
-    <LinkButton href="#" layout="fullWidth" icon={<OpenblankFill/>} size="small" variant="neutral" {...actions('onMouseOver')}>Neutral</LinkButton>
+    <LinkButton href="#" layout="fullWidth" icon={<Present/>} size="large" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" icon={<PencilAdd/>} size="medium" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
+    <LinkButton href="#" layout="fullWidth" icon={<GraphBar/>} size="small" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" layout="fullWidth" icon={<PlusBold/>} size="large" variant="contained">Contained</LinkButton>
-<LinkButton href="#" layout="fullWidth" icon={<ArrowRightBold/>} size="medium" variant="outlined">Outlined</LinkButton>
-<LinkButton href="#" layout="fullWidth" icon={<OpenblankFill/>} size="small" variant="neutral">Neutral</LinkButton>
+<LinkButton href="#" layout="fullWidth" icon={<Present/>} size="large" variant="contained">応援を送る</LinkButton>
+<LinkButton href="#" layout="fullWidth" icon={<PencilAdd/>} size="medium" variant="outlined">ブログを書く</LinkButton>
+<LinkButton href="#" layout="fullWidth" icon={<GraphBar/>} size="small" variant="neutral">詳細を見る</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>Contained</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>Outlined</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>Neutral</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>修正する</a>
   `}
 />
 
@@ -264,20 +264,20 @@ import { PlusBold, ArrowRightBold, OpenblankFill } from '../Icon';
 
 <Preview withSource="open">
   <Story name="Lighted">
-    <LinkButton href="#" size="large" variant="lighted" {...actions('onMouseOver')}>Lighted</LinkButton>
+    <LinkButton href="#" size="large" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<LinkButton href="#" size="large" variant="lighted">Lighted</LinkButton>
+<LinkButton href="#" size="large" variant="lighted">フォロー中</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--lighted" href="#">Lighted</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--lighted" href="#">フォロー中</a>
   `}
 />
 

--- a/packages/spindle-ui/src/Modal/AppealModal.stories.example.tsx
+++ b/packages/spindle-ui/src/Modal/AppealModal.stories.example.tsx
@@ -29,8 +29,13 @@ export function AppealModalExample() {
 
   return (
     <>
-      <Button aria-haspopup="true" onClick={handleOpenButtonClick}>
-        Open Appeal Modal
+      <Button
+        aria-haspopup="true"
+        size="medium"
+        variant="neutral"
+        onClick={handleOpenButtonClick}
+      >
+        開く
       </Button>
       <AppealModal.Frame
         aria-describedby="dialog-description"

--- a/packages/spindle-ui/src/Modal/AppealModal.stories.mdx
+++ b/packages/spindle-ui/src/Modal/AppealModal.stories.mdx
@@ -69,8 +69,8 @@ function AppealModalExample() {
   }, [dialogRef]);
   return (
     <>
-      <Button aria-haspopup="true" onClick={handleOpenButtonClick}>
-        Open Appeal Modal
+      <Button aria-haspopup="true" size="medium" variant="neutral" onClick={handleOpenButtonClick}>
+        開く
       </Button>
       <AppealModal.Frame
         aria-describedby="dialog-description"
@@ -169,7 +169,7 @@ function AppealModalExample() {
     <div class="spui-ButtonGroup spui-ButtonGroup--column spui-ButtonGroup--medium spui-AppealModal-buttonGroup">
       <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--contained" href="https://about.ameba.jp/">サイトを見る</a>
     </div>
-    <div class="spui-AppealModal-closeTextButton"><button class="spui-SubtleButton spui-SubtleButton--large">閉じる</button></div>
+    <div class="spui-AppealModal-closeTextButton"><button class="spui-SubtleButton spui-SubtleButton--large">とじる</button></div>
   </div>
 </div>
   `}

--- a/packages/spindle-ui/src/Modal/AppealModal.tsx
+++ b/packages/spindle-ui/src/Modal/AppealModal.tsx
@@ -161,7 +161,7 @@ const StyleOnly = ({
         </div>
         {children}
         <div className={`${BLOCK_NAME}-closeTextButton`}>
-          <SubtleButton>閉じる</SubtleButton>
+          <SubtleButton>とじる</SubtleButton>
         </div>
       </div>
     </div>

--- a/packages/spindle-ui/src/SnackBar/SnackBar.stories.mdx
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.stories.mdx
@@ -45,7 +45,7 @@ export const ActivateButton = ({
         variant={variant === 'error' ? 'danger' : 'outlined'}
         onClick={() => setMessage(_message || 'メッセージが届きました')}
       >
-        Activate
+        送信する
       </Button>
       <SnackBar.Frame
         active={!!message}
@@ -82,7 +82,7 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
           setMessage2('メッセージが届きました');
         }}
       >
-        Activate
+        送信する
       </Button>
       <SnackBar.Frame
         active={!!message1}

--- a/packages/spindle-ui/src/SubtleButton/SubtleButton.stories.mdx
+++ b/packages/spindle-ui/src/SubtleButton/SubtleButton.stories.mdx
@@ -25,20 +25,20 @@ import { SubtleButton } from './SubtleButton';
 
 <Preview withSource="open">
   <Story name="Large">
-    <SubtleButton size="large" {...actions('onClick', 'onMouseOver')}>Subtle Button</SubtleButton>
+    <SubtleButton size="large" {...actions('onClick', 'onMouseOver')}>とじる</SubtleButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<SubtleButton size="large">Subtle Button</SubtleButton>
+<SubtleButton size="large">とじる</SubtleButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-SubtleButton spui-SubtleButton--large">Subtle Button</button>
+<button class="spui-SubtleButton spui-SubtleButton--large">とじる</button>
   `}
 />
 
@@ -46,20 +46,20 @@ import { SubtleButton } from './SubtleButton';
 
 <Preview withSource="open">
   <Story name="Medium">
-    <SubtleButton size="medium" {...actions('onClick', 'onMouseOver')}>Subtle Button</SubtleButton>
+    <SubtleButton size="medium" {...actions('onClick', 'onMouseOver')}>とじる</SubtleButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<SubtleButton size="medium">Subtle Button</SubtleButton>
+<SubtleButton size="medium">とじる</SubtleButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-SubtleButton spui-SubtleButton--medium">Subtle Button</button>
+<button class="spui-SubtleButton spui-SubtleButton--medium">とじる</button>
   `}
 />
 
@@ -67,19 +67,19 @@ import { SubtleButton } from './SubtleButton';
 
 <Preview withSource="open">
   <Story name="Small">
-    <SubtleButton size="Small" {...actions('onClick', 'onMouseOver')}>Subtle Button</SubtleButton>
+    <SubtleButton size="Small" {...actions('onClick', 'onMouseOver')}>とじる</SubtleButton>
   </Story>
 </Preview>
 
 <Source
   code={`
-<SubtleButton size="small">Subtle Button</SubtleButton>
+<SubtleButton size="small">とじる</SubtleButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-SubtleButton spui-SubtleButton--small">Subtle Button</button>
+<button class="spui-SubtleButton spui-SubtleButton--small">とじる</button>
   `}
 />

--- a/packages/spindle-ui/src/Toast/Toast.stories.mdx
+++ b/packages/spindle-ui/src/Toast/Toast.stories.mdx
@@ -42,7 +42,7 @@ export const ActivateButton = ({
         variant={variant === "error" ? 'danger' : 'outlined'}
         onClick={() => setMessage(_message || 'メッセージが届きました')}
       >
-        Activate
+        送信する
       </Button>
       <div style={{["--Toast-z-index"]: 2 }}>
         <Toast
@@ -75,7 +75,7 @@ export const MultiActivateButton = ({ offset, icon, position }) => {
           setMessage2('今何してる？');
         }}
       >
-        Activate
+        送信する
       </Button>
       <div style={{["--Toast-z-index"]: 2 }}>
         <Toast


### PR DESCRIPTION
## 概要
AmebaでSpindle-uiで使用する際は基本的に日本語なので、日本語フォントのサイズ感やウェイトの具合などを確認できるようにStorybookのラベルを全て日本語化しました

また、日本語化する際は適当な文字列ではなく、Ameba内での実際の使用用途にあった日本語に変更しています

## Issue
fix [StorybookのUIのラベルを日本語にする](https://github.com/openameba/spindle/issues/162)