### PR TITLE
chore(spindle-ui,spindle-hooks): set React 19 to peerDependencies

### DIFF
--- a/packages/spindle-hooks/package.json
+++ b/packages/spindle-hooks/package.json
@@ -35,8 +35,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0|| ^19.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0|| ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -49,8 +49,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
(とある案件で使いたいため) 利用できるReactのバージョンに19を追加しました。問題出たら、:sugu: 対応します。
