### PR TITLE
fix(spindle-ui): fix `NavigationTab/UnderlineTab` component

### DIFF
--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.stories.mdx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.stories.mdx
@@ -99,7 +99,7 @@ UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が
 
 <Source
   code={`
-<div class="spui-UnderlineTab spui-UnderlineTab--fixed spui-UnderlineTab--border">
+<div class="spui-UnderlineTab spui-UnderlineTab--fixed">
   <div class="spui-UnderlineTab-container" role="tablist">
     <button aria-controls="fixed-all-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="fixed-all" tabindex="0" type="button" role="tab" style="max-width: calc(33.3333%);">
       <span class="spui-UnderlineTab-labelWrapper">
@@ -146,40 +146,38 @@ UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が
 
 <Source
   code={`
-<div id="story--navigationtab-underlinetab--scrollable">
-  <div class="spui-UnderlineTab spui-UnderlineTab--scrollable spui-UnderlineTab--border">
-    <div class="spui-UnderlineTab-arrow spui-UnderlineTab-arrow--left">
-      <button class="spui-UnderlineTab-arrowButton" type="button">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" role="img" aria-label="左に移動"><path d="M13.49 21.06 6.2 13.77c-.97-.97-.97-2.56 0-3.54l7.29-7.29a1.49 1.49 0 0 1 2.12 0c.59.59.59 1.54 0 2.12L8.67 12l6.94 6.94c.59.59.59 1.54 0 2.12-.29.29-.68.44-1.06.44s-.77-.15-1.06-.44Z"></path></svg>
-      </button>
-    </div>
-    <div class="spui-UnderlineTab-container" role="tablist">
-      <button aria-controls="scrollable-all-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-all" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
-        <span class="spui-UnderlineTab-labelWrapper">
-          <span class="spui-UnderlineTab-label">すべて</span>
-        </span>
-      </button>
-      <button aria-controls="scrollable-follow-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="scrollable-follow" tabindex="0" type="button" role="tab" style="max-width: fit-content;">
-        <span class="spui-UnderlineTab-labelWrapper">
-          <span class="spui-UnderlineTab-label">フォロー</span>
-        </span>
-      </button>
-      <button aria-controls="scrollable-follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-follower" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
-        <span class="spui-UnderlineTab-labelWrapper">
-          <span class="spui-UnderlineTab-label">フォロワー</span>
-        </span>
-      </button>
-      <button aria-controls="scrollable-others-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-others" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
-        <span class="spui-UnderlineTab-labelWrapper">
-          <span class="spui-UnderlineTab-label">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</span>
-        </span>
-      </button>
-    </div>
-    <div class="spui-UnderlineTab-arrow spui-UnderlineTab-arrow--right is-showed">
-      <button class="spui-UnderlineTab-arrowButton" type="button">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" role="img" aria-label="右に移動"><path d="M9.41 21.5c-.38 0-.77-.15-1.06-.44a1.49 1.49 0 0 1 0-2.12L15.29 12 8.35 5.06a1.49 1.49 0 0 1 0-2.12c.59-.58 1.54-.59 2.12 0l7.29 7.29c.97.97.97 2.56 0 3.54l-7.29 7.29c-.29.29-.67.44-1.06.44Z"></path></svg>
-      </button>
-    </div>
+<div class="spui-UnderlineTab spui-UnderlineTab--scrollable">
+  <div class="spui-UnderlineTab-arrow spui-UnderlineTab-arrow--left">
+    <button class="spui-UnderlineTab-arrowButton" type="button">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" role="img" aria-label="左に移動"><path d="M13.49 21.06 6.2 13.77c-.97-.97-.97-2.56 0-3.54l7.29-7.29a1.49 1.49 0 0 1 2.12 0c.59.59.59 1.54 0 2.12L8.67 12l6.94 6.94c.59.59.59 1.54 0 2.12-.29.29-.68.44-1.06.44s-.77-.15-1.06-.44Z"></path></svg>
+    </button>
+  </div>
+  <div class="spui-UnderlineTab-container" role="tablist">
+    <button aria-controls="scrollable-all-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-all" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+      <span class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-label">すべて</span>
+      </span>
+    </button>
+    <button aria-controls="scrollable-follow-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="scrollable-follow" tabindex="0" type="button" role="tab" style="max-width: fit-content;">
+      <span class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-label">フォロー</span>
+      </span>
+    </button>
+    <button aria-controls="scrollable-follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-follower" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+      <span class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-label">フォロワー</span>
+      </span>
+    </button>
+    <button aria-controls="scrollable-others-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-others" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+      <span class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-label">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</span>
+      </span>
+    </button>
+  </div>
+  <div class="spui-UnderlineTab-arrow spui-UnderlineTab-arrow--right is-showed">
+    <button class="spui-UnderlineTab-arrowButton" type="button">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" role="img" aria-label="右に移動"><path d="M9.41 21.5c-.38 0-.77-.15-1.06-.44a1.49 1.49 0 0 1 0-2.12L15.29 12 8.35 5.06a1.49 1.49 0 0 1 0-2.12c.59-.58 1.54-.59 2.12 0l7.29 7.29c.97.97.97 2.56 0 3.54l-7.29 7.29c-.29.29-.67.44-1.06.44Z"></path></svg>
+    </button>
   </div>
 </div>
   `}

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.stories.mdx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.stories.mdx
@@ -102,19 +102,19 @@ UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が
 <div class="spui-UnderlineTab spui-UnderlineTab--fixed spui-UnderlineTab--border">
   <div class="spui-UnderlineTab-container" role="tablist">
     <button aria-controls="fixed-all-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="fixed-all" tabindex="0" type="button" role="tab" style="max-width: calc(33.3333%);">
-      <p class="spui-UnderlineTab-labelWrapper">
+      <span class="spui-UnderlineTab-labelWrapper">
         <span class="spui-UnderlineTab-label">すべて</span>
-      </p>
+      </span>
     </button>
     <button aria-controls="fixed-follow-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="fixed-follow" tabindex="-1" type="button" role="tab" style="max-width: calc(33.3333%);">
-      <p class="spui-UnderlineTab-labelWrapper">
+      <span class="spui-UnderlineTab-labelWrapper">
         <span class="spui-UnderlineTab-label">フォロー</span>
-      </p>
+      </span>
     </button>
     <button aria-controls="fixed-follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="fixed-follower" tabindex="-1" type="button" role="tab" style="max-width: calc(33.3333%);">
-      <p class="spui-UnderlineTab-labelWrapper">
+      <span class="spui-UnderlineTab-labelWrapper">
         <span class="spui-UnderlineTab-label">フォロワー</span>
-      </p>
+      </span>
     </button>
   </div>
 </div>
@@ -155,24 +155,24 @@ UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が
     </div>
     <div class="spui-UnderlineTab-container" role="tablist">
       <button aria-controls="scrollable-all-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-all" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
-        <p class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-labelWrapper">
           <span class="spui-UnderlineTab-label">すべて</span>
-        </p>
+        </span>
       </button>
       <button aria-controls="scrollable-follow-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="scrollable-follow" tabindex="0" type="button" role="tab" style="max-width: fit-content;">
-        <p class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-labelWrapper">
           <span class="spui-UnderlineTab-label">フォロー</span>
-        </p>
+        </span>
       </button>
       <button aria-controls="scrollable-follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-follower" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
-        <p class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-labelWrapper">
           <span class="spui-UnderlineTab-label">フォロワー</span>
-        </p>
+        </span>
       </button>
       <button aria-controls="scrollable-others-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-others" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
-        <p class="spui-UnderlineTab-labelWrapper">
+        <span class="spui-UnderlineTab-labelWrapper">
           <span class="spui-UnderlineTab-label">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</span>
-        </p>
+        </span>
       </button>
     </div>
     <div class="spui-UnderlineTab-arrow spui-UnderlineTab-arrow--right is-showed">

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.stories.mdx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.stories.mdx
@@ -83,17 +83,17 @@ UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が
 <Preview withSource="open">
   <Story name="Variant (fixed)">
     <UnderlineTab
-      defaultSelectedId={'all'}
+      defaultSelectedId={'fixed-all'}
       options={[
-        { id: 'all', label: 'すべて' },
-        { id: 'follow', label: 'フォロー' },
-        { id: 'follower', label: 'フォロワー' },
+        { id: 'fixed-all', label: 'すべて' },
+        { id: 'fixed-follow', label: 'フォロー' },
+        { id: 'fixed-follower', label: 'フォロワー' },
       ]}
       {...actions('onClick')}
     />
-    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
-    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
-    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+    <div id="fixed-all-tabpanel" role="tabpanel" aria-labelledby="fixed-all" />
+    <div id="fixed-follow-tabpanel" role="tabpanel" aria-labelledby="fixed-follow" />
+    <div id="fixed-follower-tabpanel" role="tabpanel" aria-labelledby="fixed-follower" />
   </Story>
 </Preview>
 
@@ -101,17 +101,17 @@ UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が
   code={`
 <div class="spui-UnderlineTab spui-UnderlineTab--fixed spui-UnderlineTab--border">
   <div class="spui-UnderlineTab-container" role="tablist">
-    <button aria-controls="all-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="all" tabindex="0" type="button" role="tab" style="max-width: calc(33.3333%);">
+    <button aria-controls="fixed-all-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="fixed-all" tabindex="0" type="button" role="tab" style="max-width: calc(33.3333%);">
       <p class="spui-UnderlineTab-labelWrapper">
         <span class="spui-UnderlineTab-label">すべて</span>
       </p>
     </button>
-    <button aria-controls="follow-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="follow" tabindex="-1" type="button" role="tab" style="max-width: calc(33.3333%);">
+    <button aria-controls="fixed-follow-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="fixed-follow" tabindex="-1" type="button" role="tab" style="max-width: calc(33.3333%);">
       <p class="spui-UnderlineTab-labelWrapper">
         <span class="spui-UnderlineTab-label">フォロー</span>
       </p>
     </button>
-    <button aria-controls="follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="follower" tabindex="-1" type="button" role="tab" style="max-width: calc(33.3333%);">
+    <button aria-controls="fixed-follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="fixed-follower" tabindex="-1" type="button" role="tab" style="max-width: calc(33.3333%);">
       <p class="spui-UnderlineTab-labelWrapper">
         <span class="spui-UnderlineTab-label">フォロワー</span>
       </p>
@@ -127,20 +127,20 @@ UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が
 <Preview withSource="open">
   <Story name="Variant (scrollable)">
     <UnderlineTab
-      defaultSelectedId={'follow'}
+      defaultSelectedId={'scrollable-follow'}
       options={[
-        { id: 'all', label: 'すべて' },
-        { id: 'follow', label: 'フォロー' },
-        { id: 'follower', label: 'フォロワー' },
-        { id: 'others', label: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+        { id: 'scrollable-all', label: 'すべて' },
+        { id: 'scrollable-follow', label: 'フォロー' },
+        { id: 'scrollable-follower', label: 'フォロワー' },
+        { id: 'scrollable-others', label: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
       ]}
       variant='scrollable'
       {...actions('onClick')}
     />
-    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
-    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
-    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
-    <div id="others-tabpanel" role="tabpanel" aria-labelledby="others" />
+    <div id="scrollable-all-tabpanel" role="tabpanel" aria-labelledby="scrollable-all" />
+    <div id="scrollable-follow-tabpanel" role="tabpanel" aria-labelledby="scrollable-follow" />
+    <div id="scrollable-follower-tabpanel" role="tabpanel" aria-labelledby="scrollable-follower" />
+    <div id="scrollable-others-tabpanel" role="tabpanel" aria-labelledby="scrollable-others" />
   </Story>
 </Preview>
 
@@ -154,22 +154,22 @@ UnderlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が
       </button>
     </div>
     <div class="spui-UnderlineTab-container" role="tablist">
-      <button aria-controls="all-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="all" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+      <button aria-controls="scrollable-all-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-all" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
         <p class="spui-UnderlineTab-labelWrapper">
           <span class="spui-UnderlineTab-label">すべて</span>
         </p>
       </button>
-      <button aria-controls="follow-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="follow" tabindex="0" type="button" role="tab" style="max-width: fit-content;">
+      <button aria-controls="scrollable-follow-tabpanel" aria-selected="true" class="spui-UnderlineTab-button" id="scrollable-follow" tabindex="0" type="button" role="tab" style="max-width: fit-content;">
         <p class="spui-UnderlineTab-labelWrapper">
           <span class="spui-UnderlineTab-label">フォロー</span>
         </p>
       </button>
-      <button aria-controls="follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="follower" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+      <button aria-controls="scrollable-follower-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-follower" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
         <p class="spui-UnderlineTab-labelWrapper">
           <span class="spui-UnderlineTab-label">フォロワー</span>
         </p>
       </button>
-      <button aria-controls="others-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="others" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
+      <button aria-controls="scrollable-others-tabpanel" aria-selected="false" class="spui-UnderlineTab-button" id="scrollable-others" tabindex="-1" type="button" role="tab" style="max-width: fit-content;">
         <p class="spui-UnderlineTab-labelWrapper">
           <span class="spui-UnderlineTab-label">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</span>
         </p>
@@ -191,18 +191,18 @@ UnderlineTabの全体が表示領域内に収まっている場合は、特に�
 <Preview withSource="open">
   <Story name="Variant (scrollable with short label)">
     <UnderlineTab
-      defaultSelectedId={'follower'}
+      defaultSelectedId={'scrollable-short-follower'}
       options={[
-        { id: 'all', label: 'すべて' },
-        { id: 'follow', label: 'フォロー' },
-        { id: 'follower', label: 'フォロワー' },
+        { id: 'scrollable-short-all', label: 'すべて' },
+        { id: 'scrollable-short-follow', label: 'フォロー' },
+        { id: 'scrollable-short-follower', label: 'フォロワー' },
       ]}
       variant='scrollable'
       {...actions('onClick')}
     />
-    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
-    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
-    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+    <div id="scrollable-short-all-tabpanel" role="tabpanel" aria-labelledby="scrollable-short-all" />
+    <div id="scrollable-short-follow-tabpanel" role="tabpanel" aria-labelledby="scrollable-short-follow" />
+    <div id="scrollable-short-follower-tabpanel" role="tabpanel" aria-labelledby="scrollable-short-follower" />
   </Story>
 </Preview>
 
@@ -212,18 +212,18 @@ UnderlineTabの全体が表示領域内に収まっている場合は、特に�
 <Preview withSource="open">
   <Story name="HasBorder (true)">
     <UnderlineTab
-      defaultSelectedId={'all'}
+      defaultSelectedId={'hasBorder-all'}
       hasBorder={true}
       options={[
-        { id: 'all', label: 'すべて' },
-        { id: 'follow', label: 'フォロー' },
-        { id: 'follower', label: 'フォロワー' },
+        { id: 'hasBorder-all', label: 'すべて' },
+        { id: 'hasBorder-follow', label: 'フォロー' },
+        { id: 'hasBorder-follower', label: 'フォロワー' },
       ]}
       {...actions('onClick')}
     />
-    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
-    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
-    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+    <div id="hasBorder-all-tabpanel" role="tabpanel" aria-labelledby="hasBorder-all" />
+    <div id="hasBorder-follow-tabpanel" role="tabpanel" aria-labelledby="hasBorder-follow" />
+    <div id="hasBorder-follower-tabpanel" role="tabpanel" aria-labelledby="hasBorder-follower" />
   </Story>
 </Preview>
 
@@ -233,17 +233,17 @@ UnderlineTabの全体が表示領域内に収まっている場合は、特に�
 <Preview withSource="open">
   <Story name="CountBadge">
     <UnderlineTab
-      defaultSelectedId={'follow'}
+      defaultSelectedId={'countBadge-follow'}
       options={[
-        { id: 'all', label: 'すべて', countBadge: '1' },
-        { id: 'follow', label: 'フォロー' },
-        { id: 'follower', label: 'フォロワー', countBadge: '100' },
+        { id: 'countBadge-all', label: 'すべて', countBadge: '1' },
+        { id: 'countBadge-follow', label: 'フォロー' },
+        { id: 'countBadge-follower', label: 'フォロワー', countBadge: '100' },
       ]}
       variant='scrollable'
       {...actions('onClick')}
     />
-    <div id="all-tabpanel" role="tabpanel" aria-labelledby="all" />
-    <div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow" />
-    <div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower" />
+    <div id="countBadge-all-tabpanel" role="tabpanel" aria-labelledby="countBadge-all" />
+    <div id="countBadge-follow-tabpanel" role="tabpanel" aria-labelledby="countBadge-follow" />
+    <div id="countBadge-follower-tabpanel" role="tabpanel" aria-labelledby="countBadge-follower" />
   </Story>
 </Preview>

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.tsx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.tsx
@@ -212,7 +212,7 @@ export const UnderlineTab: React.FC<Props> = ({
               onClick={(e) => handleClick(e, id)}
               onKeyDown={(e) => handleKeyDown(e, index)}
             >
-              <p className={`${BLOCK_NAME}-labelWrapper`}>
+              <span className={`${BLOCK_NAME}-labelWrapper`}>
                 <span className={`${BLOCK_NAME}-label`}>{label}</span>
                 {countBadge && (
                   <>
@@ -220,7 +220,7 @@ export const UnderlineTab: React.FC<Props> = ({
                     <span className={`${BLOCK_NAME}-visuallyHidden`}>件</span>
                   </>
                 )}
-              </p>
+              </span>
             </button>
           );
         })}


### PR DESCRIPTION
## 概要
https://github.com/openameba/spindle/pull/909 で追加した`NavigationTab/UnderlineTab` にて、一部修正箇所を見つけたので対応しました

- ドキュメントのIDが一意になるように修正： https://github.com/openameba/spindle/pull/925/commits/2f392feb9d0154613aa3eb8f1629d7fd612c6b9f
- マークアップを一部変更： https://github.com/openameba/spindle/pull/925/commits/ec66c4f33a05403830564fdb55bcd0cff2d9cb0e
- 実装例（HTML）が古い実装のままになっていたので修正：https://github.com/openameba/spindle/pull/925/commits/7c3ca85304f92b2237da3f50e789648066b9fc77

## レビュー完了希望日
2/8（木）

## その他
`Hide whitespace`を ✅ してcommitベースで見るのが追いやすいかもです 🙏🏻 
<img width="274" alt="スクリーンショット 2024-02-06 18 38 43" src="https://github.com/openameba/spindle/assets/42470015/16f0ce9a-31d5-434e-9b42-81b4b1998b54">