### PR TITLE
ci: set permissions for firebase hosting preview

### DIFF
--- a/.github/workflows/deploy-highlightjs-styles-preview.yml
+++ b/.github/workflows/deploy-highlightjs-styles-preview.yml
@@ -11,6 +11,10 @@ jobs:
     defaults:
       run:
         working-directory: ./packages/spindle-syntax-themes/
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy-hoooks-preview.yml
+++ b/.github/workflows/deploy-hoooks-preview.yml
@@ -11,6 +11,10 @@ jobs:
     defaults:
       run:
         working-directory: ./packages/spindle-hooks/
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy-theme-switch-preview.yml
+++ b/.github/workflows/deploy-theme-switch-preview.yml
@@ -11,6 +11,10 @@ jobs:
     defaults:
       run:
         working-directory: ./packages/spindle-theme-switch/
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy-ui-preview.yml
+++ b/.github/workflows/deploy-ui-preview.yml
@@ -29,6 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_paths
     if: ${{ needs.check_paths.outputs.ui == 'true' }}
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Pull Request上でFirebase HostingのPreviewをする上で必要なpermissionsを設定しました。

検証は以下のブランチ (PR) でしています。
https://github.com/openameba/spindle/pull/885

- [pull-requestsはwriteがないとコメントできなかった](https://github.com/openameba/spindle/actions/runs/7328010807/job/19955656870)
- [contentsのreadがないとコメント内容が空だった](https://github.com/openameba/spindle/actions/runs/7328054607/job/19955765922)
