### PR TITLE
ci: set firebase-tools version to deploy

### DIFF
--- a/.github/workflows/deploy-highlightjs-styles-preview.yml
+++ b/.github/workflows/deploy-highlightjs-styles-preview.yml
@@ -25,3 +25,4 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 30d
           entryPoint: ./packages/spindle-syntax-themes/
+          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-highlightjs-styles.yml
+++ b/.github/workflows/deploy-highlightjs-styles.yml
@@ -27,3 +27,4 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           entryPoint: ./packages/spindle-syntax-themes/
           channelId: live
+          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-hooks-catalog.yml
+++ b/.github/workflows/deploy-hooks-catalog.yml
@@ -33,3 +33,4 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           entryPoint: ./packages/spindle-hooks/
           channelId: live
+          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-hoooks-preview.yml
+++ b/.github/workflows/deploy-hoooks-preview.yml
@@ -25,3 +25,4 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           entryPoint: ./packages/spindle-hooks/
+          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-theme-switch-preview.yml
+++ b/.github/workflows/deploy-theme-switch-preview.yml
@@ -26,3 +26,4 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 30d
           entryPoint: ./packages/spindle-theme-switch/
+          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-theme-switch.yml
+++ b/.github/workflows/deploy-theme-switch.yml
@@ -27,3 +27,4 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           entryPoint: ./packages/spindle-theme-switch/
           channelId: live
+          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-ui-catalog.yml
+++ b/.github/workflows/deploy-ui-catalog.yml
@@ -35,3 +35,4 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           entryPoint: ./packages/spindle-ui/
           channelId: live
+          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-ui-preview.yml
+++ b/.github/workflows/deploy-ui-preview.yml
@@ -47,3 +47,4 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 30d
           entryPoint: ./packages/spindle-ui/
+          firebaseToolsVersion: v12.9.1


### PR DESCRIPTION
[Firebase HostingにデプロイできずPRが取り込めない](https://github.com/openameba/spindle/pull/858#issuecomment-1849246603)ので、取り急ぎデプロイできるようにしました。

本質的にはnodeバージョンを上げるべきですが、変更範囲がFirebase関連以外にもあり、対応にやや時間を要するため[firebase-toolsのバージョン](https://github.com/firebase/firebase-tools/releases)を落として現状のnodeで動作するようにしています。

成功workflow: https://github.com/openameba/spindle/actions/runs/7189444688/job/19580966571