### PR TITLE
feat(spindle-ui): add iconPosition to Button

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -215,17 +215,36 @@
   line-height: 0; /* Fix Icon position align */
 }
 
-.spui-Button-icon--large {
+.spui-Button--iconstart .spui-Button-icon--large {
   font-size: 1.375em; /* Icon 22px / Text 16px = 1.375 */
   margin-right: 6px;
 }
 
-.spui-Button-icon--medium {
+.spui-Button--iconstart .spui-Button-icon--medium {
   font-size: 1.429em; /* Icon 20px / Text 14px =  1.42857142857 */
   margin-right: 4px;
 }
 
-.spui-Button-icon--small {
+.spui-Button--iconstart .spui-Button-icon--small {
   font-size: 1.23em; /* Icon 16px / Text 13px = 1.23076923077 */
   margin-right: 2px;
+}
+
+.spui-Button--iconend {
+  flex-direction: row-reverse;
+}
+
+.spui-Button--iconend .spui-Button-icon--large {
+  font-size: 1.125em; /* Icon 18px / Text 16px = 1.125 */
+  margin-left: 6px;
+}
+
+.spui-Button--iconend .spui-Button-icon--medium {
+  font-size: 1.143em; /* Icon 16px / Text 14px =  1.14285714285 */
+  margin-left: 4px;
+}
+
+.spui-Button--iconend .spui-Button-icon--small {
+  font-size: 1.077em; /* Icon 14px / Text 13px = 1.07692307692 */
+  margin-left: 2px;
 }

--- a/packages/spindle-ui/src/Button/Button.stories.mdx
+++ b/packages/spindle-ui/src/Button/Button.stories.mdx
@@ -1,7 +1,7 @@
 import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { Button } from './Button';
-import { PlusBold, Link, FileAdd } from '../Icon';
+import { PlusBold, Link, FileAdd, ChevronDownBold } from '../Icon';
 
 # Button
 
@@ -293,6 +293,9 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button icon={<FileAdd/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>ファイルを選択する</Button>
     <Button icon={<Link/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>リンクをコピーする</Button>
     <Button icon={<PlusBold/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>フォロー</Button>
+    <Button icon={<ChevronDownBold/>} iconPosition="end" size="large" variant="contained"  {...actions('onClick', 'onMouseOver')}>さらに表示</Button>
+    <Button icon={<ChevronDownBold/>} iconPosition="end" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>もっと見る</Button>
+    <Button icon={<ChevronDownBold/>} iconPosition="end" size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>さらに表示</Button>
   </Story>
 </Preview>
 
@@ -301,15 +304,21 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button icon={<FileAdd/>} size="large" variant="contained">ファイルを選択する</Button>
 <Button icon={<Link/>} size="medium" variant="outlined">リンクをコピーする</Button>
 <Button icon={<PlusBold/>} size="small" variant="neutral">フォロー</Button>
+<Button icon={<ChevronDownBold/>} iconPosition="end" size="large" variant="contained">さらに表示</Button>
+<Button icon={<ChevronDownBold/>} iconPosition="end" size="medium" variant="outlined">もっと見る</Button>
+<Button icon={<ChevronDownBold/>} iconPosition="end" size="small" variant="neutral">さらに表示</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--intrinsic spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
-<button class="spui-Button spui-Button--intrinsic spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
-<button class="spui-Button spui-Button--intrinsic spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォロー</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--large spui-Button--contained spui-Button--iconstart"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--medium spui-Button--outlined spui-Button--iconstart"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--small spui-Button--neutral spui-Button--iconstart"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォロー</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--large spui-Button--contained spui-Button--iconend"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>さらに表示</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--medium spui-Button--outlined spui-Button--iconend"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>もっと見る</button>
+<button class="spui-Button spui-Button--intrinsic spui-Button--small spui-Button--neutral spui-Button--iconend"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>さらに表示</button>
   `}
 />
 
@@ -320,6 +329,9 @@ import { PlusBold, Link, FileAdd } from '../Icon';
     <Button layout="fullWidth" icon={<FileAdd/>} size="large" variant="contained" {...actions('onClick', 'onMouseOver')}>ファイルを選択する</Button>
     <Button layout="fullWidth" icon={<Link/>} size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>リンクをコピーする</Button>
     <Button layout="fullWidth" icon={<PlusBold/>} size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>フォロー</Button>
+    <Button layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="large" variant="contained"  {...actions('onClick', 'onMouseOver')}>さらに表示</Button>
+    <Button layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="medium" variant="outlined" {...actions('onClick', 'onMouseOver')}>もっと見る</Button>
+    <Button layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="small" variant="neutral" {...actions('onClick', 'onMouseOver')}>さらに表示</Button>
   </Story>
 </Preview>
 
@@ -328,15 +340,21 @@ import { PlusBold, Link, FileAdd } from '../Icon';
 <Button layout="fullWidth" icon={<FileAdd/>} size="large" variant="contained">ファイルを選択する</Button>
 <Button layout="fullWidth" icon={<Link/>} size="medium" variant="outlined">リンクをコピーする</Button>
 <Button layout="fullWidth" icon={<PlusBold/>} size="small" variant="neutral">フォロー</Button>
+<Button layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="large" variant="contained">さらに表示</Button>
+<Button layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="medium" variant="outlined">もっと見る</Button>
+<Button layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="small" variant="neutral">さらに表示</Button>
   `}
 />
 
 <Source
   language='html'
   code={`
-<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
-<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォロー</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained spui-Button--iconstart"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>ファイルを選択する</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined spui-Button--iconstart"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>リンクをコピーする</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral spui-Button--iconstart"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>フォロー</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--large spui-Button--contained spui-Button--iconend"><span class="spui-Button-icon spui-Button-icon--large"><svg /></span>さらに表示</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--medium spui-Button--outlined spui-Button--iconend"><span class="spui-Button-icon spui-Button-icon--medium"><svg /></span>もっと見る</button>
+<button class="spui-Button spui-Button--fullWidth spui-Button--small spui-Button--neutral spui-Button--iconend"><span class="spui-Button-icon spui-Button-icon--small"><svg /></span>さらに表示</button>
   `}
 />
 

--- a/packages/spindle-ui/src/Button/Button.tsx
+++ b/packages/spindle-ui/src/Button/Button.tsx
@@ -13,6 +13,7 @@ interface Props
   size?: Size;
   variant?: Variant;
   icon?: React.ReactNode;
+  iconPosition?: 'start' | 'end';
 }
 
 const BLOCK_NAME = 'spui-Button';
@@ -24,13 +25,22 @@ export const Button = forwardRef<HTMLButtonElement, Props>(function Button(
     size = 'large',
     variant = 'contained',
     icon,
+    iconPosition = 'start',
     ...rest
   }: Props,
   ref,
 ) {
   return (
     <button
-      className={`${BLOCK_NAME} ${BLOCK_NAME}--${layout} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
+      className={[
+        BLOCK_NAME,
+        `${BLOCK_NAME}--${layout}`,
+        `${BLOCK_NAME}--${size}`,
+        `${BLOCK_NAME}--${variant}`,
+        icon && `${BLOCK_NAME}--icon${iconPosition}`,
+      ]
+        .filter(Boolean)
+        .join(' ')}
       ref={ref}
       {...rest}
     >


### PR DESCRIPTION
## 概要

ButtonコンポーネントのIcon位置が左のみ対応していたのを、左右に対応できるようにしました。

<img width="640" alt="スクリーンショット 2023-07-28 10 40 31" src="https://github.com/openameba/spindle/assets/40178733/4d5a94b6-85af-4280-8e59-91a6f571afbf">

※ iconを指定した場合に初期値として左を選択させることで、破壊的変更にならないようにしています。