### PR TITLE
feat: node to version 18

### DIFF
--- a/.github/workflows/build-icon-from-figma.yml
+++ b/.github/workflows/build-icon-from-figma.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: restore lerna
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-icon.yml
+++ b/.github/workflows/build-icon.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: restore lerna
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-tokens.yml
+++ b/.github/workflows/build-tokens.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: restore lerna
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: restore lerna
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-highlightjs-styles-preview.yml
+++ b/.github/workflows/deploy-highlightjs-styles-preview.yml
@@ -15,14 +15,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: yarn build:example
       - name: deploy to preview channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           entryPoint: ./packages/spindle-syntax-themes/
-          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-highlightjs-styles.yml
+++ b/.github/workflows/deploy-highlightjs-styles.yml
@@ -17,14 +17,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: yarn build:example
       - name: deploy to live channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           entryPoint: ./packages/spindle-syntax-themes/
           channelId: live
-          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-hooks-catalog.yml
+++ b/.github/workflows/deploy-hooks-catalog.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: restore lerna
         uses: actions/cache@v3
         with:
@@ -29,8 +29,7 @@ jobs:
       - name: deploy to live channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           entryPoint: ./packages/spindle-hooks/
           channelId: live
-          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-hoooks-preview.yml
+++ b/.github/workflows/deploy-hoooks-preview.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: yarn storybook:build
       - name: deploy to preview channel
@@ -25,4 +25,3 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           entryPoint: ./packages/spindle-hooks/
-          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-theme-switch-preview.yml
+++ b/.github/workflows/deploy-theme-switch-preview.yml
@@ -15,15 +15,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn cp
       - name: deploy to preview channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           entryPoint: ./packages/spindle-theme-switch/
-          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-theme-switch.yml
+++ b/.github/workflows/deploy-theme-switch.yml
@@ -17,14 +17,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: deploy to live channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           entryPoint: ./packages/spindle-theme-switch/
           channelId: live
-          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-ui-catalog.yml
+++ b/.github/workflows/deploy-ui-catalog.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: restore lerna
         uses: actions/cache@v3
         with:
@@ -31,8 +31,7 @@ jobs:
       - name: deploy to live channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           entryPoint: ./packages/spindle-ui/
           channelId: live
-          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/deploy-ui-preview.yml
+++ b/.github/workflows/deploy-ui-preview.yml
@@ -35,7 +35,7 @@ jobs:
           ref: 'refs/pull/${{ github.event.number }}/merge'
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: |
           yarn lerna run --scope @openameba/spindle-hooks build
@@ -43,8 +43,7 @@ jobs:
       - name: deploy to preview channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           entryPoint: ./packages/spindle-ui/
-          firebaseToolsVersion: v12.9.1

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
       - name: restore lerna
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: restore lerna
         uses: actions/cache@v3
         with:

--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: restore lerna
         uses: actions/cache@v3
         with:

--- a/packages/spindle-hooks/package.json
+++ b/packages/spindle-hooks/package.json
@@ -4,9 +4,6 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-  },
   "scripts": {
     "test": "run-p bundlesize test:interaction",
     "test:interaction": "jest --passWithNoTests",

--- a/packages/spindle-ui/bundlesize.config.json
+++ b/packages/spindle-ui/bundlesize.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "./dist/SnackBar/*.mjs",
-      "maxSize": "1.4 kB"
+      "maxSize": "1.5 kB"
     },
     {
       "path": "./dist/Toast/*.mjs",


### PR DESCRIPTION
[firebase tools v13.0.0](https://github.com/firebase/firebase-tools/releases/tag/v13.0.0)以降からNode.js v16以下をサポートしなくなりました。

現状は、firebase toolsのバージョンを下げて対応(https://github.com/openameba/spindle/pull/866) していますが、本来はNode.js側を上げるべきなのでこのPRでそちらの対応を行いました！