### PR TITLE
chore: disable commit scope for renovate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,6 +3,7 @@
     "config:base",
     ":label(renovate)",
     ":preserveSemverRanges",
+    ":semanticCommitScopeDisabled",
     ":timezone(Asia/Tokyo)",
     "group:definitelyTyped",
     "group:linters",


### PR DESCRIPTION
renovateが作るPRのコミットスコープをdepsから何もない`chore:`となるようにしました

- ref: https://github.com/openameba/spindle/pull/857#issuecomment-1869477922
- ref: https://docs.renovatebot.com/semantic-commits/#changing-the-semantic-commit-scope