### PR TITLE
docs: change license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Ameba Design System
 
 ## License
 
-Spindle is licensed under MIT License, but Icon files in [Spindle Icons](https://github.com/openameba/spindle/tree/docs/license/packages/spindle-icons/dist) and [Spindle UI](https://github.com/openameba/spindle/tree/docs/license/packages/spindle-ui/src/Icon) are licensed under Creative Commons BY-NC-ND 4.0.
+Spindle is licensed under MIT License, but Icon files in [Spindle Icons](https://github.com/openameba/spindle/tree/main/packages/spindle-icons#%E3%83%A9%E3%82%A4%E3%82%BB%E3%83%B3%E3%82%B9) and [Spindle UI](https://github.com/openameba/spindle/tree/main/packages/spindle-ui#%E3%83%A9%E3%82%A4%E3%82%BB%E3%83%B3%E3%82%B9) are licensed under Creative Commons BY-NC-ND 4.0.

--- a/packages/spindle-ui/README.md
+++ b/packages/spindle-ui/README.md
@@ -129,7 +129,7 @@ yarn generate
 ```
 
 ## ライセンス
-Spindle UIはMITライセンスで公開されています。ただし、アイコンは[Spindle Icons](../spindle-icons/)に準じて、Creative Commons BY-NC-ND 4.0ライセンスで公開されています。
+Spindle UIはMITライセンスで公開されています。ただし、アイコンは[Spindle Icons](https://github.com/openameba/spindle/tree/main/packages/spindle-icons#%E3%83%A9%E3%82%A4%E3%82%BB%E3%83%B3%E3%82%B9)に準じて、Creative Commons BY-NC-ND 4.0ライセンスで公開されています。
 
 ## 関連ドキュメント
 - [Design Doc](docs/design-doc.md)


### PR DESCRIPTION
### 概要
Licenseにあるリンクが404になっていたため修正をおこないました。
遷移先正しいかご確認いただきたく。