### PR TITLE
chore: updates to React client rendering API

### DIFF
--- a/examples/css-modules/src/main.tsx
+++ b/examples/css-modules/src/main.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { SpindleButton } from './SpindleButton';
 
 // Ameba color palette should be loaded before using Spindle UI
@@ -14,4 +14,6 @@ const App = () => (
   </>
 );
 
-ReactDOM.render(<App />, document.body);
+const container = document.body;
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/preact/src/main.tsx
+++ b/examples/preact/src/main.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { SpindleButton } from './SpindleButton';
 
 // Ameba color palette should be loaded before using Spindle UI
@@ -14,4 +14,6 @@ const App = () => (
   </>
 );
 
-ReactDOM.render(<App />, document.body);
+const container = document.body;
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/styled-components/src/main.tsx
+++ b/examples/styled-components/src/main.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import styled, { createGlobalStyle } from 'styled-components';
 import { SpindleButton } from './SpindleButton';
 
@@ -26,4 +26,6 @@ const App = () => (
   </>
 );
 
-ReactDOM.render(<App />, document.body);
+const container = document.body;
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
Task [build design tokens via webhook](https://github.com/openameba/spindle/actions/workflows/build-tokens.yml) を実行したいですが、エラー(ReactDOM.render is no longer supported in React 18) が出るので対応しました。

※ example用途のディレクトリなのでソースコード変更しましたが、動作確認は~あんまり~してません

ref: https://github.com/openameba/spindle/actions/runs/7326304838/job/19951823465