### PR TITLE
feat(spindle-tokens): create font tokens

### DIFF
--- a/packages/spindle-tokens/.stylelintrc.json
+++ b/packages/spindle-tokens/.stylelintrc.json
@@ -6,6 +6,11 @@
     "declaration-property-value-allowed-list": {
       "/^--animation-easing-/": "/^cubic-bezier\\([\\d.]+, [\\d.]+, [\\d.]+, [\\d.]+\\)/"
     },
-    "color-hex-length": "long"
+    "color-hex-length": "long",
+    "value-keyword-case": ["lower", {
+      "ignoreProperties": [
+        "/^--font-/"
+      ]
+    }]
   }
 }

--- a/packages/spindle-tokens/config.js
+++ b/packages/spindle-tokens/config.js
@@ -26,6 +26,14 @@ const themeDarkFilter = {
   },
 };
 
+const fontFilter = {
+  name: 'font',
+  filter: async (token) => {
+    return token.$type === 'fontFamily';
+  },
+};
+
+
 // Using dynamic import until ESM is supported in this repogitory
 import('style-dictionary').then((module) => {
   const StyleDictionary = module.default;
@@ -33,6 +41,7 @@ import('style-dictionary').then((module) => {
   StyleDictionary.registerFilter(primitiveColorFilter);
   StyleDictionary.registerFilter(themeLightFilter);
   StyleDictionary.registerFilter(themeDarkFilter);
+  StyleDictionary.registerFilter(fontFilter);
 });
 
 module.exports = {
@@ -48,6 +57,14 @@ module.exports = {
             outputReferences: true,
           },
           filter: 'transition',
+        },
+        {
+          destination: 'dist/css/spindle-tokens-font.css',
+          format: 'css/variables',
+          options: {
+            outputReferences: true,
+          },
+          filter: 'font',
         },
         {
           destination: 'dist/css/spindle-tokens.css',

--- a/packages/spindle-tokens/tokens/font.tokens.json
+++ b/packages/spindle-tokens/tokens/font.tokens.json
@@ -1,0 +1,18 @@
+{
+  "Font": {
+    "Font Family": {
+      "Basic Version 1": {
+        "$value": "Meiryo, Yu Gothic Medium, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+        "$type": "fontFamily"
+      },
+      "Basic Version 2": {
+        "$value": "Helvetica Neue, Helvetica, Arial, Segoe UI, Hiragino Sans, ヒラギノ角ゴ ProN, Hiragino Kaku Gothic ProN, Hiragino Kaku Gothic Pro, メイリオ, Meiryo, Yu Gothic Medium, sans-seri",
+        "$type": "fontFamily"
+      },
+      "Blog Body": {
+        "$value": "-apple-system, BlinkMacSystemFont, sans-serif",
+        "$type": "fontFamily"
+      }
+    }
+  }
+}


### PR DESCRIPTION
[Spindleサイト](https://spindle.ameba.design/styles/typography/ui/)で更新した font-family のデザイントークンを反映しました。

ref: https://tr.designtokens.org/format/#font-family

CSSは以下のように書き出されます。

<details>
<summary>spindle-tokens-font.css</summary>

```css
/**
 * Do not edit directly, this file was auto-generated.
 */

:root {
  --font-font-family-blog-body: -apple-system, BlinkMacSystemFont, sans-serif;
  --font-font-family-basic-version-2: 'Helvetica Neue', Helvetica, Arial, 'Segoe UI', 'Hiragino Sans', 'ヒラギノ角ゴ ProN', 'Hiragino Kaku Gothic ProN', 'Hiragino Kaku Gothic Pro', メイリオ, Meiryo, 'Yu Gothic Medium', sans-seri;
  --font-font-family-basic-version-1: Meiryo, 'Yu Gothic Medium', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
}
```
</details>

Chromeで確認したところ、指定されているようでした。

<img width="325" alt="Screenshot 2025-01-28 at 5 58 21 PM" src="https://github.com/user-attachments/assets/8a1cafe0-a0a1-4891-8329-e52facc34387" />
