### PR TITLE
chore: upgrade ameba-color-palette.css

### DIFF
--- a/examples/css-modules/package.json
+++ b/examples/css-modules/package.json
@@ -22,7 +22,7 @@
     "@openameba/spindle-ui": "^0.5.0",
     "@types/react": "^16.9.56",
     "@types/react-dom": "^16.9.9",
-    "ameba-color-palette.css": "^4.2.0",
+    "ameba-color-palette.css": "^4.14.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   }

--- a/examples/css-modules/yarn.lock
+++ b/examples/css-modules/yarn.lock
@@ -259,10 +259,10 @@ ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ameba-color-palette.css@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.2.0.tgz#e61fb906eb1210368f646b7745f79d1c384c18b4"
-  integrity sha512-5aYbuMY0aXSZjR+ot55SYyLX6cXib5J11AuAiMaMKY+87UawT6515JvPJ3LQxlivxK7/rA14+qnFuLTnLmDFNQ==
+ameba-color-palette.css@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.14.0.tgz#0f437153094e0be7e57a6c024ae8d13c94058f14"
+  integrity sha512-iPUmaWW3EvpQm1TRJ69E3smgeoVNCKskzPjknPjT3aWwbMlRHaT2/dWnLdYsFqz/huNchw5Dp1g01ekkPPjSBQ==
 
 ameba-color-palette.css@openameba/ameba-color-palette.css#v3.0.0-beta.0:
   version "3.0.0-beta.0"

--- a/examples/postcss/package.json
+++ b/examples/postcss/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@openameba/spindle-ui": "^0.5.0",
-    "ameba-color-palette.css": "^4.2.0"
+    "ameba-color-palette.css": "^4.14.0"
   }
 }

--- a/examples/postcss/yarn.lock
+++ b/examples/postcss/yarn.lock
@@ -71,10 +71,10 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-ameba-color-palette.css@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.2.0.tgz#e61fb906eb1210368f646b7745f79d1c384c18b4"
-  integrity sha512-5aYbuMY0aXSZjR+ot55SYyLX6cXib5J11AuAiMaMKY+87UawT6515JvPJ3LQxlivxK7/rA14+qnFuLTnLmDFNQ==
+ameba-color-palette.css@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.14.0.tgz#0f437153094e0be7e57a6c024ae8d13c94058f14"
+  integrity sha512-iPUmaWW3EvpQm1TRJ69E3smgeoVNCKskzPjknPjT3aWwbMlRHaT2/dWnLdYsFqz/huNchw5Dp1g01ekkPPjSBQ==
 
 ameba-color-palette.css@openameba/ameba-color-palette.css#v3.0.0-beta.0:
   version "3.0.0-beta.0"

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -21,7 +21,7 @@
     "@openameba/spindle-ui": "^0.5.0",
     "@types/react": "^16.9.56",
     "@types/react-dom": "^16.9.9",
-    "ameba-color-palette.css": "^4.2.0",
+    "ameba-color-palette.css": "^4.14.0",
     "preact": "^10.5.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/examples/preact/yarn.lock
+++ b/examples/preact/yarn.lock
@@ -259,10 +259,10 @@ ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ameba-color-palette.css@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.2.0.tgz#e61fb906eb1210368f646b7745f79d1c384c18b4"
-  integrity sha512-5aYbuMY0aXSZjR+ot55SYyLX6cXib5J11AuAiMaMKY+87UawT6515JvPJ3LQxlivxK7/rA14+qnFuLTnLmDFNQ==
+ameba-color-palette.css@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.14.0.tgz#0f437153094e0be7e57a6c024ae8d13c94058f14"
+  integrity sha512-iPUmaWW3EvpQm1TRJ69E3smgeoVNCKskzPjknPjT3aWwbMlRHaT2/dWnLdYsFqz/huNchw5Dp1g01ekkPPjSBQ==
 
 ameba-color-palette.css@openameba/ameba-color-palette.css#v3.0.0-beta.0:
   version "3.0.0-beta.0"

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -22,7 +22,7 @@
     "@types/react": "^16.9.56",
     "@types/react-dom": "^16.9.9",
     "@types/styled-components": "^5.1.4",
-    "ameba-color-palette.css": "^4.2.0",
+    "ameba-color-palette.css": "^4.14.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "^5.2.1"

--- a/examples/styled-components/yarn.lock
+++ b/examples/styled-components/yarn.lock
@@ -472,10 +472,10 @@ ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ameba-color-palette.css@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.2.0.tgz#e61fb906eb1210368f646b7745f79d1c384c18b4"
-  integrity sha512-5aYbuMY0aXSZjR+ot55SYyLX6cXib5J11AuAiMaMKY+87UawT6515JvPJ3LQxlivxK7/rA14+qnFuLTnLmDFNQ==
+ameba-color-palette.css@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.14.0.tgz#0f437153094e0be7e57a6c024ae8d13c94058f14"
+  integrity sha512-iPUmaWW3EvpQm1TRJ69E3smgeoVNCKskzPjknPjT3aWwbMlRHaT2/dWnLdYsFqz/huNchw5Dp1g01ekkPPjSBQ==
 
 ameba-color-palette.css@openameba/ameba-color-palette.css#v3.0.0-beta.0:
   version "3.0.0-beta.0"

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@openameba/spindle-hooks": "^1.4.2",
-    "ameba-color-palette.css": "^4.9.0",
+    "ameba-color-palette.css": "^4.14.0",
     "react-merge-refs": "^1.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7178,10 +7178,10 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.1.0, ajv@^8.11.0, ajv@^8.3.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ameba-color-palette.css@^4.9.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.13.0.tgz#94843116c63d89db67c8172daf959ad3279d9cc1"
-  integrity sha512-z0V0kVYd/EHawsFVPRbzjy/Y8Sc5yYTJHbzLv7+g7tQs6nPihLyEC+9106fpHaxwjM131SXP1zqweFxwkapQWA==
+ameba-color-palette.css@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/ameba-color-palette.css/-/ameba-color-palette.css-4.14.0.tgz#0f437153094e0be7e57a6c024ae8d13c94058f14"
+  integrity sha512-iPUmaWW3EvpQm1TRJ69E3smgeoVNCKskzPjknPjT3aWwbMlRHaT2/dWnLdYsFqz/huNchw5Dp1g01ekkPPjSBQ==
 
 analyze-desumasu-dearu@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
spindle-uiとexamples以下の各パッケージが依存しているameba-color-palette.cssのバージョンを、4.14.0に上げました。
ただし、examples/sassについてはnode-sassがNode.js v13しか対応しておらずアップグレードできなかったため、一旦除外しました。