### PR TITLE
feat(spindle-ui): add switch attribute to ToggleSwitch

### DIFF
--- a/packages/spindle-ui/src/Form/ToggleSwitch.tsx
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.tsx
@@ -15,6 +15,9 @@ export const ToggleSwitch = forwardRef<HTMLInputElement, Props>(
           className={`${BLOCK_NAME}-input`}
           id={id}
           ref={ref}
+          // TODO: update this when the switch attribute is supported
+          // eslint-disable-next-line react/no-unknown-property
+          switch="switch"
           type="checkbox"
           {...rest}
         />

--- a/packages/spindle-ui/src/types/react.d.ts
+++ b/packages/spindle-ui/src/types/react.d.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// TODO: remove this when the type definition is officially supported
+declare module 'react' {
+  interface InputHTMLAttributes<T> extends React.HTMLAttributes<T> {
+    switch?: string;
+  }
+}


### PR DESCRIPTION
Safariで\<input type="checkbox" switch\>が対応されたので、switch属性を追加しました。スタイルはSpindle定義のものを使いたいのでそれ以外の変更はないですが、スクリーンショットの通りroleがswitchになるのでより正確になるかなと思います。属性追加に際して互換性が担保されているためサポートしていないブラウザでは何も起こらないはずです。

サポートブラウザが広がりしだいスタイルも対応できたらと思います。

ref: [Safari 17.4 supports \<input type="checkbox" switch\>](https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes#New-Features:~:text=checkbox%22%20switch%3E.%20(-,119378678,-))

Preview: https://ameba-spindle--pr1114-feat-input-switch-gsn3fmis.web.app/?path=/story/form-toggleswitch--toggle-switch

## Before
<img width="603" alt="Screenshot 2024-09-17 at 4 45 42 PM" src="https://github.com/user-attachments/assets/d7499810-899b-453b-8ac3-8f010c2f7b1e">

## After
<img width="629" alt="Screenshot 2024-09-17 at 4 45 17 PM" src="https://github.com/user-attachments/assets/54a6d3a6-fd0d-490f-b785-f22f80ae0a53">
