### PR TITLE
chore(spindle-hooks): spindle-hooksのdist/をpackageに含める

### DIFF
--- a/packages/spindle-hooks/package.json
+++ b/packages/spindle-hooks/package.json
@@ -24,6 +24,9 @@
     "prepublishOnly": "yarn build"
   },
   "license": "MIT",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openameba/spindle.git"


### PR DESCRIPTION
spindle-hooksをpublishすると `dist/` が含まれないまま公開されてしまう。
dist/を明示的に含めるためにfilesを指定しました。

`$ npm pack` で含まれることを確認しました