### PR TITLE
fix(spindle-ui): change padding to correct Button height

### DIFF
--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -77,24 +77,27 @@
   border-radius: calc(48em / 16);
   font-size: 1em;
   min-height: 48px;
-  padding-left: 16px;
-  padding-right: 16px;
+  padding: 8px 16px;
 }
 
 .spui-Button--medium {
   border-radius: calc(40em / 14);
   font-size: 0.875em;
   min-height: 40px;
-  padding-left: 16px;
-  padding-right: 16px;
+  padding: 8px 16px;
 }
 
 .spui-Button--small {
   border-radius: calc(32em / 13);
   font-size: 0.8125em;
   min-height: 32px;
-  padding-left: 10px;
-  padding-right: 10px;
+  padding: 6px 10px;
+}
+
+/* Bordered small buttons exceeds the minimum height with the default padding */
+.spui-Button--small:is(.spui-Button--outlined, .spui-Button--danger) {
+  padding-bottom: 5px;
+  padding-top: 5px;
 }
 
 /*
@@ -117,9 +120,6 @@
   background-color: var(--Button--contained-backgroundColor);
   border: none;
   color: var(--Button--contained-color);
-  /* Button variants have different vertical padding to normalize height */
-  padding-bottom: 8px;
-  padding-top: 8px;
 }
 
 .spui-Button--contained:active {
@@ -137,8 +137,6 @@
   background-color: transparent;
   border: 2px solid var(--Button--outlined-borderColor);
   color: var(--Button--outlined-color);
-  padding-bottom: 6px;
-  padding-top: 6px;
 }
 
 .spui-Button--outlined:active {
@@ -156,8 +154,6 @@
   background-color: var(--Button--lighted-backgroundColor);
   border: none;
   color: var(--Button--lighted-color);
-  padding-bottom: 8px;
-  padding-top: 8px;
 }
 
 .spui-Button--lighted:active {
@@ -175,8 +171,6 @@
   background-color: var(--Button--neutral-backgroundColor);
   border: none;
   color: var(--Button--neutral-color);
-  padding-bottom: 8px;
-  padding-top: 8px;
 }
 
 .spui-Button--neutral:active {
@@ -194,8 +188,6 @@
   background-color: transparent;
   border: 2px solid var(--Button--danger-borderColor);
   color: var(--Button--danger-color);
-  padding-bottom: 6px;
-  padding-top: 6px;
 }
 
 .spui-Button--danger:active {

--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -75,24 +75,30 @@
   border-radius: calc(48em / 16);
   font-size: 1em;
   min-height: 48px;
-  padding-left: 16px;
-  padding-right: 16px;
+  padding: 8px 16px;
 }
 
 .spui-LinkButton--medium {
   border-radius: calc(40em / 14);
   font-size: 0.875em;
   min-height: 40px;
-  padding-left: 16px;
-  padding-right: 16px;
+  padding: 8px 16px;
 }
 
 .spui-LinkButton--small {
   border-radius: calc(32em / 13);
   font-size: 0.8125em;
   min-height: 32px;
-  padding-left: 10px;
-  padding-right: 10px;
+  padding: 6px 10px;
+}
+
+/* Bordered small buttons exceeds the minimum height with the default padding */
+.spui-LinkButton--small:is(
+    .spui-LinkButton--outlined,
+    .spui-LinkButton--danger
+  ) {
+  padding-bottom: 5px;
+  padding-top: 5px;
 }
 
 /*
@@ -115,9 +121,6 @@
   background-color: var(--LinkButton--contained-backgroundColor);
   border: none;
   color: var(--LinkButton--contained-color);
-  /* Button variants have different vertical padding to normalize height */
-  padding-bottom: 8px;
-  padding-top: 8px;
 }
 
 .spui-LinkButton--contained:active {
@@ -135,8 +138,6 @@
   background-color: transparent;
   border: 2px solid var(--LinkButton--outlined-borderColor);
   color: var(--LinkButton--outlined-color);
-  padding-bottom: 6px;
-  padding-top: 6px;
 }
 
 .spui-LinkButton--outlined:active {
@@ -154,8 +155,6 @@
   background-color: var(--LinkButton--lighted-backgroundColor);
   border: none;
   color: var(--LinkButton--lighted-color);
-  padding-bottom: 8px;
-  padding-top: 8px;
 }
 
 .spui-LinkButton--lighted:active {
@@ -173,8 +172,6 @@
   background-color: var(--LinkButton--neutral-backgroundColor);
   border: none;
   color: var(--LinkButton--neutral-color);
-  padding-bottom: 8px;
-  padding-top: 8px;
 }
 
 .spui-LinkButton--neutral:active {
@@ -192,8 +189,6 @@
   background-color: transparent;
   border: 2px solid var(--LinkButton--danger-borderColor);
   color: var(--LinkButton--danger-color);
-  padding-bottom: 6px;
-  padding-top: 6px;
 }
 
 .spui-LinkButton--danger:active {


### PR DESCRIPTION
Buttonの高さがFigmaと異なっていたので、修正しました。

元々「/* Button variants have different vertical padding to normalize height */」とコメントがあったのでvariantごとに設定される前提のようでしたが、現状のFigmaではsizeごとで良さそうなのでそちらに変更しています。~また、min-heightが設定されており、中央位置配置はFlexboxで行なっているので上下のpaddingは0px指定に変更しました。~

また、[サイズごとに上下余白が指定されている](https://www.figma.com/file/vVkCe93sDd0NK6JP5DmQOt/Spindle-UI-(Community)?type=design&node-id=367-44426&mode=design&t=7XmP83ZLvJLtifw1-0)ので揃えました。

![Text Size](https://github.com/openameba/spindle/assets/869023/b24f3cbd-e64c-4d37-a5c9-4c50dbc0975b)

※ Smallボタンは6pxに変更予定です by @MasatoHonda 



Figma: https://www.figma.com/file/vVkCe93sDd0NK6JP5DmQOt/Spindle-UI-(Community)?node-id=367%3A44210&mode=dev

fix #368
