### PR TITLE
feat(spindle-ui): pagination style with container queries

### DIFF
--- a/packages/spindle-ui/src/Pagination/Pagination.css
+++ b/packages/spindle-ui/src/Pagination/Pagination.css
@@ -9,6 +9,7 @@
 
 .spui-Pagination {
   align-items: center;
+  container: spui-pagination / inline-size;
   display: flex;
   flex-direction: column;
 }
@@ -93,7 +94,7 @@
   margin-left: 10px;
 }
 
-@media screen and (max-width: 360px) {
+@container spui-pagination (max-width: 360px) {
   .spui-Pagination-item--first,
   .spui-Pagination-item--last {
     display: none;

--- a/packages/spindle-ui/src/Pagination/PaginationItem.css
+++ b/packages/spindle-ui/src/Pagination/PaginationItem.css
@@ -63,7 +63,7 @@
   }
 }
 
-@media screen and (max-width: 768px) {
+@container spui-pagination (max-width: 768px) {
   .spui-PaginationItem-label {
     display: none;
   }


### PR DESCRIPTION
paginationの幅レイアウト処理をMedia QueryからContainer Queryに変更しました。(変更に関して @MasatoHonda 確認済みです)

Container Queryに対応していないブラウザでは非表示項目が表示されてしまいますが、致命的でないためProgressive Enhancementとして問題ないかなとは考えています。

(一応以下の形で既存の動作を担保できはしますが、ただこれまた`@supports not`に対応していないとです)

```css
@supports not (container-type: inline-size) {
  ...
}
```

## 確認方法

https://ameba-spindle--pr710-feat-pagination-cq-b35rjhox.web.app/?path=/story/pagination--on-page-change-function&globals=backgrounds.grid:false あたりで幅を小さく表示し、DevToolsで確認します。


<img width="335" alt="Screenshot 2023-05-19 at 6 13 43 PM" src="https://github.com/openameba/spindle/assets/869023/4aadb299-68c9-4751-81b7-d004005be68b">
