### PR TITLE
ci: fix restore cache

### DIFF
--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -24,7 +24,9 @@ jobs:
           node-version: 16
       - uses: actions/cache@v3
         with:
-          path: '**/node_modules'
+          path: |
+            node_modules
+            */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-v2
       - run: yarn install --frozen-lockfile
       - run: >

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -14,7 +14,7 @@ jobs:
   lint-commit-message:
     name: lint commit message(s)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
https://github.com/openameba/spindle/actions/runs/7175709702/job/19539460009 等、タイムアウトしてしまうことがあったので改善しました。

修正内容としては以下の2点です。

- そもそもキャッシュの展開がうまくいっておらずモジュールを新規ダウンロードしてしまっていたこと
- タイムアウトの指定が短いので延長しました
