### PR TITLE
ci: add permissions to releasing job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
   releaseing:
     name: releaseing
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
https://github.com/openameba/ameba-color-palette.css/pull/93#discussion_r1277009262 により追加しました。

Error: https://github.com/openameba/spindle/actions/runs/6007814783/job/16294523111
