### PR TITLE
Chore/husky unnecessary lines

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install commitlint --edit "$1"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no-install commitlint --edit "$1"
+commitlint --edit "$1"


### PR DESCRIPTION
DEPRECATED messageが出ていたので削除しました。 2e8f4d85e0b1001744ca443ffc132f1b998bc43a

<details>
husky - DEPRECATED

Please remove the following two lines from .husky/commit-msg:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
</detail>

ついでに [run package commands directly](https://github.com/typicode/husky/releases/tag/v9.1.1) もしてみました。 911bd5dacfcb007a441c042eaaee13998f1f4975
