### PR TITLE
build(spindle-ui,spindle-hooks): 個別パッケージのbuild時にもextensionReplaceが実行されるように修正

### DIFF
--- a/packages/spindle-hooks/package.json
+++ b/packages/spindle-hooks/package.json
@@ -18,9 +18,10 @@
     "prebuild": "yarn clean",
     "build": "run-s build:esm build:cjs",
     "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build:esm": "run-s build:esm:js build:esm:rename",
+    "build:esm": "run-s build:esm:*",
     "build:esm:js": "tsc -p tsconfig.esm.json",
     "build:esm:rename": "npx renamer --find js --replace mjs 'dist/**'",
+    "build:esm:extensionReplace": "jscodeshift -t ../../bin/outputExtensionReplace.js dist/** --extensions=mjs",
     "prepublishOnly": "yarn build"
   },
   "license": "MIT",

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -32,6 +32,7 @@
     "build:script:esm": "run-s build:script:esm:*",
     "build:script:esm:js": "tsc -p tsconfig.esm.json",
     "build:script:esm:rename": "npx renamer --find js --replace mjs 'dist/**'",
+    "build:script:esm:extensionReplace": "jscodeshift -t ../../bin/outputExtensionReplace.js dist/** --extensions=mjs",
     "build:style": "postcss src/**/*.css src/*.css --base src -d dist/",
     "preicon": "npx rimraf 'src/Icon/!(*.stories).tsx' && npx cpx '../spindle-icons/dist/svg/!(sprite).svg' icon-tmp",
     "icon": "run-s icon:react icon:connect",


### PR DESCRIPTION
## 概要

#1178 で内部参照の拡張子を置き換える処理を追加しましたが、リリース時に実行されるのは個別パッケージのbuildなので、リリース時に置き換えが実行されていなかったのを修正しました。

少々不格好なのでリリースフロー自体を見直す等したいのですが、ひとまず意図したとおりに配信されるのを優先し、今回の対応を加えました。

## 確認方法

spindle-ui,spindle-hooksの階層で `yarn build` を実行し、distに出力されたものの置き換えが完了しているのかを確認する。