### PR TITLE
build(spindle-syntax-themes): change port to 5001

### DIFF
--- a/packages/spindle-syntax-themes/acot.config.js
+++ b/packages/spindle-syntax-themes/acot.config.js
@@ -3,7 +3,7 @@ module.exports = {
   connection: {
     command: 'yarn serve',
   },
-  origin: 'http://localhost:5000',
+  origin: 'http://localhost:5001',
   paths: ['/', '/?theme=dark'],
   rules: {
     '@acot/wcag/focusable-has-indicator': 'warn',

--- a/packages/spindle-syntax-themes/package.json
+++ b/packages/spindle-syntax-themes/package.json
@@ -21,7 +21,7 @@
     "build:example": "npx rimraf public && npx cpx '*.{html,css,ico}' public",
     "predeploy": "yarn build:example",
     "deploy": "firebase deploy --only hosting",
-    "serve": "npx serve -p 5000"
+    "serve": "npx serve -p 5001"
   },
   "devDependencies": {
     "@acot/acot-config": "^0.0.19",


### PR DESCRIPTION
ref: https://developer.apple.com/forums/thread/682332

MacOS Montereyで、AirPlayの機能で5000ポートを常に使うようになってしまったために、local開発時に毎度5000ポートが利用できなくなっていました。
特段5000にこだわりがあるわけでもないので変更します。

https://github.com/openameba/spindle/pull/322#issuecomment-1670553671 も関連して発生しているようですが、なぜ #322　では ~~毎度~~ 高頻度で発生して他のPRではごく稀にしか発生しないのかははっきりしていません。
> パラレルに動いてるのでもしかしたらたまたま5000を専有するやつが競合するタイミングがあって……みたいなのなんだろうなあとは思いつつ…… by @sasaplus1 

## 確認方法

Montereyの人：
1. システム環境設定→共有→左側の「AirPlayレシーバー」にチェックが入っていることを確認
2. `$ yarn test` 実行して全て成功すること
3. Workflowのtestが成功していることを確認

それ以外の人：なんだろう 🤔 
1. `$ yarn test` 実行して全て成功すること
2. Workflowのtestが成功していることを確認

・・かなw