### PR TITLE
build(spindle-theme-switch): moduleResolutionの設定値をnode16に変更

### DIFF
--- a/packages/spindle-theme-switch/tsconfig.json
+++ b/packages/spindle-theme-switch/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "outDir": "dist",
-    "moduleResolution": "node"
+    "moduleResolution": "node16"
   },
   "include": [
     "src"


### PR DESCRIPTION
## 概要

`deploy theme switch preview` のActionがコケていたため、そちらの対応を行いました。
#1108 でActionがコケているにもかかわらずオートマージされた差分が原因でコケていたため、こちらの対応を行いました。

## 問題の原因

package.jsonのtypesの指定がexportsの指定に置き換わったため、型を見つけられなくなった。

https://github.com/GoogleChromeLabs/dark-mode-toggle/commit/6ecfb2a5c4db2942f58af7752ea7f242c33f0ba6#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R10-R17

## 対応したこと

`moduleResolution` を `node16` へ変更しました。

### 意図

https://www.typescriptlang.org/tsconfig/#moduleResolution

に記載されている

> 'node16' or 'nodenext' for modern versions of Node.js. Node.js v12 and later supports both ECMAScript imports and CommonJS require, which resolve using different algorithms. These moduleResolution values, when combined with the corresponding [module](https://www.typescriptlang.org/tsconfig/#module) values, picks the right algorithm for each resolution based on whether Node.js will see an import or require in the output JavaScript code.

の通り、適切なファイルの参照手段を選択するようになるため、 `node16` を指定しました。