### PR TITLE
feat(spindle-ui): add `NavigationTab/UnderlineTab` component

### DIFF
--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.css
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.css
@@ -1,0 +1,213 @@
+.spui-UnderlineTab {
+  background-color: var(--color-surface-primary);
+}
+
+.spui-UnderlineTab--border {
+  border-bottom: 1px solid var(--color-border-low-emphasis);
+}
+
+.spui-UnderlineTab--scrollable {
+  position: relative;
+}
+
+.spui-UnderlineTab-container {
+  align-items: center;
+  display: flex;
+}
+
+.spui-UnderlineTab--scrollable .spui-UnderlineTab-container {
+  column-gap: 16px;
+  overflow-x: scroll;
+  padding: 0 16px;
+  scroll-behavior: smooth;
+}
+
+.spui-UnderlineTab-button {
+  background-color: transparent;
+  border: none;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  padding: 0 4px;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.spui-UnderlineTab--fixed .spui-UnderlineTab-button {
+  width: 100%;
+}
+
+.spui-UnderlineTab--scrollable .spui-UnderlineTab-button {
+  min-width: 44px;
+}
+
+.spui-UnderlineTab-button:hover {
+  background-color: var(--color-surface-tertiary);
+}
+
+.spui-UnderlineTab-button:focus {
+  border-radius: 4px;
+  outline: 2px solid var(--color-focus-clarity);
+  outline-offset: -2px;
+}
+
+.spui-UnderlineTab-button:not(:focus-visible) {
+  outline: none;
+}
+
+.spui-UnderlineTab-labelWrapper {
+  align-items: center;
+  column-gap: 6px;
+  display: flex;
+  margin: 0 auto;
+  max-width: 100%;
+  padding: 14px 0;
+  position: relative;
+  width: fit-content;
+}
+
+.spui-UnderlineTab-labelWrapper::after {
+  background-color: var(--color-border-accent-primary);
+  border-radius: 3px;
+  bottom: 0;
+  content: '';
+  height: 3px;
+  left: 50%;
+  min-width: 40px;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(-50%);
+  transition: opacity 0.35s ease-in-out;
+  width: 100%;
+}
+
+/* stylelint-disable-next-line  */
+.spui-UnderlineTab-button[aria-selected='true'] .spui-UnderlineTab-labelWrapper::after {
+  opacity: 1;
+}
+
+.spui-UnderlineTab-label {
+  color: var(--color-text-low-emphasis);
+  font-size: 0.875rem;
+  font-weight: bold;
+  line-height: 1.3;
+}
+
+.spui-UnderlineTab--fixed .spui-UnderlineTab-label {
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+/* stylelint-disable-next-line  */
+.spui-UnderlineTab-button[aria-selected='true'] .spui-UnderlineTab-label {
+  color: var(--color-text-accent-primary);
+}
+
+.spui-UnderlineTab-badge {
+  background-color: var(--color-surface-accent-primary);
+  border-radius: 8px;
+  box-sizing: border-box;
+  color: var(--color-text-high-emphasis-inverse);
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  font-weight: bold;
+  line-height: 1.3;
+  min-width: 20px;
+  padding: 1px 4px;
+}
+
+.spui-UnderlineTab-visuallyHidden {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+
+.spui-UnderlineTab-arrow {
+  background-color: var(--color-surface-primary);
+  bottom: 0;
+  height: fit-content;
+  margin: auto;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  transition:
+    opacity 0.35s ease-in-out,
+    visibility 0.35s ease-in-out;
+  visibility: hidden;
+  z-index: 1;
+}
+
+.spui-UnderlineTab-arrow.is-showed {
+  opacity: 1;
+  visibility: visible;
+}
+
+.spui-UnderlineTab-arrow::before {
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 10px;
+  z-index: -1;
+}
+
+.spui-UnderlineTab-arrow--left {
+  left: 0;
+}
+
+.spui-UnderlineTab-arrow--left::before {
+  background: linear-gradient(
+    270deg,
+    rgba(255, 255, 255, 0) 0,
+    var(--color-surface-primary) 100%
+  );
+  left: 44px; /* ボタンの横幅分 */
+}
+
+.spui-UnderlineTab-arrow--right {
+  right: 0;
+}
+
+.spui-UnderlineTab-arrow--right::before {
+  background: linear-gradient(
+    270deg,
+    var(--color-surface-primary) 0,
+    rgba(255, 255, 255, 0) 100%
+  );
+  right: 44px; /* ボタンの横幅分 */
+}
+
+.spui-UnderlineTab-arrowButton {
+  background-color: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--color-object-low-emphasis);
+  display: flex;
+  padding: 14px;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.spui-UnderlineTab-arrowButton:hover {
+  background-color: var(--color-surface-tertiary);
+}
+
+.spui-UnderlineTab-arrowButton:focus {
+  outline: 2px solid var(--color-focus-clarity);
+}
+
+.spui-UnderlineTab-arrowButton:not(:focus-visible) {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spui-UnderlineTab-button,
+  .spui-UnderlineTab-labelWrapper::after,
+  .spui-UnderlineTab-arrow,
+  .spui-UnderlineTab-arrowButton {
+    transition: 0.1ms;
+  }
+
+  .spui-UnderlineTab--scrollable .spui-UnderlineTab-container {
+    scroll-behavior: auto;
+  }
+}

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.stories.mdx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.stories.mdx
@@ -1,0 +1,249 @@
+import { Description, Meta, Source, Story } from '@storybook/addon-docs/blocks';
+import { UnderlineTab } from './UnderlineTab';
+import { actions } from '@storybook/addon-actions';
+
+# NavigationTab/UnderlineTab
+<Description>
+  NavigationTabは表示内容を伝え、切り替える事を目的としたコンポーネントです。ページ上部に配置し、ナビゲーション（Header）的役割を担うことを想定しています。
+</Description>
+
+<Meta title="NavigationTab/UnderlineTab" component={UnderlineTab} />
+
+<Source
+  language="javascript"
+  code={`import { UnderlineTab } from '@openameba/spindle-ui'`}
+/>
+
+<Source
+  language="css"
+  code={`@import './node_modules/@openameba/spindle-ui/NavigationTab/UnderlineTab/UnderlineTab.css'`}
+/>
+
+<Source
+  language="html"
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/NavigationTab/UnderlineTab/UnderlineTab.css">`}
+/>
+
+## NavigationTabの種類
+NavigationTabには、Underline/Capsule/Inlineの3種類が存在します（※CapsuleとInlineはこれから実装予定です）
+
+Component | 用途 | 数字バッチを表示できるか | 区切り線を表示できるか | 横スクロールできるか
+:-- | :-- | :-- | :-- | :-- |
+UnderlineTab | 最も汎用的なコンポーネントです。よりHeaderらしく使いたい時に利用してください。また、表示内容が類推し易い時に利用してください。 | ○ | ○ | ○ |
+CapsuleTab | UnderlineTabより象徴的に使ったり、目立たせたい時に利用してください。UnderlineTabと併用してサブナビゲーション的に利用することも可能です。 | × | ○ | ○ |
+InlineTab | NavigationTabのいずれかと並列に配置したい時に利用してください。ただし、横スクロールできないため項目数が少ない時のみ利用してください。 | × | × | × |
+
+## 指定できるプロパティ
+<Description>
+  - `defaultSelectedId`(必須): 初期選択状態にしたい項目の`id`を指定します。この`id`は`options`内のいずれかの`id`と一致している必要があります。
+</Description>
+<Description>
+  - `options`(必須): 各項目の情報を指定します。`id`（必須）は各項目を識別するためのもので、配列内で一意である必要があります。`label`（必須）はUnderlineTabに表示されるラベルです。`countBadge`（任意）は`label`右横に数字バッチを表示したい時に指定してください。
+</Description>
+<Description>
+  - `hasBorder`(任意): コンポーネント下に区切り線を表示するかどうかを指定します。デフォルトは`false`です。
+</Description>
+<Description>
+  - `variant`(任意): UnderlineTabの種類を指定します。デフォルトは`fixed`で、その他に`scrollable`を指定することもできます。
+</Description>
+<Description>
+  - `onClick`(任意): 各項目をクリックした際に追加で行いたい処理がある場合は指定します。第2引数の`id`には、選択された項目の`id`が渡されます。
+</Description>
+
+## アクセシビリティ
+UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が設定されます。また、`aria-controls`には`options`の`id`に`-tabpanel`を付与したものが設定されます。（例：`id`が`all`の場合、`id`には`all`、`aria-controls`には`all-tabpanel`が設定されます）
+
+上記を用いて、各項目と表示内容を関連付けてください。
+
+<Source
+  code={`
+<UnderlineTab
+  defaultSelectedId={'all'}
+  options={[
+    { id: 'all', label: 'すべて' },
+    { id: 'follow', label: 'フォロー' },
+    { id: 'follower', label: 'フォロワー' },
+  ]}
+/>
+<div id="all-tabpanel" role="tabpanel" aria-labelledby="all">
+  <p>「すべて」選択時の表示内容</p>
+</div>
+<div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow">
+  <p>「フォロー」選択時の表示内容</p>
+</div>
+<div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower">
+  <p>「フォロワー」選択時の表示内容</p>
+</div>
+  `}
+/>
+
+## Variant（fixed）
+`variant: fixed`を指定した場合、各項目の幅は項目数で等分した長さになります。`fixed`を指定している場合、長い項目名（`label`）や多数の項目が設定されることは期待していません。そのため、`variant: fixed`指定時は項目名を最大7文字程度に収めることを推奨しており、長い項目名や多数の項目を設定したい場合は`variant: scrollable`の利用を検討してください。
+
+<Preview withSource="open">
+  <Story name="Variant (fixed)">
+    <UnderlineTab
+      defaultSelectedId={'all'}
+      options={[
+        { id: 'all', label: 'すべて' },
+        { id: 'follow', label: 'フォロー' },
+        { id: 'follower', label: 'フォロワー' },
+      ]}
+      {...actions('onClick')}
+    />
+    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
+    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
+    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<div class="spui-UnderlineTab spui-UnderlineTab--fixed spui-UnderlineTab--border">
+  <div class="spui-UnderlineTab-container" role="tablist">
+    <button aria-controls="all-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="all" tabindex="0" type="button" role="tab" style="max-width: calc(33.3333%);">
+      <p class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-label">すべて</span>
+      </p>
+    </button>
+    <button aria-controls="follow-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="follow" tabindex="-1" type="button" role="tab" style="max-width: calc(33.3333%);">
+      <p class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-label">フォロー</span>
+      </p>
+    </button>
+    <button aria-controls="follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="follower" tabindex="-1" type="button" role="tab" style="max-width: calc(33.3333%);">
+      <p class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-label">フォロワー</span>
+      </p>
+    </button>
+  </div>
+</div>
+  `}
+/>
+
+## Variant（scrollable）
+`variant: scrollable`を指定した場合、各項目の幅は項目名（`label`）の長さと同等になります。（項目名が長くても省略されることはありません）UnderlineTabの全体が表示領域内に収まらなくなった瞬間から、横スクロール可能になります。
+
+<Preview withSource="open">
+  <Story name="Variant (scrollable)">
+    <UnderlineTab
+      defaultSelectedId={'follow'}
+      options={[
+        { id: 'all', label: 'すべて' },
+        { id: 'follow', label: 'フォロー' },
+        { id: 'follower', label: 'フォロワー' },
+        { id: 'others', label: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      ]}
+      variant='scrollable'
+      {...actions('onClick')}
+    />
+    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
+    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
+    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+    <div id="others-tabpanel" role="tabpanel" aria-labelledby="others" />
+  </Story>
+</Preview>
+
+<Source
+  code={`
+<div id="story--navigationtab-underlinetab--scrollable">
+  <div class="spui-UnderlineTab spui-UnderlineTab--scrollable spui-UnderlineTab--border">
+    <div class="spui-UnderlineTab-arrow spui-UnderlineTab-arrow--left">
+      <button class="spui-UnderlineTab-arrowButton" type="button">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" role="img" aria-label="左に移動"><path d="M13.49 21.06 6.2 13.77c-.97-.97-.97-2.56 0-3.54l7.29-7.29a1.49 1.49 0 0 1 2.12 0c.59.59.59 1.54 0 2.12L8.67 12l6.94 6.94c.59.59.59 1.54 0 2.12-.29.29-.68.44-1.06.44s-.77-.15-1.06-.44Z"></path></svg>
+      </button>
+    </div>
+    <div class="spui-UnderlineTab-container" role="tablist">
+      <button aria-controls="all-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="all" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+        <p class="spui-UnderlineTab-labelWrapper">
+          <span class="spui-UnderlineTab-label">すべて</span>
+        </p>
+      </button>
+      <button aria-controls="follow-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="follow" tabindex="0" type="button" role="tab" style="max-width: fit-content;">
+        <p class="spui-UnderlineTab-labelWrapper">
+          <span class="spui-UnderlineTab-label">フォロー</span>
+        </p>
+      </button>
+      <button aria-controls="follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="follower" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+        <p class="spui-UnderlineTab-labelWrapper">
+          <span class="spui-UnderlineTab-label">フォロワー</span>
+        </p>
+      </button>
+      <button aria-controls="others-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="others" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+        <p class="spui-UnderlineTab-labelWrapper">
+          <span class="spui-UnderlineTab-label">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</span>
+        </p>
+      </button>
+    </div>
+    <div class="spui-UnderlineTab-arrow spui-UnderlineTab-arrow--right is-showed">
+      <button class="spui-UnderlineTab-arrowButton" type="button">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" role="img" aria-label="右に移動"><path d="M9.41 21.5c-.38 0-.77-.15-1.06-.44a1.49 1.49 0 0 1 0-2.12L15.29 12 8.35 5.06a1.49 1.49 0 0 1 0-2.12c.59-.58 1.54-.59 2.12 0l7.29 7.29c.97.97.97 2.56 0 3.54l-7.29 7.29c-.29.29-.67.44-1.06.44Z"></path></svg>
+      </button>
+    </div>
+  </div>
+</div>
+  `}
+/>
+
+## Variant（scrollable with short label）
+UnderlineTabの全体が表示領域内に収まっている場合は、特にスクロールはしません。
+
+<Preview withSource="open">
+  <Story name="Variant (scrollable with short label)">
+    <UnderlineTab
+      defaultSelectedId={'follower'}
+      options={[
+        { id: 'all', label: 'すべて' },
+        { id: 'follow', label: 'フォロー' },
+        { id: 'follower', label: 'フォロワー' },
+      ]}
+      variant='scrollable'
+      {...actions('onClick')}
+    />
+    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
+    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
+    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+  </Story>
+</Preview>
+
+## HasBorder（true）
+コンポーネント下に区切り線を表示するかどうかを指定します。デフォルトは`false`ですが、`true`を指定すれば表示できます。
+
+<Preview withSource="open">
+  <Story name="HasBorder (true)">
+    <UnderlineTab
+      defaultSelectedId={'all'}
+      hasBorder={true}
+      options={[
+        { id: 'all', label: 'すべて' },
+        { id: 'follow', label: 'フォロー' },
+        { id: 'follower', label: 'フォロワー' },
+      ]}
+      {...actions('onClick')}
+    />
+    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
+    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
+    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+  </Story>
+</Preview>
+
+## CountBadge
+`label`右横に数字バッチを表示したい時に指定してください。数字バッチの省略処理（例: `countBadge: 100`の場合に`99+`と表示）はコンポーネント内では特に行っていないので、必要に応じて利用元で処理してから指定してください。
+
+<Preview withSource="open">
+  <Story name="CountBadge">
+    <UnderlineTab
+      defaultSelectedId={'follow'}
+      options={[
+        { id: 'all', label: 'すべて', countBadge: '1' },
+        { id: 'follow', label: 'フォロー' },
+        { id: 'follower', label: 'フォロワー', countBadge: '100' },
+      ]}
+      variant='scrollable'
+      {...actions('onClick')}
+    />
+    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
+    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
+    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+  </Story>
+</Preview>

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.test.tsx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { jest } from '@jest/globals';
+
+import { UnderlineTab } from './UnderlineTab';
+
+const options = [
+  { id: 'all', label: 'すべて' },
+  { id: 'follow', label: 'フォロー' },
+  { id: 'follower', label: 'フォロワー', countBadge: '100' },
+];
+
+describe('<UnderlineTab />', () => {
+  describe('defaultSelectedId Props', () => {
+    test('If defaultSelectedId is not included in options, nothing is selected.', () => {
+      render(
+        <UnderlineTab defaultSelectedId={'notIncludedId'} options={options} />,
+      );
+
+      const notSelectedButtons = screen.getAllByRole('tab', {
+        selected: false,
+      });
+      expect(notSelectedButtons.length).toEqual(options.length);
+    });
+
+    test('If defaultSelectedId is included in options, it must not be selected.', () => {
+      const defaultSelectedId = options[0].id;
+      render(
+        <UnderlineTab
+          defaultSelectedId={defaultSelectedId}
+          options={options}
+        />,
+      );
+
+      const notSelectedButtons = screen.getAllByRole('tab', {
+        selected: false,
+      });
+      expect(notSelectedButtons.length).toEqual(options.length - 1);
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(defaultSelectedId);
+    });
+  });
+
+  describe('options Props', () => {
+    test('Nothing is displayed when options is empty array.', () => {
+      const { container } = render(
+        <UnderlineTab defaultSelectedId={options[0].id} options={[]} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    test('If options are specified, they should be properly reflected.', () => {
+      const defaultSelectedId = options[1].id;
+      render(
+        <UnderlineTab
+          defaultSelectedId={defaultSelectedId}
+          options={options}
+        />,
+      );
+
+      const buttons = screen.getAllByRole('tab');
+      buttons.forEach((button, i) => {
+        expect(button.getAttribute('aria-controls')).toEqual(
+          `${options[i].id}-tabpanel`,
+        );
+        expect(button.getAttribute('aria-selected')).toEqual(
+          defaultSelectedId === button.id ? 'true' : 'false',
+        );
+        expect(button.getAttribute('id')).toEqual(options[i].id);
+        expect(button.getAttribute('tabIndex')).toEqual(
+          defaultSelectedId === button.id ? '0' : '-1',
+        );
+        if (options[i].countBadge) {
+          expect(
+            (button.textContent || button.innerText).includes(
+              options[i].countBadge || '',
+            ),
+          ).toEqual(true);
+        }
+      });
+    });
+  });
+
+  describe('hasBorder Props', () => {
+    test('Border must be displayed when hasBorder is true.', () => {
+      const { container } = render(
+        <UnderlineTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          hasBorder={true}
+        />,
+      );
+
+      expect(container.firstChild).toHaveClass('spui-UnderlineTab--border');
+    });
+
+    test('Border is not initially displayed.', () => {
+      const { container } = render(
+        <UnderlineTab defaultSelectedId={options[0].id} options={options} />,
+      );
+
+      expect(container.firstChild).not.toHaveClass('spui-UnderlineTab--border');
+    });
+  });
+
+  describe('variant Props', () => {
+    test('Border must be displayed when variant is fixed.', () => {
+      const { container } = render(
+        <UnderlineTab defaultSelectedId={options[0].id} options={options} />,
+      );
+
+      expect(container.firstChild).toHaveClass('spui-UnderlineTab--fixed');
+    });
+
+    test('Border is not displayed when variant is scrollable.', () => {
+      const { container } = render(
+        <UnderlineTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          variant={'scrollable'}
+        />,
+      );
+
+      expect(container.firstChild).toHaveClass('spui-UnderlineTab--scrollable');
+    });
+  });
+
+  describe('onClick Props', () => {
+    test('The selected item should change when onClick is called.', async () => {
+      const defaultSelectedId = options[0].id;
+      const selectedId = options[1].id;
+      const onClick = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <UnderlineTab
+          defaultSelectedId={defaultSelectedId}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      const defaultSelectedButton = screen.getByRole('tab', { selected: true });
+      expect(defaultSelectedButton.getAttribute('id')).toEqual(
+        defaultSelectedId,
+      );
+
+      if (defaultSelectedButton.nextElementSibling) {
+        await user.click(defaultSelectedButton.nextElementSibling);
+      }
+      expect(onClick).toBeCalled();
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(selectedId);
+    });
+  });
+});

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.tsx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.tsx
@@ -1,0 +1,251 @@
+import React, {
+  RefObject,
+  createRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import ChevronLeftBold from '../../Icon/ChevronLeftBold';
+import ChevronRightBold from '../../Icon/ChevronRightBold';
+
+type Option = {
+  label: string;
+  id: string;
+  countBadge?: string;
+};
+
+type Variant = 'fixed' | 'scrollable';
+
+type Props = {
+  defaultSelectedId: string;
+  options: Option[];
+  hasBorder?: boolean;
+  variant?: Variant;
+  onClick?: (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLButtonElement>,
+    id: string,
+  ) => void;
+};
+
+const BLOCK_NAME = 'spui-UnderlineTab';
+const SCROLL_DISTANCE = 150;
+
+export const UnderlineTab: React.FC<Props> = ({
+  defaultSelectedId,
+  options,
+  hasBorder = false,
+  variant = 'fixed',
+  onClick,
+}) => {
+  const [selectedId, setSelectedId] = useState(defaultSelectedId);
+  const [showPrevButton, setShowPrevButton] = useState(false);
+  const [showNextButton, setShowNextButton] = useState(false);
+
+  const buttonsRef = useRef<RefObject<HTMLButtonElement>[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useCallback((direction: 'prev' | 'next') => {
+    const containerElement = containerRef.current;
+    if (!containerElement) {
+      return;
+    }
+
+    const scrollDistance =
+      direction === 'next' ? SCROLL_DISTANCE : -SCROLL_DISTANCE;
+    containerElement.scrollLeft = containerElement.scrollLeft + scrollDistance;
+  }, []);
+
+  const handleClick = useCallback(
+    (
+      e:
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+      id: string,
+    ) => {
+      const targetButtonElement = document.querySelector(`#${id}`);
+      // 既に選択中の項目に対してクリックした場合は何もしない
+      if (targetButtonElement?.getAttribute('aria-selected') === 'true') {
+        return;
+      }
+
+      setSelectedId(id);
+
+      if (typeof onClick === 'function') {
+        onClick(e, id);
+      }
+    },
+    [onClick],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const totalLength = options.length;
+
+      switch (e.key) {
+        case 'ArrowLeft': {
+          // 基本的には1つ前の要素に移動。ただし、既に先頭の要素にいる場合はリストの最後尾に移動
+          const prevButtonIndex = index - 1 < 0 ? totalLength - 1 : index - 1;
+          const prevButtonRef = buttonsRef.current[prevButtonIndex];
+          prevButtonRef.current?.focus();
+          handleClick(e, options[prevButtonIndex].id);
+          break;
+        }
+        case 'ArrowRight': {
+          // 基本的には1つ後の要素に移動。ただし、既に最後尾の要素にいる場合はリストの先頭に移動
+          const nextButtonIndex = index + 1 >= totalLength ? 0 : index + 1;
+          const nextButtonRef = buttonsRef.current[nextButtonIndex];
+          nextButtonRef.current?.focus();
+          handleClick(e, options[nextButtonIndex].id);
+          break;
+        }
+        case 'Enter': {
+          const targetButton = buttonsRef.current[index].current;
+          // 既に選択中の項目に対してEnterを押下した場合は無効にする
+          if (targetButton?.getAttribute('aria-selected') === 'true') {
+            e.preventDefault();
+          }
+          break;
+        }
+      }
+    },
+    [options, handleClick],
+  );
+
+  useEffect(() => {
+    buttonsRef.current = options.map(
+      (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
+    );
+  }, [options]);
+
+  useEffect(() => {
+    if (variant !== 'scrollable') {
+      return;
+    }
+    const containerElement = containerRef.current;
+    if (!containerElement) {
+      return;
+    }
+
+    const updateDisplayedButton = () => {
+      setShowPrevButton(containerElement.scrollLeft > 0);
+      setShowNextButton(
+        containerElement.scrollWidth >
+          Math.ceil(containerElement.clientWidth + containerElement.scrollLeft),
+      );
+    };
+
+    updateDisplayedButton();
+    window.addEventListener('resize', updateDisplayedButton);
+    containerElement.addEventListener('scroll', updateDisplayedButton);
+
+    return () => {
+      window.removeEventListener('resize', updateDisplayedButton);
+      containerElement.removeEventListener('scroll', updateDisplayedButton);
+    };
+  }, [variant]);
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={[
+        BLOCK_NAME,
+        `${BLOCK_NAME}--${variant}`,
+        hasBorder && `${BLOCK_NAME}--border`,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .trim()}
+    >
+      {variant === 'scrollable' && (
+        <div
+          className={[
+            `${BLOCK_NAME}-arrow`,
+            `${BLOCK_NAME}-arrow--left`,
+            showPrevButton && 'is-showed',
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .trim()}
+        >
+          <button
+            className={`${BLOCK_NAME}-arrowButton`}
+            type="button"
+            onClick={() => handleScroll('prev')}
+          >
+            <ChevronLeftBold aria-label="左に移動" height={16} width={16} />
+          </button>
+        </div>
+      )}
+
+      <div
+        className={`${BLOCK_NAME}-container`}
+        role="tablist"
+        ref={containerRef}
+      >
+        {options.map((option, index) => {
+          const { label, id, countBadge } = option;
+          const isSelected = id === selectedId;
+
+          return (
+            <button
+              aria-controls={`${id}-tabpanel`}
+              aria-selected={isSelected}
+              className={`${BLOCK_NAME}-button`}
+              key={id}
+              id={id}
+              style={{
+                maxWidth:
+                  variant === 'fixed'
+                    ? `calc(${100 / options.length}%`
+                    : 'fit-content',
+              }}
+              tabIndex={isSelected ? 0 : -1}
+              type="button"
+              ref={buttonsRef.current[index]}
+              role="tab"
+              onClick={(e) => handleClick(e, id)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+            >
+              <p className={`${BLOCK_NAME}-labelWrapper`}>
+                <span className={`${BLOCK_NAME}-label`}>{label}</span>
+                {countBadge && (
+                  <>
+                    <span className={`${BLOCK_NAME}-badge`}>{countBadge}</span>
+                    <span className={`${BLOCK_NAME}-visuallyHidden`}>件</span>
+                  </>
+                )}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+
+      {variant === 'scrollable' && (
+        <div
+          className={[
+            `${BLOCK_NAME}-arrow`,
+            `${BLOCK_NAME}-arrow--right`,
+            showNextButton && 'is-showed',
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .trim()}
+        >
+          <button
+            className={`${BLOCK_NAME}-arrowButton`}
+            type="button"
+            onClick={() => handleScroll('next')}
+          >
+            <ChevronRightBold aria-label="右に移動" height={16} width={16} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/spindle-ui/src/NavigationTab/index.css
+++ b/packages/spindle-ui/src/NavigationTab/index.css
@@ -1,0 +1,1 @@
+@import './UnderlineTab/UnderlineTab.css';

--- a/packages/spindle-ui/src/NavigationTab/index.ts
+++ b/packages/spindle-ui/src/NavigationTab/index.ts
@@ -1,0 +1,1 @@
+export { UnderlineTab } from './UnderlineTab/UnderlineTab';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -20,3 +20,4 @@
 @import './Pagination/Pagination.css';
 @import './InlineNotification/InlineNotification.css';
 @import './SegmentedControl/SegmentedControl.css';
+@import './NavigationTab/index.css';


### PR DESCRIPTION
## 概要
[DesignDocs](https://github.com/openameba/spindle/blob/main/packages/spindle-ui/src/NavigationTab/UnderlineTab/design-doc.md#%E4%BD%BF%E7%94%A8%E4%BE%8B)に沿って、`NavigationTab/UnderlineTab`コンポーネントを実装しました

### DesignDocsと実装の差分について
設計（DesignDocs）段階では、`UnderlineTab`の各項目がリンクの場合とボタンの場合の両方を考慮していました
...が、`UnderlineTab`の利用予定画面では現状ボタンのパターンしか存在せず（またリンク要件が存在するわけでもないため）、設計者 @tatz-ibz と話し合いの上現時点ではボタンのパターンのみ考慮にすることにしました

※ 今後リンク要件が出てくる可能性はあるため、DesignDocsからは削っていません

---

その他細かい変更箇所については、`design-doc.md`の差分にコメントする形で言及しています 📝 

## レビュー完了希望日
2/5（月）

## その他
Figma等の関連リンクは、AccessibilityチームのAsanaの概要欄に貼ってあります 📝 
また、デザイナーさんとやりとりした細かなデザイン仕様についてはFigma上にコメントしています 📝 