### PR TITLE
feat(spindle-tokens): include minimum tokens in token.css

### DIFF
--- a/packages/spindle-tokens/config-css.js
+++ b/packages/spindle-tokens/config-css.js
@@ -38,6 +38,10 @@ module.exports = {
         },
         {
           destination: 'dist/css/spindle-tokens.css',
+          format: 'cssAnimation',
+        },
+        {
+          destination: 'dist/css/spindle-tokens.all.css',
           format: 'css/variables',
         },
       ],


### PR DESCRIPTION
[ameba-color-palette.css](https://github.com/openameba/ameba-color-palette.css)をspindle-tokens.cssに移行するにあたり、一発で設定変更できるように spindle-tokens.css には使われている最低限のtokenしか含まれないようにしてみます。

現時点では色はameba-color-palette.cssにお任せして、spindle-tokens.cssには新規のアニメーションだけ入れています。

ついでに全部入れてくれい！用のspindle-tokens.all.cssも作りました。

## 各アプリケーションでの移行イメージ
- spindle-tokens.cssをinstall (animation tokenのみ)
- ameba-color-palette.cssとspindle-tokens.cssを併用する
- spindle-tokens.cssをupdate (colorなど追加)
- ameba-color-palette.cssに記載している色をspindle-tokens.css用に変換する
- ameba-color-palette.cssを消す

