### PR TITLE
ci: fix VRT condition

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request_target:
+    paths:
+      - 'packages/spindle-ui/**'
   workflow_dispatch:
 
 jobs:
@@ -18,13 +20,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: 'refs/pull/${{ github.event.number }}/merge'
-      - id: changes
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v2
-        with:
-          filters: |
-            ui:
-              - 'packages/spindle-ui/**'
       - run: echo 'RESULT=false' >> "$GITHUB_ENV"
       - name: execute if triggered by members
         if: >
@@ -35,14 +30,12 @@ jobs:
         if: >
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name != github.repository &&
-          contains(github.event.pull_request.labels.*.name, 'allow execute workflow') &&
-          steps.changes.outputs.ui == 'true'
+          contains(github.event.pull_request.labels.*.name, 'allow execute workflow')
         run: echo 'RESULT=true' >> "$GITHUB_ENV"
       - name: execute if the PR from a this repository
         if: >
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          steps.changes.outputs.ui == 'true'
+          github.event.pull_request.head.repo.full_name == github.repository
         run: echo 'RESULT=true' >> "$GITHUB_ENV"
       - id: condition
         run: echo "result=${RESULT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -44,11 +44,6 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository &&
           steps.changes.outputs.ui == 'true'
         run: echo 'RESULT=true' >> "$GITHUB_ENV"
-      - name: ignoring if triggered by bot
-        if: >
-          github.actor == 'dependabot[bot]' ||
-          github.actor == 'renovate[bot]'
-        run: echo 'RESULT=false' >> "$GITHUB_ENV"
       - id: condition
         run: echo "result=${RESULT}" >> "$GITHUB_OUTPUT"
   visual_regression_test:


### PR DESCRIPTION
- github.actorがボットだった場合の処理を削除しました
- パスのフィルターにGitHub Actions標準の構文を使うようにしました
    - typesやbranchesやpathsなど、複数の条件を指定すると意図に反するような動きをするが、単体で使用するのなら問題ないと思ったため