### PR TITLE
ci: lint commit messages

### DIFF
--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -1,0 +1,34 @@
+name: lint commit message(s)
+
+on:
+  - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: Asia/Tokyo
+
+jobs:
+  lint-commit-message:
+    name: lint commit message(s)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-v2
+      - run: yarn install --frozen-lockfile
+      - run: >
+          npx commitlint
+          --from "$(git merge-base "origin/${GITHUB_BASE_REF}" "origin/${GITHUB_HEAD_REF}")"
+          --to "origin/${GITHUB_HEAD_REF}"
+          --verbose


### PR DESCRIPTION
## 課題

https://github.com/openameba/spindle/pull/858#issuecomment-1845117345 のように人間がコミットメッセージについてレビューする必要がある

## 対応内容

`commitlint`がインストールされるよう`package.json`に記述されているのでそれを利用してCIで検査させる

## 期待する状態

CIにある程度機械的にコミットメッセージを検査させ、人間が楽をする
