### PR TITLE
feat(spindle-ui): add iconPosition to LinkButton

### DIFF
--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -214,17 +214,36 @@
   line-height: 0; /* Fix Icon position align */
 }
 
-.spui-LinkButton-icon--large {
+.spui-LinkButton--iconstart .spui-LinkButton-icon--large {
   font-size: 1.375em; /* Icon 22px / Text 16px = 1.375 */
   margin-right: 6px;
 }
 
-.spui-LinkButton-icon--medium {
+.spui-LinkButton--iconstart .spui-LinkButton-icon--medium {
   font-size: 1.429em; /* Icon 20px / Text 14px =  1.42857142857 */
   margin-right: 4px;
 }
 
-.spui-LinkButton-icon--small {
+.spui-LinkButton--iconstart .spui-LinkButton-icon--small {
   font-size: 1.23em; /* Icon 16px / Text 13px = 1.23076923077 */
   margin-right: 2px;
+}
+
+.spui-LinkButton--iconend {
+  flex-direction: row-reverse;
+}
+
+.spui-LinkButton--iconend .spui-LinkButton-icon--large {
+  font-size: 1.125em; /* Icon 18px / Text 16px = 1.125 */
+  margin-left: 6px;
+}
+
+.spui-LinkButton--iconend .spui-LinkButton-icon--medium {
+  font-size: 1.143em; /* Icon 16px / Text 14px =  1.14285714285 */
+  margin-left: 4px;
+}
+
+.spui-LinkButton--iconend .spui-LinkButton-icon--small {
+  font-size: 1.077em; /* Icon 14px / Text 13px = 1.07692307692 */
+  margin-left: 2px;
 }

--- a/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.stories.mdx
@@ -1,7 +1,7 @@
 import { Description, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { actions } from '@storybook/addon-actions';
 import { LinkButton } from './LinkButton';
-import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, PencilAdd } from '../Icon';
+import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, PencilAdd, ChevronDownBold } from '../Icon';
 
 # LinkButton
 
@@ -227,6 +227,9 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
     <LinkButton href="#" icon={<Present/>} size="large" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
     <LinkButton href="#" icon={<PencilAdd/>} size="medium" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
     <LinkButton href="#" icon={<GraphBar/>} size="small" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
+    <LinkButton href="#" icon={<ChevronDownBold/>} iconPosition="end" size="large" variant="contained" {...actions('onMouseOver')}>さらに表示</LinkButton>
+    <LinkButton href="#" icon={<ChevronDownBold/>} iconPosition="end" size="medium" variant="outlined" {...actions('onMouseOver')}>もっと見る</LinkButton>
+    <LinkButton href="#" icon={<ChevronDownBold/>} iconPosition="end" size="small" variant="neutral" {...actions('onMouseOver')}>さらに表示</LinkButton>
   </Story>
 </Preview>
 
@@ -235,15 +238,21 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <LinkButton href="#" icon={<Present/>} size="large" variant="contained">応援を送る</LinkButton>
 <LinkButton href="#" icon={<PencilAdd/>} size="medium" variant="outlined">ブログを書く</LinkButton>
 <LinkButton href="#" icon={<GraphBar/>} size="small" variant="neutral">詳細を見る</LinkButton>
+<LinkButton href="#" icon={<ChevronDownBold/>} iconPosition="end" size="large" variant="contained">さらに表示</LinkButton>
+<LinkButton href="#" icon={<ChevronDownBold/>} iconPosition="end" size="medium" variant="outlined">もっと見る</LinkButton>
+<LinkButton href="#" icon={<ChevronDownBold/>} iconPosition="end" size="small" variant="neutral">さらに表示</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>応援を送る</a>
-<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>ブログを書く</a>
-<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>詳細を見る</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--large spui-LinkButton--contained spui-LinkButton--iconstart" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--medium spui-LinkButton--outlined spui-LinkButton--iconstart" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--small spui-LinkButton--neutral spui-LinkButton--iconstart" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>詳細を見る</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--large spui-LinkButton--contained spui-LinkButton--iconend" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>さらに表示</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--medium spui-LinkButton--outlined spui-LinkButton--iconend" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>もっと見る</a>
+<a class="spui-LinkButton spui-LinkButton--intrinsic spui-LinkButton--small spui-LinkButton--neutral spui-LinkButton--iconend" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>さらに表示</a>
   `}
 />
 
@@ -254,6 +263,9 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
     <LinkButton href="#" layout="fullWidth" icon={<Present/>} size="large" variant="contained" {...actions('onMouseOver')}>応援を送る</LinkButton>
     <LinkButton href="#" layout="fullWidth" icon={<PencilAdd/>} size="medium" variant="outlined" {...actions('onMouseOver')}>ブログを書く</LinkButton>
     <LinkButton href="#" layout="fullWidth" icon={<GraphBar/>} size="small" variant="neutral" {...actions('onMouseOver')}>詳細を見る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="large" variant="contained" {...actions('onMouseOver')}>さらに表示</LinkButton>
+    <LinkButton href="#" layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="medium" variant="outlined" {...actions('onMouseOver')}>もっと見る</LinkButton>
+    <LinkButton href="#" layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="small" variant="neutral" {...actions('onMouseOver')}>さらに表示</LinkButton>
   </Story>
 </Preview>
 
@@ -262,15 +274,21 @@ import { PlusBold, ArrowRightBold, OpenblankFill, Link, GraphBar, Present, Penci
 <LinkButton href="#" layout="fullWidth" icon={<Present/>} size="large" variant="contained">応援を送る</LinkButton>
 <LinkButton href="#" layout="fullWidth" icon={<PencilAdd/>} size="medium" variant="outlined">ブログを書く</LinkButton>
 <LinkButton href="#" layout="fullWidth" icon={<GraphBar/>} size="small" variant="neutral">詳細を見る</LinkButton>
+<LinkButton href="#" layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="large" variant="contained">さらに表示</LinkButton>
+<LinkButton href="#" layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="medium" variant="outlined">もっと見る</LinkButton>
+<LinkButton href="#" layout="fullWidth" icon={<ChevronDownBold/>} iconPosition="end" size="small" variant="neutral">さらに表示</LinkButton>
   `}
 />
 
 <Source
   language='html'
   code={`
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>応援を送る</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>ブログを書く</a>
-<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>修正する</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained spui-LinkButton--iconstart" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>応援を送る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined spui-LinkButton--iconstart" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>ブログを書く</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral spui-LinkButton--iconstart" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>修正する</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--large spui-LinkButton--contained spui-LinkButton--iconend" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--large"><svg /></span>さらに表示</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--medium spui-LinkButton--outlined spui-LinkButton--iconend" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--medium"><svg /></span>もっと見る</a>
+<a class="spui-LinkButton spui-LinkButton--fullWidth spui-LinkButton--small spui-LinkButton--neutral spui-LinkButton--iconend" href="#"><span class="spui-LinkButton-icon spui-LinkButton-icon--small"><svg /></span>さらに表示</a>
   `}
 />
 

--- a/packages/spindle-ui/src/LinkButton/LinkButton.tsx
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.tsx
@@ -13,6 +13,7 @@ interface Props
   size?: Size;
   variant?: Variant;
   icon?: React.ReactNode;
+  iconPosition?: 'start' | 'end';
 }
 
 const BLOCK_NAME = 'spui-LinkButton';
@@ -25,13 +26,22 @@ export const LinkButton = forwardRef<HTMLAnchorElement, Props>(
       size = 'large',
       variant = 'contained',
       icon,
+      iconPosition = 'start',
       ...rest
     }: Props,
     ref,
   ) {
     return (
       <a
-        className={`${BLOCK_NAME} ${BLOCK_NAME}--${layout} ${BLOCK_NAME}--${size} ${BLOCK_NAME}--${variant}`}
+        className={[
+          BLOCK_NAME,
+          `${BLOCK_NAME}--${layout}`,
+          `${BLOCK_NAME}--${size}`,
+          `${BLOCK_NAME}--${variant}`,
+          icon && `${BLOCK_NAME}--icon${iconPosition}`,
+        ]
+          .filter(Boolean)
+          .join(' ')}
         ref={ref}
         {...rest}
       >


### PR DESCRIPTION
## 概要

LinkButtonコンポーネントのIcon位置が左のみ対応していたのを、左右に対応できるようにしました。

<img width="640" alt="スクリーンショット 2023-07-28 10 46 53" src="https://github.com/openameba/spindle/assets/40178733/89500230-07d2-4de6-b295-794df160d2f0">

※ iconを指定した場合に初期値として左を選択させることで、破壊的変更にならないようにしています。