### PR TITLE
chore: test時にPUPPETEER_EXECUTABLE_PATHを設定

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,6 @@ jobs:
       - run: |
           yarn lerna run --scope @openameba/spindle-hooks build
           yarn test
+        env:
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome-stable
+


### PR DESCRIPTION
## 概要

前回 #1207 で対応した問題が再発していたので、根本解決を試みました。

## やったこと

1. cacheから復元した際にブラウザが存在するかの確認
  - https://github.com/openameba/spindle/actions/runs/13298300334/job/37134953641#step:5:7
  - 存在は確認出来た
2. test実行時に `PUPPETEER_EXECUTABLE_PATH` へ `/usr/bin/google-chrome-stable` を明示的に指定
  - ブラウザは入っているが、参照先が違っていそうだったので、明示的に指定しました