### PR TITLE
fix(spindle-ui): Fix snackbar/textlink type

### DIFF
--- a/packages/spindle-ui/src/SnackBar/SnackBar.tsx
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.tsx
@@ -4,6 +4,7 @@ import React, {
   Dispatch,
   FC,
   HTMLAttributes,
+  AnchorHTMLAttributes,
   MouseEventHandler,
   ReactNode,
   SetStateAction,
@@ -182,7 +183,10 @@ const TextButton: FC<
   );
 };
 const TextLink: FC<
-  { icon?: ReactNode; children: ReactNode } & HTMLAttributes<HTMLAnchorElement>
+  {
+    icon?: ReactNode;
+    children: ReactNode;
+  } & AnchorHTMLAttributes<HTMLAnchorElement>
 > = ({ icon, children, onClick, ...rest }) => {
   const [props, internalProps] = useMemo(
     () => convertInternalChildProps(rest),


### PR DESCRIPTION
<img width="760" alt="スクリーンショット 2024-03-21 13 03 28" src="https://github.com/openameba/spindle/assets/839004/3ec62466-881e-4c70-aff8-a794d9e1f766">

lint でエラーになってしまうので修正しました