### PR TITLE
feat(spindle-tokens): publish css at package root

### DIFF
--- a/packages/spindle-tokens/.gitignore
+++ b/packages/spindle-tokens/.gitignore
@@ -1,0 +1,2 @@
+# output for npm package
+spindle-tokens.css

--- a/packages/spindle-tokens/package.json
+++ b/packages/spindle-tokens/package.json
@@ -7,10 +7,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "dist/css/spindle-tokens.css",
+  "style": "spindle-tokens.css",
   "files": [
     "dist/**",
-    "spindle-tokens.png"
+    "spindle-tokens.png",
+    "spindle-tokens.css"
   ],
   "repository": {
     "type": "git",
@@ -24,7 +25,8 @@
     "build:css": "style-dictionary build --config ./config-css.js",
     "preexport": "tsc",
     "export": "./node_modules/.bin/figma-export use-config",
-    "prepublishOnly": "yarn build"
+    "cp": "npx cpx dist/css/spindle-tokens.css ./",
+    "prepublishOnly": "yarn build & yarn cp"
   },
   "bugs": {
     "url": "https://github.com/openameba/spindle/issues"


### PR DESCRIPTION
利用するメインのCSSファイルをわかりやすく簡易的に読み込めるようにパッケージルートに配置しました。

手元でpublish dry-runするとrootでspindle-tokens.cssが配信されていることがわかります。

```
 📦  @openameba/spindle-tokens@0.11.0
npm notice === Tarball Contents === 
npm notice 2.7kB   README.md                            
npm notice 0B      dist/css/spindle-tokens-animation.css
npm notice 30.4kB  dist/css/spindle-tokens.all.css      
npm notice 1.4kB   dist/css/spindle-tokens.css          
npm notice 195.4kB dist/json/spindle-tokens-flat.json   
npm notice 232.8kB dist/json/spindle-tokens.json        
npm notice 1.3kB   package.json                         
npm notice 1.4kB   spindle-tokens.css                   
npm notice 25.5kB  spindle-tokens.png 
```
