### PR TITLE
ci: fix format error in building icon workflow

### DIFF
--- a/.github/workflows/build-icon-from-figma.yml
+++ b/.github/workflows/build-icon-from-figma.yml
@@ -49,7 +49,7 @@ jobs:
           node -p "JSON.stringify({ fileKey: '$FILE_KEY', nodeId: '$NODE_ID', dest: 'dist', iconNames: $ICONS.map(({name}) => name) })" > packages/spindle-icons/figma.json
           yarn lerna run --scope @openameba/spindle-icons build
           yarn lerna run --scope @openameba/spindle-ui icon
-          yarn format
+          yarn fix
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
`fix` が必要でした。

ref: https://github.com/openameba/spindle/blob/e1c8b0e46214f57e24bb535b5e76335a3a5cf15c/.github/workflows/build-icon.yml#L42C16-L42C19

error: https://github.com/openameba/spindle/actions/runs/13128281813/job/36628594815