### PR TITLE
fix(spindle-ui): fix semi modal style

### DIFF
--- a/packages/spindle-ui/src/Modal/SemiModal.css
+++ b/packages/spindle-ui/src/Modal/SemiModal.css
@@ -219,7 +219,7 @@ html.spui-SemiModal--open {
   }
 
   .spui-SemiModal[data-type='sheet'] .spui-SemiModal-frame {
-    max-height: calc(100vh - 200px);
+    max-height: calc(100dvh - 200px);
   }
 
   .spui-SemiModal[data-type='sheet'][data-size='small'] .spui-SemiModal-frame {
@@ -253,7 +253,11 @@ html.spui-SemiModal--open {
 
   .spui-SemiModal[data-type='popup'] .spui-SemiModal-frame,
   .spui-SemiModal[data-type='sheet'] .spui-SemiModal-frame {
-    max-height: calc(100vh - (20px * 2));
+    /*
+     * popup時は上下に20pxずつの余白を持つ
+     * sheet時は上に40pxの余白を持つ
+    */
+    max-height: calc(100dvh - (20px * 2));
   }
 
   .spui-SemiModal[data-type='popup'] {


### PR DESCRIPTION
# 概要
SemiModalのmax-heightについて
モバイル端末やタブレット端末でブラウザのNavigation barの高さが考慮されていないため、
考慮する形に修正しました。

# 動作確認
before
![image](https://github.com/user-attachments/assets/b12adfad-a5e7-4385-9c85-62e0018c6cb5)

after
| pc chrome | iOS(sheet) | iOS(popup) |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/880da7a5-dd13-4a95-811a-e26512633baf) | ![image](https://github.com/user-attachments/assets/b7664061-e09c-4ec6-988c-d203be00b0dc) | ![image](https://github.com/user-attachments/assets/ace09522-c61e-420a-8882-2c029c94717d) |