### PR TITLE
Visual regression test with permissions

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -48,12 +48,12 @@ jobs:
       - run: sudo apt-get --yes update
       - run: sudo apt-get --yes install fonts-noto
       - if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: 'refs/pull/${{ github.event.number }}/merge'
       - if: github.event_name != 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4

--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -77,7 +77,8 @@ jobs:
           --outDir packages/spindle-ui/.reg-suit/actual_images/
           --serverCmd 'npx serve -p 5000 packages/spindle-ui/public'
           http://localhost:5000
-      - run: git checkout ${{ github.head_ref || github.ref_name }}
+      - name: workaround for detached HEAD
+        run: git checkout ${{ github.head_ref || github.ref_name }}
       - run: |
           printf -- '%s' "$GOOGLE_APPLICATION_CREDENTIALS_JSON" | base64 --decode > "${PWD}/storage-key.json"
           export GOOGLE_APPLICATION_CREDENTIALS="${PWD}/storage-key.json"

--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/spindle-ui/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check_condition:
     runs-on: ubuntu-latest
@@ -16,11 +19,8 @@ jobs:
     outputs:
       result: ${{ steps.condition.outputs.result }}
     steps:
-      - if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
-        with:
-          ref: 'refs/pull/${{ github.event.number }}/merge'
-      - run: echo 'RESULT=false' >> "$GITHUB_ENV"
+      - name: default to not running
+        run: echo 'RESULT=false' >> "$GITHUB_ENV"
       - name: execute if triggered by members
         if: >
           github.event_name == 'push' ||
@@ -28,13 +28,13 @@ jobs:
         run: echo 'RESULT=true' >> "$GITHUB_ENV"
       - name: execute if the PR from a forked repository, it have the [allow execute workflow] label
         if: >
-          github.event_name == 'pull_request' &&
+          github.event_name == 'pull_request_target' &&
           github.event.pull_request.head.repo.full_name != github.repository &&
           contains(github.event.pull_request.labels.*.name, 'allow execute workflow')
         run: echo 'RESULT=true' >> "$GITHUB_ENV"
       - name: execute if the PR from a this repository
         if: >
-          github.event_name == 'pull_request' &&
+          github.event_name == 'pull_request_target' &&
           github.event.pull_request.head.repo.full_name == github.repository
         run: echo 'RESULT=true' >> "$GITHUB_ENV"
       - id: condition
@@ -47,12 +47,12 @@ jobs:
     steps:
       - run: sudo apt-get --yes update
       - run: sudo apt-get --yes install fonts-noto
-      - if: github.event_name == 'pull_request'
+      - if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: 'refs/pull/${{ github.event.number }}/merge'
-      - if: github.event_name != 'pull_request'
+      - if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
I suspect this is the explanation for https://github.com/openameba/spindle/pull/645#issuecomment-1396540064

Note that this PR should be considered very scary. What you had previously was dangerous in that it was a workflow with full write permissions that could run from a PR (like this one), but because of the logic errors being fixed here, it didn't do everything that it was trying to do (namely conditionally run for PRs from forks).

With the changes here, you will be *running* the untrustworthy code (or in places the merge of the untrustworthy code).

Thus, if you are going to do this, you should make sure that:
1. `secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON` can *only* be used to write to `secrets.GCS_BUCKET_NAME_REG_SUIT` (probably without being able to delete existing content)
2. `secrets.REG_SUIT_NOTIFY_CLIENT_ID` is a relatively harmless thing for someone to have access to

Also note that you can't test this PR from this PR (the event for a `pull_request_target` is dispatched to the version of the workflow in the target branch -- it is not sent to the version of the file as seen in the head of the pr or the merge of the PR), if you're interested in testing it, you should make another repository with this code and a second repository that's a fork of that repository and create a PR from the second repository to the first.

Note that to the greatest extent possible, it's much better to have a distinct job w/ elevated privileges that's responsible for processing the output generated from an untrusted code run as opposed to giving untrusted code access to secrets/write permissions. -- As you're already using `needs`, adding an extra `needs` isn't a big deal -- you can use `actions/upload-artifact` and `actions/download-artifact` or similar to pass data between the untrustworthy job and the writing job.