### PR TITLE
feat(spindle-mcp-server): add doc for css token installation

### DIFF
--- a/packages/spindle-mcp-server/dist/design-token.d.ts
+++ b/packages/spindle-mcp-server/dist/design-token.d.ts
@@ -1,2 +1,7 @@
+interface DesignTokens {
+    tokenList: Record<string, object>;
+    documentation: string;
+}
 export declare function getCssDesignToken(tokenType: string): object | null;
-export declare function getAllCssDesignTokens(): Record<string, object>;
+export declare function getAllCssDesignTokens(): DesignTokens;
+export {};

--- a/packages/spindle-mcp-server/dist/design-token.js
+++ b/packages/spindle-mcp-server/dist/design-token.js
@@ -33,13 +33,13 @@ function getAllCssDesignTokens() {
     const files = fs_1.default
         .readdirSync(cssDir)
         .filter((file) => file.startsWith('spindle-tokens-') && file.endsWith('.css'));
-    const tokens = {};
+    const tokenList = {};
     files.forEach((file) => {
         const tokenType = file.replace('spindle-tokens-', '').replace('.css', '');
         try {
             const token = getCssDesignToken(tokenType);
             if (token) {
-                tokens[tokenType] = token;
+                tokenList[tokenType] = token;
             }
         }
         catch (error) {
@@ -47,8 +47,58 @@ function getAllCssDesignTokens() {
         }
     });
     // All apps use the ameba color palette instead of the css tokens
-    tokens.color = parseCssCustomProperties(amebaColorPaletteCss);
-    return tokens;
+    tokenList.color = parseCssCustomProperties(amebaColorPaletteCss);
+    const documentation = `
+カラートークンを利用するには、ameba-color-palette.cssを利用してください。
+
+\`\`\`bash
+npm install ameba-color-palette.css
+\`\`\`
+
+\`\`\`css
+@import 'ameba-color-palette.css';
+\`\`\`
+
+\`\`\`javascript
+import 'ameba-color-palette.css/ameba-color-palette.css';
+\`\`\`
+
+\`\`\`HTML
+<link rel="stylesheet" href="https://unpkg.com/ameba-color-palette.css/ameba-color-palette.css">
+\`\`\`
+
+※ 本番環境で利用する際にはセルフホストすることを推奨します。
+
+カラー以外のデザイントークンを利用するには、以下のようにしてください。
+
+\`\`\`bash
+npm install @openameba/spindle-tokens
+\`\`\`
+
+\`\`\`css
+@import '@openameba/spindle-tokens/dist/css/spindle-tokens-animation.css';
+@import '@openameba/spindle-tokens/dist/css/spindle-tokens-font.css';
+@import '@openameba/spindle-tokens/dist/css/spindle-tokens-shadow.css';
+\`\`\`
+
+\`\`\`javascript
+import '@openameba/spindle-tokens/dist/css/spindle-tokens-animation.css';
+import '@openameba/spindle-tokens/dist/css/spindle-tokens-font.css';
+import '@openameba/spindle-tokens/dist/css/spindle-tokens-shadow.css';
+\`\`\`
+
+\`\`\`html
+<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-tokens/dist/css/spindle-tokens-animation.css">
+<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-tokens/dist/css/spindle-tokens-font.css">
+<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-tokens/dist/css/spindle-tokens-shadow.css">
+\`\`\`
+
+※ 本番環境で利用する際にはでセルフホストすることを推奨します。
+  `;
+    return {
+        tokenList,
+        documentation,
+    };
 }
 // @see https://github.com/openameba/ameba-color-palette.css
 const amebaColorPaletteCss = `

--- a/packages/spindle-mcp-server/src/design-token.test.ts
+++ b/packages/spindle-mcp-server/src/design-token.test.ts
@@ -8,8 +8,11 @@ describe('Design token functions', () => {
 
       expect(result).toEqual(
         expect.objectContaining({
-          color: expect.any(Object),
-          animation: expect.any(Object),
+          tokenList: expect.objectContaining({
+            color: expect.any(Object),
+            animation: expect.any(Object),
+          }),
+          documentation: expect.any(String),
         }),
       );
     });

--- a/packages/spindle-mcp-server/src/design-token.ts
+++ b/packages/spindle-mcp-server/src/design-token.ts
@@ -1,6 +1,11 @@
 import path from 'path';
 import fs from 'fs';
 
+interface DesignTokens {
+  tokenList: Record<string, object>;
+  documentation: string;
+}
+
 function parseCssCustomProperties(cssContent: string): object {
   const properties: Record<string, string> = {};
   const regex = /--([^:]+):\s*([^;]+);/g;
@@ -32,7 +37,7 @@ export function getCssDesignToken(tokenType: string): object | null {
   return parseCssCustomProperties(content);
 }
 
-export function getAllCssDesignTokens(): Record<string, object> {
+export function getAllCssDesignTokens(): DesignTokens {
   const cssDir = path.join(__dirname, '../../spindle-tokens/dist/css');
   const files = fs
     .readdirSync(cssDir)
@@ -40,14 +45,14 @@ export function getAllCssDesignTokens(): Record<string, object> {
       (file) => file.startsWith('spindle-tokens-') && file.endsWith('.css'),
     );
 
-  const tokens: Record<string, object> = {};
+  const tokenList: Record<string, object> = {};
 
   files.forEach((file) => {
     const tokenType = file.replace('spindle-tokens-', '').replace('.css', '');
     try {
       const token = getCssDesignToken(tokenType);
       if (token) {
-        tokens[tokenType] = token;
+        tokenList[tokenType] = token;
       }
     } catch (error) {
       console.error(`Failed to load CSS ${tokenType} tokens:`, error);
@@ -55,9 +60,60 @@ export function getAllCssDesignTokens(): Record<string, object> {
   });
 
   // All apps use the ameba color palette instead of the css tokens
-  tokens.color = parseCssCustomProperties(amebaColorPaletteCss);
+  tokenList.color = parseCssCustomProperties(amebaColorPaletteCss);
 
-  return tokens;
+  const documentation = `
+カラートークンを利用するには、ameba-color-palette.cssを利用してください。
+
+\`\`\`bash
+npm install ameba-color-palette.css
+\`\`\`
+
+\`\`\`css
+@import 'ameba-color-palette.css';
+\`\`\`
+
+\`\`\`javascript
+import 'ameba-color-palette.css/ameba-color-palette.css';
+\`\`\`
+
+\`\`\`HTML
+<link rel="stylesheet" href="https://unpkg.com/ameba-color-palette.css/ameba-color-palette.css">
+\`\`\`
+
+※ 本番環境で利用する際にはセルフホストすることを推奨します。
+
+カラー以外のデザイントークンを利用するには、以下のようにしてください。
+
+\`\`\`bash
+npm install @openameba/spindle-tokens
+\`\`\`
+
+\`\`\`css
+@import '@openameba/spindle-tokens/dist/css/spindle-tokens-animation.css';
+@import '@openameba/spindle-tokens/dist/css/spindle-tokens-font.css';
+@import '@openameba/spindle-tokens/dist/css/spindle-tokens-shadow.css';
+\`\`\`
+
+\`\`\`javascript
+import '@openameba/spindle-tokens/dist/css/spindle-tokens-animation.css';
+import '@openameba/spindle-tokens/dist/css/spindle-tokens-font.css';
+import '@openameba/spindle-tokens/dist/css/spindle-tokens-shadow.css';
+\`\`\`
+
+\`\`\`html
+<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-tokens/dist/css/spindle-tokens-animation.css">
+<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-tokens/dist/css/spindle-tokens-font.css">
+<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-tokens/dist/css/spindle-tokens-shadow.css">
+\`\`\`
+
+※ 本番環境で利用する際にはでセルフホストすることを推奨します。
+  `;
+
+  return {
+    tokenList,
+    documentation,
+  };
 }
 
 // @see https://github.com/openameba/ameba-color-palette.css


### PR DESCRIPTION
CSSトークンがうまく読み込まれない時があるので、ドキュメントを追加しました。
