### PR TITLE
fix(spindle-ui): drop down appearance style

### DIFF
--- a/packages/spindle-ui/src/Form/DropDown.css
+++ b/packages/spindle-ui/src/Form/DropDown.css
@@ -11,7 +11,7 @@
    * Layout should be set to have appropriate width with longest option text.
    * Browsers automatically get the width from select element
   */
-  -webkit-appearance: listitem; /* To apply layout (font size, padding etc) to <select> in WebKit */
+  -webkit-appearance: none; /* To apply layout (font size, padding etc) to <select> in WebKit */
   box-sizing: border-box;
   font-size: 1em;
   margin: 0;


### PR DESCRIPTION
### 概要
DropDownでstyle崩れ（safariのみ）が発生していたため修正しました。
原因としては `listitem` を使うことでsafariの場合、幅を担保するための`padding`が受け付けなくなっていました。
なので全部リセットする `none` に変更した次第です。

### 修正前
![スクリーンショット 2023-10-19 15 08 23](https://github.com/openameba/spindle/assets/80251820/174a380c-608e-4aae-88e2-e33d06a9d464)

### 修正後
![スクリーンショット 2023-10-19 14 50 20](https://github.com/openameba/spindle/assets/80251820/8eafe6c4-2ed5-493e-af29-1879a1b040c3)

### レビュー期日
すでにリリース済みのコンポーネントのためできるだけ早いとありがたいです。