### PR TITLE
chore: update versioning commit message

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
   "includeMergedTags": true,
   "command": {
     "version": {
-      "message": "chore(release): publish",
+      "message": "chore: publish",
       "allowBranch": ["version/*", "release/*"]
     }
   },


### PR DESCRIPTION
Versioning時のコミットメッセージをcommitlintで通るように変更しました。`useWorkspaces: true` でも解決する気はしますが、ここのメッセージにこだわりはないので変更しました。

> WARN EWORKSPACES To fix this and have Lerna use workspaces to resolve packages, set `useWorkspaces: true` in lerna.json.
https://github.com/openameba/spindle/actions/runs/7204624689/job/19626362168?pr=868

ref: https://github.com/openameba/spindle/pull/868#issuecomment-1855393308