### PR TITLE
docs(spindle-ui): integrate Lighted into other variant sections

### DIFF
--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -292,7 +292,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
   <Story name="With Icon">
     <Button icon={<FileAdd/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>ファイルを選択する</Button>
     <Button icon={<Link/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>リンクをコピーする</Button>
-    <Button icon={<PlusBold/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>フォローする</Button>
+    <Button icon={<PlusBold/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>フォロー</Button>
   </Story>
 </Preview>
 
@@ -300,7 +300,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
   code={`
 <Button icon={<FileAdd/>} size="large" variant="contained">ファイルを選択する</Button>
 <Button icon={<Link/>} size="medium" variant="outlined">リンクをコピーする</Button>
-<Button icon={<PlusBold/>} size="small" variant="neutral">フォローする</Button>
+<Button icon={<PlusBold/>} size="small" variant="neutral">フォロー</Button>
   `}
 />
 
@@ -309,7 +309,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
   code={`
 <button class="spui-Button spui-Button--intrinsic spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
 <button class="spui-Button spui-Button--intrinsic spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
-<button class="spui-Button spui-Button--intrinsic spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォローする</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォロー</button>
   `}
 />
 
@@ -319,7 +319,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
   <Story name="Full Width With Icon">
     <Button layout="fullWidth" icon={<FileAdd/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>ファイルを選択する</Button>
     <Button layout="fullWidth" icon={<Link/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>リンクをコピーする</Button>
-    <Button layout="fullWidth" icon={<PlusBold/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>フォローする</Button>
+    <Button layout="fullWidth" icon={<PlusBold/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>フォロー</Button>
   </Story>
 </Preview>
 
@@ -327,7 +327,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
   code={`
 <Button layout="fullWidth" icon={<FileAdd/>} size="large" variant="contained">ファイルを選択する</Button>
 <Button layout="fullWidth" icon={<Link/>} size="medium" variant="outlined">リンクをコピーする</Button>
-<Button layout="fullWidth" icon={<PlusBold/>} size="small" variant="neutral">フォローする</Button>
+<Button layout="fullWidth" icon={<PlusBold/>} size="small" variant="neutral">フォロー</Button>
   `}
 />
 
@@ -336,7 +336,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
   code={`
 <button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォローする</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォロー</button>
   `}
 />
 

--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -30,6 +30,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
     <Button size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
     <Button size="large" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
+    <Button size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
@@ -39,6 +40,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button size="large" variant="outlined">選択する</Button>
 <Button size="large" variant="neutral">修正する</Button>
 <Button size="large" variant="danger">削除する</Button>
+<Button size="large" variant="lighted">フォロー中</Button>
   `}
 />
 
@@ -49,6 +51,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--large spui-Button--outlined">選択する</button>
 <button class="spui-Button spui-Button--large spui-Button--neutral">修正する</button>
 <button class="spui-Button spui-Button--large spui-Button--danger">削除する</button>
+<button class="spui-Button spui-Button--large spui-Button--lighted">フォロー中</button>
   `}
 />
 
@@ -60,6 +63,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button layout="fullWidth" size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
     <Button layout="fullWidth" size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
     <Button layout="fullWidth" size="large" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
+    <Button layout="fullWidth" size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
@@ -69,6 +73,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button layout="fullWidth" size="large" variant="outlined">選択する</Button>
 <Button layout="fullWidth" size="large" variant="neutral">修正する</Button>
 <Button layout="fullWidth" size="large" variant="danger">削除する</Button>
+<Button layout="fullWidth" size="large" variant="lighted">フォロー中</Button>
   `}
 />
 
@@ -79,6 +84,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--outlined">選択する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--neutral">修正する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--danger">削除する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--lighted">フォロー中</button>
   `}
 />
 
@@ -90,6 +96,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
     <Button size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
     <Button size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
+    <Button size="medium" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
@@ -99,6 +106,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button size="medium" variant="outlined">選択する</Button>
 <Button size="medium" variant="neutral">修正する</Button>
 <Button size="medium" variant="danger">削除する</Button>
+<Button size="medium" variant="lighted">フォロー中</Button>
   `}
 />
 
@@ -109,6 +117,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--medium spui-Button--outlined">選択する</button>
 <button class="spui-Button spui-Button--medium spui-Button--neutral">修正する</button>
 <button class="spui-Button spui-Button--medium spui-Button--danger">削除する</button>
+<button class="spui-Button spui-Button--medium spui-Button--lighted">フォロー中</button>
   `}
 />
 
@@ -120,6 +129,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button layout="fullWidth" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
     <Button layout="fullWidth" size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
     <Button layout="fullWidth" size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
+    <Button layout="fullWidth" size="medium" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
@@ -129,6 +139,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button layout="fullWidth" size="medium" variant="outlined">選択する</Button>
 <Button layout="fullWidth" size="medium" variant="neutral">修正する</Button>
 <Button layout="fullWidth" size="medium" variant="danger">削除する</Button>
+<Button layout="fullWidth" size="medium" variant="lighted">フォロー中</Button>
   `}
 />
 
@@ -139,6 +150,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined">選択する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral">修正する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger">削除する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--lighted">フォロー中</button>
   `}
 />
 
@@ -150,6 +162,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
     <Button size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
     <Button size="small" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
+    <Button size="small" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
@@ -159,6 +172,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button size="small" variant="outlined">選択する</Button>
 <Button size="small" variant="neutral">修正する</Button>
 <Button size="small" variant="danger">削除する</Button>
+<Button size="small" variant="lighted">フォロー中</Button>
   `}
 />
 
@@ -169,6 +183,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--small spui-Button--outlined">選択する</button>
 <button class="spui-Button spui-Button--small spui-Button--neutral">修正する</button>
 <button class="spui-Button spui-Button--small spui-Button--danger">削除する</button>
+<button class="spui-Button spui-Button--small spui-Button--lighted">フォロー中</button>
   `}
 />
 
@@ -180,6 +195,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button layout="fullWidth" size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
     <Button layout="fullWidth" size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
     <Button layout="fullWidth" size="small" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
+    <Button layout="fullWidth" size="small" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
@@ -189,6 +205,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button layout="fullWidth" size="small" variant="outlined">選択する</Button>
 <Button layout="fullWidth" size="small" variant="neutral">修正する</Button>
 <Button layout="fullWidth" size="small" variant="danger">削除する</Button>
+<Button layout="fullWidth" size="small" variant="lighted">フォロー中</Button>
   `}
 />
 
@@ -199,6 +216,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--outlined">選択する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral">修正する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--danger">削除する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--lighted">フォロー中</button>
   `}
 />
 
@@ -210,6 +228,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
     <Button disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
     <Button disabled size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
+    <Button disabled size="medium" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
@@ -219,6 +238,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button disabled size="medium" variant="outlined">選択する</Button>
 <Button disabled size="medium" variant="neutral">修正する</Button>
 <Button disabled size="medium" variant="danger">削除する</Button>
+<Button disabled size="medium" variant="lighted">フォロー中</Button>
   `}
 />
 
@@ -229,6 +249,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--medium spui-Button--outlined" disabled>選択する</button>
 <button class="spui-Button spui-Button--medium spui-Button--neutral" disabled>修正する</button>
 <button class="spui-Button spui-Button--medium spui-Button--danger" disabled>削除する</button>
+<button class="spui-Button spui-Button--medium spui-Button--lighted" disabled>フォロー中</button>
   `}
 />
 
@@ -240,6 +261,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button layout="fullWidth" disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>選択する</Button>
     <Button layout="fullWidth" disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}>修正する</Button>
     <Button layout="fullWidth" disabled size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}>削除する</Button>
+    <Button layout="fullWidth" disabled size="medium" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
   </Story>
 </Preview>
 
@@ -249,6 +271,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button layout="fullWidth" disabled size="medium" variant="outlined">選択する</Button>
 <Button layout="fullWidth" disabled size="medium" variant="neutral">修正する</Button>
 <Button layout="fullWidth" disabled size="medium" variant="danger">削除する</Button>
+<Button layout="fullWidth" disabled size="medium" variant="lighted">フォロー中</Button>
   `}
 />
 
@@ -259,6 +282,7 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined" disabled>選択する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--neutral" disabled>修正する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--danger" disabled>削除する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--lighted" disabled>フォロー中</button>
   `}
 />
 
@@ -313,27 +337,6 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
 <button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォローする</button>
-  `}
-/>
-
-## Lighted
-
-<Preview withSource="open">
-  <Story name="Lighted">
-    <Button size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}>フォロー中</Button>
-  </Story>
-</Preview>
-
-<Source
-  code={`
-<Button size="large" variant="lighted">フォロー中</Button>
-  `}
-/>
-
-<Source
-  language='html'
-  code={`
-<button class="spui-Button spui-Button--large spui-Button--lighted">フォロー中</button>
   `}
 />
 

--- a/packages/spindle-ui/src/IconButton/IconButton.stories.mdx
+++ b/packages/spindle-ui/src/IconButton/IconButton.stories.mdx
@@ -30,6 +30,7 @@ import { PlusBold } from '../Icon';
     <IconButton size="large" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton size="large" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton size="large" variant="danger" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
   </Story>
 </Preview>
 
@@ -39,6 +40,7 @@ import { PlusBold } from '../Icon';
 <IconButton size="large" variant="outlined"><PlusBold /></IconButton>
 <IconButton size="large" variant="neutral"><PlusBold /></IconButton>
 <IconButton size="large" variant="danger"><PlusBold /></IconButton>
+<IconButton size="large" variant="lighted"><PlusBold /></IconButton>
   `}
 />
 
@@ -49,6 +51,7 @@ import { PlusBold } from '../Icon';
 <button class="spui-IconButton spui-IconButton--large spui-IconButton--outlined"><svg /></button>
 <button class="spui-IconButton spui-IconButton--large spui-IconButton--neutral"><svg /></button>
 <button class="spui-IconButton spui-IconButton--large spui-IconButton--danger"><svg /></button>
+<button class="spui-IconButton spui-IconButton--large spui-IconButton--lighted"><svg /></button>
   `}
 />
 
@@ -60,6 +63,7 @@ import { PlusBold } from '../Icon';
     <IconButton size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="medium" variant="lighted" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
   </Story>
 </Preview>
 
@@ -69,6 +73,7 @@ import { PlusBold } from '../Icon';
 <IconButton size="medium" variant="outlined"><PlusBold /></IconButton>
 <IconButton size="medium" variant="neutral"><PlusBold /></IconButton>
 <IconButton size="medium" variant="danger"><PlusBold /></IconButton>
+<IconButton size="medium" variant="lighted"><PlusBold /></IconButton>
   `}
 />
 
@@ -79,6 +84,7 @@ import { PlusBold } from '../Icon';
 <button class="spui-IconButton spui-IconButton--medium spui-IconButton--outlined"><svg /></button>
 <button class="spui-IconButton spui-IconButton--medium spui-IconButton--neutral"><svg /></button>
 <button class="spui-IconButton spui-IconButton--medium spui-IconButton--danger"><svg /></button>
+<button class="spui-IconButton spui-IconButton--medium spui-IconButton--lighted"><svg /></button>
   `}
 />
 
@@ -90,6 +96,7 @@ import { PlusBold } from '../Icon';
     <IconButton size="small" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton size="small" variant="danger" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="small" variant="lighted" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
   </Story>
 </Preview>
 
@@ -99,6 +106,7 @@ import { PlusBold } from '../Icon';
 <IconButton size="small" variant="outlined"><PlusBold /></IconButton>
 <IconButton size="small" variant="neutral"><PlusBold /></IconButton>
 <IconButton size="small" variant="danger"><PlusBold /></IconButton>
+<IconButton size="small" variant="lighted"><PlusBold /></IconButton>
   `}
 />
 
@@ -109,6 +117,7 @@ import { PlusBold } from '../Icon';
 <button class="spui-IconButton spui-IconButton--small spui-IconButton--outlined"><svg /></button>
 <button class="spui-IconButton spui-IconButton--small spui-IconButton--neutral"><svg /></button>
 <button class="spui-IconButton spui-IconButton--small spui-IconButton--danger"><svg /></button>
+<button class="spui-IconButton spui-IconButton--small spui-IconButton--lighted"><svg /></button>
   `}
 />
 
@@ -120,6 +129,7 @@ import { PlusBold } from '../Icon';
     <IconButton size="exSmall" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton size="exSmall" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton size="exSmall" variant="danger" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton size="exSmall" variant="lighted" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
   </Story>
 </Preview>
 
@@ -129,6 +139,7 @@ import { PlusBold } from '../Icon';
 <IconButton size="exSmall" variant="outlined"><PlusBold /></IconButton>
 <IconButton size="exSmall" variant="neutral"><PlusBold /></IconButton>
 <IconButton size="exSmall" variant="danger"><PlusBold /></IconButton>
+<IconButton size="exSmall" variant="lighted"><PlusBold /></IconButton>
   `}
 />
 
@@ -139,6 +150,7 @@ import { PlusBold } from '../Icon';
 <button class="spui-IconButton spui-IconButton--exSmall spui-IconButton--outlined"><svg /></button>
 <button class="spui-IconButton spui-IconButton--exSmall spui-IconButton--neutral"><svg /></button>
 <button class="spui-IconButton spui-IconButton--exSmall spui-IconButton--danger"><svg /></button>
+<button class="spui-IconButton spui-IconButton--exSmall spui-IconButton--lighted"><svg /></button>
   `}
 />
 
@@ -150,6 +162,7 @@ import { PlusBold } from '../Icon';
     <IconButton disabled size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton disabled size="medium" variant="neutral" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
     <IconButton disabled size="medium" variant="danger" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
+    <IconButton disabled size="medium" variant="lighted" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
   </Story>
 </Preview>
 
@@ -159,6 +172,7 @@ import { PlusBold } from '../Icon';
 <IconButton disabled size="medium" variant="outlined"><PlusBold /></IconButton>
 <IconButton disabled size="medium" variant="neutral"><PlusBold /></IconButton>
 <IconButton disabled size="medium" variant="danger"><PlusBold /></IconButton>
+<IconButton disabled size="medium" variant="lighted"><PlusBold /></IconButton>
   `}
 />
 
@@ -169,27 +183,7 @@ import { PlusBold } from '../Icon';
 <button class="spui-IconButton spui-IconButton--medium spui-IconButton--outlined" disabled><svg /></button>
 <button class="spui-IconButton spui-IconButton--medium spui-IconButton--neutral" disabled><svg /></button>
 <button class="spui-IconButton spui-IconButton--medium spui-IconButton--danger" disabled><svg /></button>
-  `}
-/>
-
-## Lighted
-
-<Preview withSource="open">
-  <Story name="Lighted">
-    <IconButton size="large" variant="lighted" {...actions('onClick', 'onMouseOver')}><PlusBold /></IconButton>
-  </Story>
-</Preview>
-
-<Source
-  code={`
-<IconButton size="large" variant="lighted">+</IconButton>
-  `}
-/>
-
-<Source
-  language='html'
-  code={`
-<button class="spui-IconButton spui-IconButton--large spui-IconButton--lighted">+</button>
+<button class="spui-IconButton spui-IconButton--medium spui-IconButton--lighted" disabled><svg /></button>
   `}
 />
 

--- a/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
@@ -258,10 +258,6 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 
 ## Lighted
 
-<Description>
-  Neutralからの状態変化先のスタイルとして定義しており、単独での利用は推奨していません。Lightedは試験的なVarientであるため、今後に破壊的な変更や削除がおこなわれる可能性があることに注意して利用してください。
-</Description>
-
 <Preview withSource="open">
   <Story name="Lighted">
     <LinkButton href="#" size="large" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>

--- a/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
@@ -30,6 +30,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
     <LinkButton href="#" size="large" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
     <LinkButton href="#" size="large" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
     <LinkButton href="#" size="large" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
+    <LinkButton href="#" size="large" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>
   </Story>
 </Preview>
 
@@ -39,6 +40,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <LinkButton href="#" size="large" variant="outlined">ブログを書く</LinkButton>
 <LinkButton href="#" size="large" variant="neutral">詳細を見る</LinkButton>
 <LinkButton href="#" size="large" variant="danger">削除する</LinkButton>
+<LinkButton href="#" size="large" variant="lighted">フォロー中</LinkButton>
   `}
 />
 
@@ -49,6 +51,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--outlined" href="#">ブログを書く</a>
 <a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--neutral" href="#">詳細を見る</a>
 <a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--danger" href="#">削除する</a>
+<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--lighted" href="#">フォロー中</a>
   `}
 />
 
@@ -60,6 +63,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
     <LinkButton href="#" layout="fullWidth" size="large" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
     <LinkButton href="#" layout="fullWidth" size="large" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
     <LinkButton href="#" layout="fullWidth" size="large" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="large" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>
   </Story>
 </Preview>
 
@@ -69,6 +73,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <LinkButton href="#" layout="fullWidth" size="large" variant="outlined">ブログを書く</LinkButton>
 <LinkButton href="#" layout="fullWidth" size="large" variant="neutral">詳細を見る</LinkButton>
 <LinkButton href="#" layout="fullWidth" size="large" variant="danger">削除する</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="large" variant="lighted">フォロー中</LinkButton>
   `}
 />
 
@@ -79,6 +84,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--outlined" href="#">ブログを書く</a>
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--neutral" href="#">詳細を見る</a>
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--danger" href="#">削除する</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--lighted" href="#">フォロー中</a>
   `}
 />
 
@@ -90,6 +96,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
     <LinkButton href="#" size="medium" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
     <LinkButton href="#" size="medium" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
     <LinkButton href="#" size="medium" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
+    <LinkButton href="#" size="medium" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>
   </Story>
 </Preview>
 
@@ -99,6 +106,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <LinkButton href="#" size="medium" variant="outlined">ブログを書く</LinkButton>
 <LinkButton href="#" size="medium" variant="neutral">詳細を見る</LinkButton>
 <LinkButton href="#" size="medium" variant="danger">削除する</LinkButton>
+<LinkButton href="#" size="medium" variant="lighted">フォロー中</LinkButton>
   `}
 />
 
@@ -109,6 +117,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--outlined" href="#">ブログを書く</a>
 <a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--neutral" href="#">詳細を見る</a>
 <a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--danger" href="#">削除する</a>
+<a class="spui-LinkButton spui-LinkButton--medium spui-LinkButton--lighted" href="#">フォロー中</a>
   `}
 />
 
@@ -120,6 +129,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
     <LinkButton href="#" layout="fullWidth" size="medium" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
     <LinkButton href="#" layout="fullWidth" size="medium" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
     <LinkButton href="#" layout="fullWidth" size="medium" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="medium" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>
   </Story>
 </Preview>
 
@@ -129,6 +139,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <LinkButton href="#" layout="fullWidth" size="medium" variant="outlined">ブログを書く</LinkButton>
 <LinkButton href="#" layout="fullWidth" size="medium" variant="neutral">詳細を見る</LinkButton>
 <LinkButton href="#" layout="fullWidth" size="medium" variant="danger">削除する</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="medium" variant="lighted">フォロー中</LinkButton>
   `}
 />
 
@@ -139,6 +150,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#">ブログを書く</a>
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--neutral" href="#">詳細を見る</a>
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--danger" href="#">削除する</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--lighted" href="#">フォロー中</a>
   `}
 />
 
@@ -150,6 +162,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
     <LinkButton href="#" size="small" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
     <LinkButton href="#" size="small" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
     <LinkButton href="#" size="small" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
+    <LinkButton href="#" size="small" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>
   </Story>
 </Preview>
 
@@ -159,6 +172,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <LinkButton href="#" size="small" variant="outlined">ブログを書く</LinkButton>
 <LinkButton href="#" size="small" variant="neutral">詳細を見る</LinkButton>
 <LinkButton href="#" size="small" variant="danger">削除する</LinkButton>
+<LinkButton href="#" size="small" variant="lighted">フォロー中</LinkButton>
   `}
 />
 
@@ -169,6 +183,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--outlined" href="#">ブログを書く</a>
 <a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--neutral" href="#">詳細を見る</a>
 <a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--danger" href="#">削除する</a>
+<a class="spui-LinkButton spui-LinkButton--small spui-LinkButton--lighted" href="#">フォロー中</a>
   `}
 />
 
@@ -180,6 +195,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
     <LinkButton href="#" layout="fullWidth" size="small" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
     <LinkButton href="#" layout="fullWidth" size="small" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
     <LinkButton href="#" layout="fullWidth" size="small" variant="danger" {...actions('onMouseOver')}>削除する</LinkButton>
+    <LinkButton href="#" layout="fullWidth" size="small" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>
   </Story>
 </Preview>
 
@@ -189,6 +205,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <LinkButton href="#" layout="fullWidth" size="small" variant="outlined">ブログを書く</LinkButton>
 <LinkButton href="#" layout="fullWidth" size="small" variant="neutral">詳細を見る</LinkButton>
 <LinkButton href="#" layout="fullWidth" size="small" variant="danger">削除する</LinkButton>
+<LinkButton href="#" layout="fullWidth" size="small" variant="lighted">フォロー中</LinkButton>
   `}
 />
 
@@ -199,6 +216,7 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--outlined" href="#">ブログを書く</a>
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#">詳細を見る</a>
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--danger" href="#">削除する</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--lighted" href="#">フォロー中</a>
   `}
 />
 
@@ -253,27 +271,6 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>応援を送る</a>
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>ブログを書く</a>
 <a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>修正する</a>
-  `}
-/>
-
-## Lighted
-
-<Preview withSource="open">
-  <Story name="Lighted">
-    <LinkButton href="#" size="large" variant="lighted" {...actions('onMouseOver')}>フォロー中</LinkButton>
-  </Story>
-</Preview>
-
-<Source
-  code={`
-<LinkButton href="#" size="large" variant="lighted">フォロー中</LinkButton>
-  `}
-/>
-
-<Source
-  language='html'
-  code={`
-<a class="spui-LinkButton spui-LinkButton--large spui-LinkButton--lighted" href="#">フォロー中</a>
   `}
 />
 


### PR DESCRIPTION
## 概要
主に`Lighted`variant関連のドキュメントのアップデートです 📝 

### 変更①：LinkButtonのLightedセクションから、試験中の記述を削除 https://github.com/openameba/spindle/commit/79bf3360d68b6d48144083656b19487acbdf8f9c
[`Lighted`variantは既に本番運用されていますが](https://github.com/openameba/spindle/pull/289)、LinkButtonのドキュメントにだけ試験中の記述が残っていたので削除しました

![スクリーンショット 2023-05-27 20 28 05](https://github.com/openameba/spindle/assets/42470015/e222a119-9467-4331-aa22-2b609a4f7338)

### 変更②：`Lighted`セクションを他のvariantのセクションとマージhttps://github.com/openameba/spindle/commit/f8bb64e3d2197b4e533ad7ad003168c605fc4705
元々Lightedだけ試験公開していたのもあり別セクションに別れていましたが、現在は他のvariantと同等の扱いのため、セクションをマージしました

| Before | After |
| -- | -- |
| ![スクリーンショット 2023-05-29 22 36 37](https://github.com/openameba/spindle/assets/42470015/ca9e2442-77e2-4f75-83a7-66b8ea707cb8) | ![スクリーンショット 2023-05-29 22 45 29](https://github.com/openameba/spindle/assets/42470015/7a32cf26-2dbf-49b3-98e0-a69570c5e0b0) |

### 変更③（おまけ）：`Button（Neutral）`のドキュメントのラベルを変更 https://github.com/openameba/spindle/commit/78388c1700706031d601dd532711a27bf24102b4
[SpindleのUIラベリングルール](https://spindle.ameba.design/principles/contents/ui-labeling/)に則ると、`Button（Neutral）`のドキュメントのラベルは古そうだったのでついでに修正しました

`フォローする` -> `フォロー`

## 関連リンク
fix [Lighted ButtonのStoryを修正する](https://github.com/openameba/spindle/issues/298)