### PR TITLE
feat(spindle-tokens): create shadow tokens

### DIFF
--- a/packages/spindle-tokens/config.js
+++ b/packages/spindle-tokens/config.js
@@ -33,6 +33,13 @@ const fontFilter = {
   },
 };
 
+const shadowFilter = {
+  name: 'shadow',
+  filter: async (token) => {
+    return token.$type === 'shadow';
+  },
+};
+
 // Using dynamic import until ESM is supported in this repogitory
 import('style-dictionary').then((module) => {
   const StyleDictionary = module.default;
@@ -41,6 +48,7 @@ import('style-dictionary').then((module) => {
   StyleDictionary.registerFilter(themeLightFilter);
   StyleDictionary.registerFilter(themeDarkFilter);
   StyleDictionary.registerFilter(fontFilter);
+  StyleDictionary.registerFilter(shadowFilter);
 });
 
 module.exports = {
@@ -64,6 +72,15 @@ module.exports = {
             outputReferences: true,
           },
           filter: 'font',
+        },
+        {
+          destination: 'dist/css/spindle-tokens-shadow.css',
+          format: 'css/variables',
+          trasform: 'shadow/css/shorthand',
+          options: {
+            outputReferences: true,
+          },
+          filter: 'shadow',
         },
         {
           destination: 'dist/css/spindle-tokens.css',

--- a/packages/spindle-tokens/tokens/shadow.tokens.json
+++ b/packages/spindle-tokens/tokens/shadow.tokens.json
@@ -9,8 +9,7 @@
           "offsetY": "3.25px",
           "blur": "3.875px",
           "spread": "0"
-        },
-        "$description": "If you want to use this drop shadow as a box shadow, please double the value of the blur."
+        }
       },
       "Strong": {
         "$type": "shadow",
@@ -93,6 +92,104 @@
           "offsetX": "0",
           "offsetY": "11px",
           "blur": "14px",
+          "spread": "0"
+        }
+      }
+    }
+  },
+  "Box Shadow": {
+    "Lv2": {
+      "Normal": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a1f",
+          "offsetX": "0",
+          "offsetY": "3.25px",
+          "blur": "7.75px",
+          "spread": "0"
+        }
+      },
+      "Strong": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a3d",
+          "offsetX": "0",
+          "offsetY": "3.25px",
+          "blur": "7.75px",
+          "spread": "0"
+        }
+      },
+      "Weak": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a0f",
+          "offsetX": "0",
+          "offsetY": "3.25px",
+          "blur": "7.75px",
+          "spread": "0"
+        }
+      }
+    },
+    "Lv4": {
+      "Normal": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a1f",
+          "offsetX": "0",
+          "offsetY": "4.75px",
+          "blur": "14.25px",
+          "spread": "0"
+        }
+      },
+      "Strong": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a3d",
+          "offsetX": "0",
+          "offsetY": "4.75px",
+          "blur": "14.25px",
+          "spread": "0"
+        }
+      },
+      "Weak": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a0f",
+          "offsetX": "0",
+          "offsetY": "4.75px",
+          "blur": "14.25px",
+          "spread": "0"
+        }
+      }
+    },
+    "Lv6": {
+      "Normal": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a1f",
+          "offsetX": "0",
+          "offsetY": "11px",
+          "blur": "28px",
+          "spread": "0"
+        }
+      },
+      "Strong": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a3d",
+          "offsetX": "0",
+          "offsetY": "11px",
+          "blur": "28px",
+          "spread": "0"
+        }
+      },
+      "Weak": {
+        "$type": "shadow",
+        "$value": {
+          "color": "#08121a0f",
+          "offsetX": "0",
+          "offsetY": "11px",
+          "blur": "28px",
           "spread": "0"
         }
       }


### PR DESCRIPTION
shadowのtokenを `@openameba/spindle-tokens` から利用できるようにしました。

[定義ファイル](https://github.com/openameba/spindle/tree/main/packages/spindle-tokens/tokens/shadow)を元に以下のようなCSSが生成されます。アプリケーションでは [box-shadow](https://developer.mozilla.org/ja/docs/Web/CSS/box-shadow) として `--box-shadow-lv*` or [drop-shadow](https://developer.mozilla.org/ja/docs/Web/CSS/filter-function/drop-shadow) `--drop-shadow-lv*` を使います。

<details>
<summary>spindle-tokens-shadow.css</summary>

```css
:root {
  --box-shadow-lv6-weak: 0 11px 28px 0 #08121a0f;
  --box-shadow-lv6-strong: 0 11px 28px 0 #08121a3d;
  --box-shadow-lv6-normal: 0 11px 28px 0 #08121a1f;
  --box-shadow-lv4-weak: 0 4.75px 14.25px 0 #08121a0f;
  --box-shadow-lv4-strong: 0 4.75px 14.25px 0 #08121a3d;
  --box-shadow-lv4-normal: 0 4.75px 14.25px 0 #08121a1f;
  --box-shadow-lv2-weak: 0 3.25px 7.75px 0 #08121a0f;
  --box-shadow-lv2-strong: 0 3.25px 7.75px 0 #08121a3d;
  --box-shadow-lv2-normal: 0 3.25px 7.75px 0 #08121a1f;
  --drop-shadow-lv6-weak: 0 11px 14px 0 #08121a0f;
  --drop-shadow-lv6-strong: 0 11px 14px 0 #08121a3d;
  --drop-shadow-lv6-normal: 0 11px 14px 0 #08121a1f;
  --drop-shadow-lv4-weak: 0 4.75px 7.125px 0 #08121a0f;
  --drop-shadow-lv4-strong: 0 4.75px 7.125px 0 #08121a3d;
  --drop-shadow-lv4-normal: 0 4.75px 7.125px 0 #08121a1f;
  --drop-shadow-lv2-weak: 0 3.25px 3.875px 0 #08121a0f;
  --drop-shadow-lv2-strong: 0 3.25px 3.875px 0 #08121a3d;
  --drop-shadow-lv2-normal: 0 3.25px 3.875px 0 #08121a1f;
}
```
</details>

Spindle Tokenは必要なカテゴリのみimportして利用する想定です。

```
npm i @openameba/spindle-tokens
```

```
import '@openameba/spindle-tokens/dist/css/spindle-tokens-shadow.css';
```

![Shadow](https://github.com/user-attachments/assets/6d6618bb-3353-46bd-87c0-a21d7c7a9179)
