### PR TITLE
fix(spindle-ui): inline notification emphasized style

### DIFF
--- a/packages/spindle-ui/src/InlineNotification/InlineNotification.css
+++ b/packages/spindle-ui/src/InlineNotification/InlineNotification.css
@@ -128,7 +128,7 @@
 }
 
 /* === Information Emphasized === */
-.spui-InlineNotification--information ~ .spui-InlineNotification--emphasized {
+.spui-InlineNotification--information.spui-InlineNotification--emphasized {
   background-color: var(--color-surface-accent-neutral-high-emphasis);
 }
 .spui-InlineNotification--information.spui-InlineNotification--emphasized
@@ -209,7 +209,7 @@
 }
 
 /* === Confirmation Emphasized === */
-.spui-InlineNotification--confirmation ~ .spui-InlineNotification--emphasized {
+.spui-InlineNotification--confirmation.spui-InlineNotification--emphasized {
   background-color: var(--color-surface-accent-primary);
 }
 .spui-InlineNotification--confirmation.spui-InlineNotification--emphasized
@@ -263,7 +263,7 @@
 }
 
 /* === Error Emphasized === */
-.spui-InlineNotification--error ~ .spui-InlineNotification--emphasized {
+.spui-InlineNotification--error.spui-InlineNotification--emphasized {
   background-color: var(--color-surface-caution);
 }
 .spui-InlineNotification--error.spui-InlineNotification--emphasized

--- a/packages/spindle-ui/src/InlineNotification/InlineNotification.stories.mdx
+++ b/packages/spindle-ui/src/InlineNotification/InlineNotification.stories.mdx
@@ -64,6 +64,11 @@ Avatar画像に関してはalt属性をPropsとして提供しているため、
       <InlineNotification.Icon><Information aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>ブログの管理者が承認するまで、コメントが反映されない場合があります</InlineNotification.Text>
     </InlineNotification.Frame>
+  </Story>
+</Preview>
+
+<Preview withSource="open">
+  <Story name="Information Emphasis">
     <InlineNotification.Frame variant='information' emphasis visible>
       <InlineNotification.Icon><Information aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>ブログの管理者が承認するまで、コメントが反映されない場合があります</InlineNotification.Text>
@@ -93,6 +98,11 @@ Avatar画像に関してはalt属性をPropsとして提供しているため、
       <InlineNotification.Icon><Information aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>コメントが投稿されました</InlineNotification.Text>
     </InlineNotification.Frame>
+  </Story>
+</Preview>
+
+<Preview withSource="open">
+  <Story name="Confirmation Emphasis">
     <InlineNotification.Frame variant='confirmation' emphasis visible>
       <InlineNotification.Icon><Information aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>コメントが投稿されました</InlineNotification.Text>
@@ -122,6 +132,11 @@ Avatar画像に関してはalt属性をPropsとして提供しているため、
       <InlineNotification.Icon><ExclamationmarkCircleFill aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>ファイル形式が正しくありません</InlineNotification.Text>
     </InlineNotification.Frame>
+  </Story>
+</Preview>
+
+<Preview withSource="open">
+  <Story name="Error Emphasis">
     <InlineNotification.Frame variant='error' emphasis visible>
       <InlineNotification.Icon><ExclamationmarkCircleFill aria-hidden="true"/></InlineNotification.Icon>
       <InlineNotification.Text>ファイル形式が正しくありません</InlineNotification.Text>


### PR DESCRIPTION
### 概要
issueに記載されている通りではあるのですが、
emphasizedで定義されている `~` が原因でこの一般兄弟結合子は

> 一般兄弟結合子 (general sibling combinator, ~) は 2 個のセレクターを結びつけ、 1 つ目の要素の後に 2 つ目の要素のがあり（直後である必要はない）、かつ両者が同じ親[要素](https://developer.mozilla.org/ja/docs/Glossary/Element)の子であるすべてのパターンに一致します。

なのでstorybookのパターンが2つ並んでいるから成立しているだけで実際、単体で使おうとするとstyleが効かなくなってしまっていました。

[iconの色をつけているstyle](https://github.com/openameba/spindle/blob/4c26959df9deedac0e996962443f656f7f3617f8/packages/spindle-ui/src/InlineNotification/InlineNotification.css#L134-L137) あたりに合わせてcss修正しております。


### スクリーンショット

#### 現状
![スクリーンショット 2023-05-25 16 53 19](https://github.com/openameba/spindle/assets/80251820/ea5e4936-fe8e-425e-b658-b30f2e423b2e)

#### 現状からstorybookのパターンを1つにしたもの
![スクリーンショット 2023-05-25 16 53 28](https://github.com/openameba/spindle/assets/80251820/012d1b4c-a492-4611-871c-5294c4a53c78)

#### 修正後
![スクリーンショット 2023-05-25 16 53 39](https://github.com/openameba/spindle/assets/80251820/76faf292-3492-4b91-9fe0-256e6c4c2c5a)


### 関連するissue
close: #721