### PR TITLE
ci(spindle-ui): add repository url

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -39,6 +39,10 @@
     "prepublishOnly": "yarn build && yarn cp"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openameba/spindle.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
[準備が足りていなかった](https://docs.npmjs.com/generating-provenance-statements#:~:text=Ensure%20your%20package.json%20is%20configured%20with%20a%20public%20repository%20that%20matches%20where%20you%20are%20publishing%20with%20provenance%20from.)ようなので、`repository` を追加しました。ひとまずリリース対象のspindle-uiに入れてみます。

ref: https://github.com/openameba/ameba-color-palette.css/blob/0d2ec79028abb272b8a8249f49dadb52998c4f09/package.json#L9-L12

> Failed to validate repository information: package.json: “repository.url” is “undefined”, expected to match “https://github.com/openameba/spindle” from provenance https://github.com/openameba/spindle/actions/runs/6007998381/job/16294989755