### PR TITLE
test(spindle-ui): fix import jest-dom types

### DIFF
--- a/packages/spindle-hooks/tsconfig.json
+++ b/packages/spindle-hooks/tsconfig.json
@@ -8,6 +8,7 @@
     "paths": {
       "react": ["./node_modules/@types/react"]
     },
+    "types": ["node", "jest", "@testing-library/jest-dom"],
     "jsx": "react"
   },
   "include": [

--- a/packages/spindle-ui/tsconfig.json
+++ b/packages/spindle-ui/tsconfig.json
@@ -8,6 +8,7 @@
     "paths": {
       "react": ["./node_modules/@types/react"]
     },
+    "types": ["node", "jest", "@testing-library/jest-dom"],
     "jsx": "react"
   },
   "include": [


### PR DESCRIPTION
https://github.com/openameba/spindle/pull/844#issuecomment-1826990725 のtestが落ちるのを修正します。

## 原因と修正内容

おそらくjest-domを[v6系](https://github.com/testing-library/jest-dom/releases/tag/v6.0.0)に上げてから発生しているのではと想像しています。（v6.0.0でtypes周りが大きく変わっています）
v6以前は `@types/testing-library__jest-dom"` を使っていたようですが、v6から[jest-dom内で自前の型定義ファイルを作成するようになった](https://github.com/testing-library/jest-dom/pull/511/files#diff-baec3cdaf936322986fb071fbeed16b784ac14926409ebba5469ce6d6ce054c4)みたいです。

> testing-library/jest-domは独自の型定義を提供するので、@types/testing-library__jest-domをインストールする必要はありません！

https://www.npmjs.com/package/@types/testing-library__jest-dom （翻訳）

とのことなので `@types/testing-library__jest-dom` ではなく `testing-library/jest-dom` をコンパイルする必要がありそうです。
[tsconfigのtypesはデフォルトで `@types`パッケージをコンパイルします](https://www.typescriptlang.org/tsconfig#types)が、`testing-library/jest-dom`は含まれないので追加します。

## 関連リンク

- https://stackoverflow.com/a/61636112