### PR TITLE
docs(spindle-ui): create design doc with scaffdog

### DIFF
--- a/packages/spindle-ui/.scaffdog/design-doc.md
+++ b/packages/spindle-ui/.scaffdog/design-doc.md
@@ -1,0 +1,68 @@
+---
+name: 'design doc'
+root: 'src/'
+output: '**/*'
+ignore: []
+questions:
+  name: 'Please enter a component name.'
+---
+
+# `{{ inputs.name | pascal }}/design-doc.md`
+
+```
+# {{ inputs.name | pascal }}
+
+<!-- NOTE: Design Docにはコードだけでは読み取れないコンポーネントが作られた背景や設計のポイントを記載します。また、レビューを通じて不明点や考慮できていない箇所を洗い出す役割も兼ねています。仕様書ではないので完璧に記述する必要はありません！ -->
+
+## 概要・背景
+<!-- 必須項目です。コンポーネントの概要や必要になった背景などを簡潔に記載します -->
+
+## スクリーンショット
+<!-- オプション項目です。設計を説明する上で必要なスクリーンショットがあれば追加します。画像はリポジトリに含めなくて良いので、GitHubへのアップロードを推奨しています 例) https://github.com/openameba/spindle/pull/732#discussion_r1238040016 -->
+
+## 使用例
+<!-- オプション項目です。コンポーネントの使用例や誤った使い方があれば記載します -->
+
+### DO
+
+### DO NOT
+
+## 要素
+<!-- 必須項目です。コンポーネントに必要な要素をあらかじめリストアップします -->
+
+### Design Tokens
+<!--
+コンポーネントで利用するデザイントークン(色・アニメーションなど)をリストアップします
+https://github.com/openameba/spindle/tree/main/packages/spindle-tokens/tokens
+
+(例)
+- Surface Primary (背景色)
+- Text Medium Emphasis (本文テキスト色)
+-->
+
+### プロパティ
+<!--
+コンポーネントで利用するプロパティ(Props)をリストアップします
+
+(例)
+type Props = {
+  active?: boolean;
+  // デフォルト値はmediumです
+  size?: 'large' | 'medium' | 'small';
+};
+-->
+
+```TypeScript
+type Props = {};
+```
+
+## 実装例
+<!-- オプション項目です。大まかなコードを書いたり、複数の実装を比較する際に利用します -->
+
+## アクセシビリティ
+<!-- 必須項目です。「Ameba Accessibility Checklist」を使って対応する項目をリストアップします。利用方法はお近くのSpindlerにお尋ねください -->
+
+## リンク集
+<!-- オプション項目です。ドキュメントや参考にした実装例のURLをリストアップします。非公開のリンクを記載しないように注意してください -->
+
+```

--- a/packages/spindle-ui/README.md
+++ b/packages/spindle-ui/README.md
@@ -107,7 +107,20 @@ yarn build
 cd -
 ```
 
-新規コンポーネントを作成する際にはgenerateコマンドが便利です。
+新規コンポーネントを作成する際にはgenerateコマンドが便利です。推奨されるフローは、まずDesign Docを作成しPull Requestします。レビューが終わったらマージし、コンポーネント実装を進めます。
+
+```
+yarn generate
+? Please select a document. (Use arrow keys)
+❯ design doc 
+? Please select the output destination directory. (Use arrow keys or type to search)
+❯ src/ 
+? Please enter a component name. NewComponent
+
+🐶 Generated 1 files!
+
+      ✔ src/NewComponent/design-doc.md
+```
 
 ```
 yarn generate


### PR DESCRIPTION
コンポーネントのDesign Docをscaffdogで生成できるようにしました。合わせて作業フロー(README)も更新しています。
