### PR TITLE
docs(spindle-hooks,spindle-ui): browser support

### DIFF
--- a/packages/spindle-hooks/README.md
+++ b/packages/spindle-hooks/README.md
@@ -46,7 +46,7 @@ Spindle HooksはSpindle UIと同様にmodule版の配信もしています。利
 
 ## ブラウザサポート
 
-Spindle HooksはFirefox、Google Chrome、Microsoft Edge、Safariの最新版とInternet Explorer 11で動作確認しています。
+Spindle HooksはGoogle Chrome最新版で動作確認しています。それ以外のブラウザでは[Amebaの推奨環境](https://helps.ameba.jp/faq/others/5510/top_08.html)に基づき表示・動作に問題がある場合は対応していきます。
 
 ## 開発方法
 

--- a/packages/spindle-ui/README.md
+++ b/packages/spindle-ui/README.md
@@ -88,7 +88,7 @@ Spindle UIのスタイルは、名前空間(`spui`)をもったCSSとして定�
 ただし、CSSファイルサイズやファイル数が不必要に大きくなり、CDNサーバが遅延の原因になる可能性があるため**本番Webアプリケーションでの利用は推奨していません**。
 
 ## ブラウザサポート
-Spindle UIはFirefox、Google Chrome、Microsoft Edge、Safariの最新版とInternet Explorer 11で動作確認しています。ただし、CSS custom propertiesを使用しているため、Internet Explorer 11での利用時には[ie11-custom-properties](https://www.npmjs.com/package/ie11-custom-properties)や[css-vars-ponyfill](https://github.com/jhildenbiddle/css-vars-ponyfill)などpolyfillとの併用が必要です。
+Spindle UIはGoogle Chrome最新版で動作確認しています。それ以外のブラウザでは[Amebaの推奨環境](https://helps.ameba.jp/faq/others/5510/top_08.html)に基づき表示・動作に問題がある場合は対応していきます。
 
 ## 開発方法
 


### PR DESCRIPTION
Browser Supportの記述が更新されていなかったので対応しました (本当はv1の時にしたかった)。


> AmebaとしてはIE11の動作保証を切っており、UIの崩れ等は保証していないのでIEでレイアウト崩れてもいいかな？はYesになりますね〜。
https://helps.ameba.jp/faq/others/5510/top_08.html
https://helps.ameba.jp/faq/ameba/0215/post_1111.html
by :pagu:

