### PR TITLE
ci: add env to export icons from Figma

### DIFF
--- a/.github/workflows/build-icon-from-figma.yml
+++ b/.github/workflows/build-icon-from-figma.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Update Icons
         env:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_TOKEN_CODE_CONNECT }} # This is for Figma Code Connect in spindle-ui
           FILE_KEY: ${{ secrets.FIGMA_ICON_FILE_KEY }}
           NODE_ID: ${{ secrets.FIGMA_ICON_NODE_ID }}
           ICONS: ${{ github.event.inputs.selection }}


### PR DESCRIPTION
Figmaからのアイコン生成時にenvの指定が漏れていたので対応しました。
(@MasatoHonda の報告により発覚しました)

error: https://github.com/openameba/spindle/actions/runs/13126344361/job/36623323870
理想的な設定な方: 
https://github.com/openameba/spindle/blob/a43eb5879733e3b266b64cd8b54a8ca62e89b7a3/.github/workflows/build-icon.yml#L32-L34