### PR TITLE
fix(spindle-ui): 選択肢が長い時にラジオボタンが潰れて見える

### DIFF
--- a/packages/spindle-ui/src/Form/Radio.css
+++ b/packages/spindle-ui/src/Form/Radio.css
@@ -28,6 +28,7 @@
   box-sizing: border-box;
   color: transparent;
   display: inline-flex;
+  flex-shrink: 0;
   font-size: 0.875em;
   height: 20px;
   justify-content: center;

--- a/packages/spindle-ui/src/Form/Radio.stories.mdx
+++ b/packages/spindle-ui/src/Form/Radio.stories.mdx
@@ -75,7 +75,11 @@ import { Radio } from './Radio';
 
 <Preview withSource="open">
   <Story name="Radio With Text">
-    <Radio id="withText" name="blog" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>Amebaブログ</Radio>
+    <div style={{ display: 'flex', gap: '20px', flexDirection: 'column' }}>
+      <Radio id="withText1" name="select" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>選択肢１</Radio>
+      <Radio id="withText2" name="select" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>選択肢２：文言が長い時の表示を確認するための選択肢です。基本的にはここまで長い文言は推奨されませんが表示の確認用です</Radio>
+      <Radio id="withText3" name="select" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>選択肢３</Radio>
+    </div>
   </Story>
 </Preview>
 


### PR DESCRIPTION
spindle-uiのRadioボタンを使っている際に、文言の長さ＋端末幅、あるいは画面・テキストサイズの拡大率によってはラジオボタンが縦に潰れて表示されてしまうため修正しました。

## 変更前後

before|after
---|---
選択肢のラベルが長い時にラジオボタンが縦に潰れて表示されている|長い時にもラジオボタンは正円で表示されている
<img width="417" alt="修正前のスクリーンショット" src="https://github.com/openameba/spindle/assets/4669600/3c82a043-6907-4db7-a2f6-645a5e04eed5">|<img width="407" alt="修正後のスクリーンショット" src="https://github.com/openameba/spindle/assets/4669600/029fd25c-fbf0-4a7b-a909-0d43674a1e55">

## 修正の意図
基本的にこのレベルの長文を表示することは想定していませんが、[1.4.4 テキストサイズを拡大縮小できる](https://a11y-guidelines.ameba.design/1/4/4/)ことでアクセシビリティを高められるので、長文に適応できることでテキストサイズの拡大やリフローに耐えうるので修正すべきと判断しました。

関連しそうなアクセシビリティのガイドライン：
- [1.4.4 テキストサイズを拡大縮小できる](https://a11y-guidelines.ameba.design/1/4/4/)
- [1.4.10 リフローできる](https://a11y-guidelines.ameba.design/1/4/10/)