### PR TITLE
fix(spindle-ui): set DropDown background color

### DIFF
--- a/packages/spindle-ui/src/Form/DropDown.css
+++ b/packages/spindle-ui/src/Form/DropDown.css
@@ -23,6 +23,7 @@
 
 .spui-DropDown-visual {
   align-items: center;
+  background-color: var(--color-surface-primary);
   border: solid 1px var(--color-border-medium-emphasis);
   border-radius: 8px;
   box-sizing: border-box;


### PR DESCRIPTION
`<DropDown>`の背景色を指定しました。

## Before
<img width="139" alt="Screenshot 2025-02-28 at 2 30 31 PM" src="https://github.com/user-attachments/assets/57d8330d-61e7-4ce4-8605-a26bd0dee421" />

## After
<img width="138" alt="Screenshot 2025-02-28 at 2 31 09 PM" src="https://github.com/user-attachments/assets/4f490b90-74c4-4b67-83dd-c9989f449148" />

