### PR TITLE
ci: set permissions to create PR

### DIFF
--- a/.github/workflows/build-icon-from-figma.yml
+++ b/.github/workflows/build-icon-from-figma.yml
@@ -18,6 +18,10 @@ on:
         default: '[]'
         required: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build_icons:
     runs-on: ubuntu-latest
@@ -48,7 +52,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: 'feat(spindle-icons): update icons'

--- a/.github/workflows/build-icon.yml
+++ b/.github/workflows/build-icon.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: '["ALL"]'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build_icons:
     runs-on: ubuntu-latest
@@ -38,7 +42,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: 'feat(spindle-icons): update icons'

--- a/.github/workflows/build-tokens.yml
+++ b/.github/workflows/build-tokens.yml
@@ -3,6 +3,10 @@ name: build design tokens via webhook
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build_tokens:
     runs-on: ubuntu-latest
@@ -33,7 +37,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: 'feat(spindle-tokens): update design tokens'


### PR DESCRIPTION
別件で[peter-evans/create-pull-requesを眺めていて](https://github.com/peter-evans/create-pull-request#:~:text=(permissions%20contents%3A%20write%20and%20pull%2Drequests%3A%20write))、permissions設定で[諦めかけていたPR Author指定](https://github.com/openameba/spindle/pull/797#issuecomment-1709344463)できるのでは？を試してみました。

できていそうな感じがします。
https://github.com/openameba/spindle/pull/802

