### PR TITLE
fix(spindle-ui): invalid AppealModal background-color type

### DIFF
--- a/packages/spindle-ui/src/Modal/AppealModal.css
+++ b/packages/spindle-ui/src/Modal/AppealModal.css
@@ -220,7 +220,7 @@ html.spui-AppealModal--open {
 
   .spui-AppealModal-closeIconButton {
     /* stylelint-disable plugin/selector-bem-pattern */
-    --IconButton--neutral-backgroundColor: none;
+    --IconButton--neutral-backgroundColor: transparent;
     --IconButton--neutral-onHover-backgroundColor: var(
       --color-surface-tertiary
     );


### PR DESCRIPTION
## 概要

`backgroud-color: none`がinvalidというエラーが出ていたので、transparentに変更しました。