### PR TITLE
fix(spindle-ui): SegmentedControlに渡っている値が更新された際の処理を追加

### DIFF
--- a/packages/spindle-ui/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/spindle-ui/src/SegmentedControl/SegmentedControl.test.tsx
@@ -101,6 +101,23 @@ describe('<SegmentedControl />', () => {
     expect(result.current.selectedId).toEqual(options[2].id);
   });
 
+  test('should be reflected if the received selectedId changes', async () => {
+    const { rerender } = render(
+      <SegmentedControl selectedId={options[0].id} options={options} />,
+    );
+    expect(
+      screen.getByText(options[0].label).getAttribute('aria-checked'),
+    ).toEqual('true');
+
+    rerender(<SegmentedControl selectedId={options[1].id} options={options} />);
+    expect(
+      screen.getByText(options[0].label).getAttribute('aria-checked'),
+    ).toEqual('false');
+    expect(
+      screen.getByText(options[1].label).getAttribute('aria-checked'),
+    ).toEqual('true');
+  });
+
   test('a11y', async () => {
     const user = userEvent.setup();
 

--- a/packages/spindle-ui/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/spindle-ui/src/SegmentedControl/SegmentedControl.tsx
@@ -56,7 +56,9 @@ export const SegmentedControl: React.FC<Props> = ({
     // selectedIdがどの項目にも一致しない場合は最初の項目を選択する
     if (!options.some((option) => option.id === userSelectedId)) {
       setSelectedId(options[0].id);
+      return;
     }
+    setSelectedId(userSelectedId);
   }, [options, userSelectedId]);
 
   const handleClick = useCallback(


### PR DESCRIPTION
## 概要

`SegmentedControl` を利用する際に渡している `selectedId` が利用元で更新された際に、 `SegmentedControl`内で保持している `selectedId` が更新されていなかったので、修正しました。

## 対応方法

`userSelectedId`(渡ってきた`selectedId`)が更新された際の処理を追加しました。

## 確認方法

テストケースをアップデートしたので不備が無いか確認をお願いします。