### PR TITLE
Fix Checkbox, Radio outline with text

### DIFF
--- a/packages/spindle-ui/src/Form/Checkbox.css
+++ b/packages/spindle-ui/src/Form/Checkbox.css
@@ -1,6 +1,10 @@
 /*
  * Checkbox
 */
+:root {
+  --Checkbox-backGroundColor: var(--color-surface-primary);
+}
+
 .spui-Checkbox-label {
   align-items: center;
   border-radius: 2px;
@@ -10,6 +14,19 @@
   font-weight: bold;
   line-height: 1;
   position: relative;
+}
+
+/* Outline with text */
+.spui-Checkbox-label:focus-within:has(.spui-Checkbox-text:not(:empty)) {
+  box-shadow:
+    0 0 0 2px var(--Checkbox-backGroundColor),
+    0 0 0 4px var(--color-focus-clarity);
+}
+
+.spui-Checkbox-label:focus-within:has(
+    .spui-Checkbox-input:not(:focus-visible)
+  ) {
+  box-shadow: none;
 }
 
 .spui-Checkbox-input {
@@ -56,12 +73,18 @@
   width: 22px;
 }
 
-/* box-shadow is used to apply border-radius as outline */
-.spui-Checkbox-input:focus ~ .spui-Checkbox-outline {
+/* Outline without text */
+.spui-Checkbox-label:has(:not(.spui-Checkbox-text))
+  .spui-Checkbox-input:focus-visible
+  ~ .spui-Checkbox-outline {
   box-shadow: 0 0 0 2px var(--color-focus-clarity);
 }
 
-.spui-Checkbox-input:focus:not(:focus-visible) ~ .spui-Checkbox-outline {
+.spui-Checkbox-label:has(.spui-Checkbox-text):has(
+    :not(.spui-Checkbox-text:empty)
+  )
+  .spui-Checkbox-input:focus-visible
+  ~ .spui-Checkbox-outline {
   box-shadow: none;
 }
 

--- a/packages/spindle-ui/src/Form/Radio.css
+++ b/packages/spindle-ui/src/Form/Radio.css
@@ -1,6 +1,10 @@
 /*
  * Radio
 */
+:root {
+  --Radio-backGroundColor: var(--color-surface-primary);
+}
+
 .spui-Radio-label {
   align-items: center;
   border-radius: 2px;
@@ -10,6 +14,17 @@
   font-weight: bold;
   line-height: 1;
   position: relative;
+}
+
+/* Outline with text */
+.spui-Radio-label:focus-within:has(.spui-Radio-text:not(:empty)) {
+  box-shadow:
+    0 0 0 2px var(--Radio-backGroundColor),
+    0 0 0 4px var(--color-focus-clarity);
+}
+
+.spui-Radio-label:focus-within:has(.spui-Radio-input:not(:focus-visible)) {
+  box-shadow: none;
 }
 
 .spui-Radio-input {
@@ -58,12 +73,16 @@
   width: 24px;
 }
 
-/* box-shadow is used to apply border-radius as outline */
-.spui-Radio-input:focus ~ .spui-Radio-outline {
+/* Outline without text */
+.spui-Radio-label:has(:not(.spui-Radio-text))
+  .spui-Radio-input:focus-visible
+  ~ .spui-Radio-outline {
   box-shadow: 0 0 0 2px var(--color-focus-clarity);
 }
 
-.spui-Radio-input:focus:not(:focus-visible) ~ .spui-Radio-outline {
+.spui-Radio-label:has(.spui-Radio-text):has(:not(.spui-Radio-text:empty))
+  .spui-Radio-input:focus-visible
+  ~ .spui-Radio-outline {
   box-shadow: none;
 }
 


### PR DESCRIPTION
CheckboxとRadioのテキストあり時のフォーカススタイルの要件が満たせておらず、CSSの変更のみで対応できたので修正しました。


<img width="236" alt="Screenshot 2024-09-06 at 6 37 10 PM" src="https://github.com/user-attachments/assets/f950c61b-b2cc-465c-a96f-3f66808a010e">
<img width="132" alt="Screenshot 2024-09-06 at 6 37 02 PM" src="https://github.com/user-attachments/assets/ba094399-585b-48c5-88a5-91a36d1ab79b">

利用時にスタイルをつけている場合2重で表示される可能性がありますが、致命的な問題ではないと判断しました w/ @yasuda-shin 

