### PR TITLE
test(spindle-ui): check aria attributes in Breadcrumb

### DIFF
--- a/packages/spindle-ui/setup-tests.ts
+++ b/packages/spindle-ui/setup-tests.ts
@@ -1,1 +1,3 @@
 import '@testing-library/jest-dom';
+
+HTMLElement.prototype.scrollTo = jest.fn();

--- a/packages/spindle-ui/src/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/spindle-ui/src/Breadcrumb/Breadcrumb.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { BreadcrumbList, BreadcrumbItem } from './';
+
+describe('<Breadcrumb />', () => {
+  test('having aria attributes', () => {
+    render(
+      <BreadcrumbList>
+        <BreadcrumbItem href="/top">Top</BreadcrumbItem>
+        <BreadcrumbItem href="/team">Team</BreadcrumbItem>
+        <BreadcrumbItem href="/about" current>
+          Amebaとは
+        </BreadcrumbItem>
+      </BreadcrumbList>,
+    );
+
+    expect(screen.getByRole('navigation').getAttribute('aria-label')).toEqual(
+      'パンくずリスト',
+    );
+    expect(screen.getByText('Amebaとは').getAttribute('aria-current')).toEqual(
+      'page',
+    );
+  });
+});


### PR DESCRIPTION
[BreadcrumbのDesign Doc](https://github.com/openameba/spindle/pull/770)を見ていく中で、`aria-*`の確認できていないなあだったのでテストを追加しました。

> パンくずリストのnav要素に `aria-label="パンくずリスト"`、現在位置には `aria-current="page"` を付与している
