### PR TITLE
feat(spindle-ui): :user-invalid for input errors

### DIFF
--- a/packages/spindle-ui/src/Form/DropDown.css
+++ b/packages/spindle-ui/src/Form/DropDown.css
@@ -82,7 +82,9 @@
 }
 
 .spui-DropDown-label.is-error .spui-DropDown-visual,
-.spui-DropDown-label.is-error .spui-DropDown-icon {
+.spui-DropDown-label.is-error .spui-DropDown-icon,
+.spui-DropDown-label:user-invalid .spui-DropDown-visual,
+.spui-DropDown-label:user-invalid .spui-DropDown-icon {
   background-color: var(--color-surface-caution-light);
   border-color: var(--color-border-caution);
 }

--- a/packages/spindle-ui/src/Form/DropDown.stories.mdx
+++ b/packages/spindle-ui/src/Form/DropDown.stories.mdx
@@ -103,6 +103,8 @@ import { DropDown } from './DropDown';
 
 ## DropDown With Error
 
+<Description>エラー表示にするには`hasError`プロパティを付与してください。また、`:user-invalid`擬似クラスが付与される条件では`hasError`プロパティに関係なくエラー表示になります。</Description>
+
 <Preview withSource="open">
   <Story name="DropDown With Error">
     <DropDown aria-label="期間を選択" hasError name="termWithError" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}>

--- a/packages/spindle-ui/src/Form/TextArea.css
+++ b/packages/spindle-ui/src/Form/TextArea.css
@@ -37,7 +37,8 @@
   box-shadow: none;
 }
 
-.spui-TextArea.is-error {
+.spui-TextArea.is-error,
+.spui-TextArea:user-invalid {
   background-color: var(--color-surface-caution-light);
   border-color: var(--color-border-caution);
 }

--- a/packages/spindle-ui/src/Form/TextArea.stories.mdx
+++ b/packages/spindle-ui/src/Form/TextArea.stories.mdx
@@ -44,6 +44,8 @@ import { TextArea } from './TextArea';
 
 ## Text Area With Error
 
+<Description>エラー表示にするには`hasError`プロパティを付与してください。また、`:user-invalid`擬似クラスが付与される条件では`hasError`プロパティに関係なくエラー表示になります。</Description>
+
 <Preview withSource="open">
   <Story name="Text Area With Error">
     <TextArea placeholder="ブログを読んで感じたことを伝えましょう" hasError id="TextAreaWithError" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')}></TextArea>

--- a/packages/spindle-ui/src/Form/TextField.css
+++ b/packages/spindle-ui/src/Form/TextField.css
@@ -35,7 +35,8 @@
   box-shadow: none;
 }
 
-.spui-TextField.is-error {
+.spui-TextField.is-error,
+.spui-TextField:user-invalid {
   background-color: var(--color-surface-caution-light);
   border-color: var(--color-border-caution);
 }

--- a/packages/spindle-ui/src/Form/TextField.stories.mdx
+++ b/packages/spindle-ui/src/Form/TextField.stories.mdx
@@ -44,6 +44,8 @@ import { TextField } from './TextField';
 
 ## Large With Error
 
+<Description>エラー表示にするには`hasError`プロパティを付与してください。また、`:user-invalid`擬似クラスが付与される条件では`hasError`プロパティに関係なくエラー表示になります。</Description>
+
 <Preview withSource="open">
   <Story name="Large With Error">
     <TextField placeholder="ameba-blog" hasError id="TextFieldWithError" variant="large" {...actions('onClick', 'onChange', 'onInput', 'onFocus', 'onBlur')} />


### PR DESCRIPTION
現在 `hasError` で意図的にエラーを指定できるコンポーネントに [user-invalid](https://developer.mozilla.org/ja/docs/Web/CSS/:user-invalid) のタイミングで自動的にエラー表示になるように追加しました。

JSライブラリで状態を管理したい場合は主に前者、formで管理したい場合は主に後者を利用するイメージです。

`:user-invalid` 時は強制的にエラー表示にしてしまって問題ないと考えていますが、懸念になりそうなことがあったら教えてください！

<img width="672" alt="Screenshot 2025-03-01 at 7 46 14 PM" src="https://github.com/user-attachments/assets/09f94053-df4b-4849-b67f-046de0399774" />
