### PR TITLE
docs(spindle-ui): fix to close with SubtleButton

### DIFF
--- a/packages/spindle-ui/src/Dialog/Dialog.stories.mdx
+++ b/packages/spindle-ui/src/Dialog/Dialog.stories.mdx
@@ -215,7 +215,7 @@ function DialogExample() {
         </Button>
         <SubtleButton size="medium">
           とじる
-        </Button>
+        </SubtleButton>
       </Dialog.ButtonGroup>
     </Dialog.StyleOnly>
   );


### PR DESCRIPTION
https://ameba-spindle.web.app/?path=/docs/dialog--button-column-with-subtle-button ← のexampleで、`SubtleButton`で閉じられるべきところが`Button`になっていたので修正しました！


| code  | Stroybook |
| ------------- | ------------- |
| https://github.com/openameba/spindle/blob/75b50c6656183551fc6aab28c22ff09fdb6d6e4f/packages/spindle-ui/src/Dialog/DialogExample.tsx#L118  | https://github.com/openameba/spindle/blob/75b50c6656183551fc6aab28c22ff09fdb6d6e4f/packages/spindle-ui/src/Dialog/Dialog.stories.mdx#L216-L218  |
