### PR TITLE
feat(spindle-ui): add table component 

### DIFF
--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -328,3 +328,9 @@
 .spui-Table-cell--alignRight {
   text-align: right;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .spui-Table-frame--scrollable {
+    scroll-behavior: auto;
+  }
+}

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -51,6 +51,7 @@
 
 .spui-Table-frame--scrollable {
   overflow-x: auto;
+  scroll-behavior: smooth;
 }
 
 /*

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -16,9 +16,9 @@
   --Table-head-fontWeight: bold;
   --Table-cell-fontWeight: normal;
   --Table-footer-fontWeight: normal;
-  --Table-head-fontSize: 14px;
-  --Table-cell-fontSize: 14px;
-  --Table-footer-fontSize: 14px;
+  --Table-head-fontSize: 0.875rem;
+  --Table-cell-fontSize: 0.875rem;
+  --Table-footer-fontSize: 0.875rem;
   --Table-head-lineHeight: 1.4;
   --Table-cell-lineHeight: 1.4;
   --Table-footer-lineHeight: 1.4;
@@ -36,7 +36,7 @@
 
   /* Caption・キャプション関連 */
   --Table-caption-color: var(--color-text-low-emphasis);
-  --Table-caption-fontSize: 12px;
+  --Table-caption-fontSize: 0.75rem;
   --Table-caption-lineHeight: 1.6;
   --Table-caption-fontWeight: normal;
 }

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -1,0 +1,365 @@
+/*
+ * Table
+ * NOTE: Styles can be overridden with "--Table-*" variables
+ */
+:root {
+  /* Surface・背景関連 */
+  --Table-backgroundColor: var(--color-surface-primary);
+  --Table-head-backgroundColor: var(--color-surface-tertiary);
+  --Table-cell-backgroundColor: var(--color-surface-primary);
+  --Table-row-striped-backgroundColor: var(--color-background);
+  --Table-row-hover-backgroundColor: var(--color-surface-secondary);
+
+  /* Text・テキスト関連 */
+  --Table-head-color: var(--color-text-high-emphasis);
+  --Table-cell-color: var(--color-text-high-emphasis);
+  --Table-head-fontWeight: bold;
+  --Table-head-fontSize: 14px;
+  --Table-cell-fontSize: 14px;
+  --Table-head-lineHeight: 1.4;
+  --Table-cell-lineHeight: 1.4;
+
+  /* Border・ボーダー関連 */
+  --Table-outlineColor: var(--color-border-strong-emphasis);
+  --Table-cell-borderColor: var(--color-border-low-emphasis);
+  --Table-footer-separatorColor: var(--color-border-medium-emphasis);
+  --Table-borderRadius: 16px;
+
+  /* Layout・レイアウト関連 */
+  --Table-head-padding: 12px;
+  --Table-cell-padding: 12px;
+  --Table-sticky-shadow: var(--box-shadow-lv2-normal);
+  --Table-sticky-z-index: 1;
+
+  /* Caption・キャプション関連 */
+  --Table-caption-color: var(--color-text-low-emphasis);
+  --Table-caption-fontSize: 12px;
+  --Table-caption-lineHeight: 1.6;
+  --Table-caption-fontWeight: normal;
+
+  /* Footer・フッター関連 */
+  --Table-footer-backgroundColor: var(--Table-cell-backgroundColor);
+  --Table-footer-color: var(--Table-cell-color);
+  --Table-footer-fontWeight: normal;
+  --Table-footer-fontSize: var(--Table-cell-fontSize);
+  --Table-footer-lineHeight: var(--Table-cell-lineHeight);
+  --Table-footer-padding: var(--Table-cell-padding);
+}
+
+/*
+ * Table container
+ */
+.spui-Table-container {
+  position: relative;
+  width: 100%;
+}
+
+.spui-Table-container--scrollable {
+  overflow-x: auto;
+}
+
+/*
+ * Table base
+ */
+.spui-Table {
+  background-color: var(--Table-backgroundColor);
+  border-spacing: 0;
+  table-layout: auto;
+  width: 100%;
+}
+
+.spui-Table--fixed {
+  table-layout: fixed;
+}
+
+.spui-Table--scrollable {
+  min-width: max-content;
+  width: 100%;
+}
+
+/*
+ * Border patterns - Array-based system
+ */
+
+/* horizontal: 水平線 */
+.spui-Table--horizontal .spui-Table-head,
+.spui-Table--horizontal .spui-Table-cell {
+  border-bottom: 1px solid var(--Table-cell-borderColor);
+}
+
+/* tbody の最後の行のみ bottom border を削除 */
+.spui-Table--horizontal
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-head,
+.spui-Table--horizontal
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-cell {
+  border-bottom: none;
+}
+
+/* footer の最初の行に強調された区切り線 */
+.spui-Table--horizontal
+  .spui-Table-footer
+  .spui-Table-row:first-child
+  .spui-Table-head,
+.spui-Table--horizontal
+  .spui-Table-footer
+  .spui-Table-row:first-child
+  .spui-Table-cell {
+  border-top: 2px solid var(--Table-footer-separatorColor);
+}
+
+/* footer の最後の行のみ bottom border を削除 */
+.spui-Table--horizontal
+  .spui-Table-footer
+  .spui-Table-row:last-child
+  .spui-Table-head,
+.spui-Table--horizontal
+  .spui-Table-footer
+  .spui-Table-row:last-child
+  .spui-Table-cell {
+  border-bottom: none;
+}
+
+/* vertical: 垂直線 */
+.spui-Table--vertical .spui-Table-head,
+.spui-Table--vertical .spui-Table-cell {
+  border-right: 1px solid var(--Table-cell-borderColor);
+}
+
+.spui-Table--vertical .spui-Table-head:last-child,
+.spui-Table--vertical .spui-Table-cell:last-child {
+  border-right: none;
+}
+
+/* outlined: 外枠 */
+.spui-Table--outlined {
+  border: 1px solid var(--Table-outlineColor);
+}
+
+/*
+ * Footer 固有のスタイル
+ * フッターは合計・集計行として目立たせる
+ */
+.spui-Table-footer .spui-Table-cell {
+  background-color: var(--Table-footer-backgroundColor);
+  color: var(--Table-footer-color);
+  font-size: var(--Table-footer-fontSize);
+  font-weight: var(--Table-footer-fontWeight);
+  line-height: var(--Table-footer-lineHeight);
+  padding: var(--Table-footer-padding);
+}
+
+.spui-Table-footer .spui-Table-head {
+  color: var(--Table-footer-color);
+  font-size: var(--Table-footer-fontSize);
+  font-weight: var(--Table-footer-fontWeight);
+  line-height: var(--Table-footer-lineHeight);
+  padding: var(--Table-footer-padding);
+}
+
+/*
+ * Rounded corners
+ */
+.spui-Table--rounded {
+  border-collapse: separate;
+  border-radius: var(--Table-borderRadius);
+  border-spacing: 0;
+}
+
+/* rounded + outlined の組み合わせでborder-radiusを適用 */
+.spui-Table--rounded.spui-Table--outlined {
+  border-radius: var(--Table-borderRadius);
+}
+
+/* 内部要素の角丸処理 */
+.spui-Table--rounded
+  .spui-Table-header
+  .spui-Table-row:first-child
+  .spui-Table-head:first-child {
+  border-top-left-radius: calc(var(--Table-borderRadius) - 1px);
+}
+
+.spui-Table--rounded
+  .spui-Table-header
+  .spui-Table-row:first-child
+  .spui-Table-head:last-child {
+  border-top-right-radius: calc(var(--Table-borderRadius) - 1px);
+}
+
+/* ヘッダー行がない場合のボディ最初の行 */
+.spui-Table--rounded:not(:has(.spui-Table-header))
+  .spui-Table-body
+  .spui-Table-row:first-child
+  .spui-Table-head:first-child,
+.spui-Table--rounded:not(:has(.spui-Table-header))
+  .spui-Table-body
+  .spui-Table-row:first-child
+  .spui-Table-cell:first-child {
+  border-top-left-radius: calc(var(--Table-borderRadius) - 1px);
+}
+
+.spui-Table--rounded:not(:has(.spui-Table-header))
+  .spui-Table-body
+  .spui-Table-row:first-child
+  .spui-Table-head:last-child,
+.spui-Table--rounded:not(:has(.spui-Table-header))
+  .spui-Table-body
+  .spui-Table-row:first-child
+  .spui-Table-cell:last-child {
+  border-top-right-radius: calc(var(--Table-borderRadius) - 1px);
+}
+
+.spui-Table--rounded
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-head:first-child,
+.spui-Table--rounded
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-cell:first-child {
+  border-bottom-left-radius: calc(var(--Table-borderRadius) - 1px);
+}
+
+.spui-Table--rounded
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-head:last-child,
+.spui-Table--rounded
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-cell:last-child {
+  border-bottom-right-radius: calc(var(--Table-borderRadius) - 1px);
+}
+
+/* footerがある場合の角丸処理 */
+.spui-Table--rounded
+  .spui-Table-footer
+  .spui-Table-row:last-child
+  .spui-Table-head:first-child,
+.spui-Table--rounded
+  .spui-Table-footer
+  .spui-Table-row:last-child
+  .spui-Table-cell:first-child {
+  border-bottom-left-radius: calc(var(--Table-borderRadius) - 1px);
+}
+
+.spui-Table--rounded
+  .spui-Table-footer
+  .spui-Table-row:last-child
+  .spui-Table-head:last-child,
+.spui-Table--rounded
+  .spui-Table-footer
+  .spui-Table-row:last-child
+  .spui-Table-cell:last-child {
+  border-bottom-right-radius: calc(var(--Table-borderRadius) - 1px);
+}
+
+/*
+ * Striped rows - セルのみ、行見出しは除外
+ */
+.spui-Table--striped
+  .spui-Table-body
+  .spui-Table-row:nth-child(even)
+  .spui-Table-cell {
+  background-color: var(--Table-row-striped-backgroundColor);
+}
+
+/*
+ * Table elements
+ */
+.spui-Table-caption {
+  caption-side: bottom;
+  color: var(--Table-caption-color);
+  font-size: var(--Table-caption-fontSize);
+  font-weight: var(--Table-caption-fontWeight);
+  line-height: var(--Table-caption-lineHeight);
+  margin-top: 12px;
+  text-align: left;
+}
+
+.spui-Table-header {
+  /* thead element - no specific styles, semantic structure only */
+}
+
+.spui-Table-body {
+  /* tbody element - no specific styles, semantic structure only */
+}
+
+.spui-Table-footer {
+  /* tfoot element - no specific styles, semantic structure only */
+}
+
+.spui-Table-row {
+  /* tr element - no specific styles, semantic structure only */
+}
+
+/*
+ * Table cells
+ */
+.spui-Table-head {
+  background-color: var(--Table-head-backgroundColor);
+  color: var(--Table-head-color);
+  font-size: var(--Table-head-fontSize);
+  font-weight: var(--Table-head-fontWeight);
+  line-height: var(--Table-head-lineHeight);
+  padding: var(--Table-head-padding);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.spui-Table-head--alignLeft {
+  text-align: left;
+}
+
+.spui-Table-head--alignCenter {
+  text-align: center;
+}
+
+.spui-Table-head--alignRight {
+  text-align: right;
+}
+
+/*
+ * Data cells
+ */
+.spui-Table-cell {
+  background-color: var(--Table-cell-backgroundColor);
+  color: var(--Table-cell-color);
+  font-size: var(--Table-cell-fontSize);
+  line-height: var(--Table-cell-lineHeight);
+  padding: var(--Table-cell-padding);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.spui-Table-cell--alignLeft {
+  text-align: left;
+}
+
+.spui-Table-cell--alignCenter {
+  text-align: center;
+}
+
+.spui-Table-cell--alignRight {
+  text-align: right;
+}
+
+/*
+ * Print styles
+ */
+@media print {
+  .spui-Table-container {
+    overflow: visible;
+  }
+
+  .spui-Table {
+    break-inside: auto;
+  }
+
+  .spui-Table-row {
+    break-inside: avoid;
+  }
+}

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -16,9 +16,9 @@
   --Table-head-fontWeight: bold;
   --Table-cell-fontWeight: normal;
   --Table-footer-fontWeight: normal;
-  --Table-head-fontSize: 0.875rem;
-  --Table-cell-fontSize: 0.875rem;
-  --Table-footer-fontSize: 0.875rem;
+  --Table-head-fontSize: 0.875em;
+  --Table-cell-fontSize: 0.875em;
+  --Table-footer-fontSize: 0.875em;
   --Table-head-lineHeight: 1.4;
   --Table-cell-lineHeight: 1.4;
   --Table-footer-lineHeight: 1.4;
@@ -36,7 +36,7 @@
 
   /* Caption・キャプション関連 */
   --Table-caption-color: var(--color-text-low-emphasis);
-  --Table-caption-fontSize: 0.75rem;
+  --Table-caption-fontSize: 0.75em;
   --Table-caption-lineHeight: 1.6;
   --Table-caption-fontWeight: normal;
 }

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -42,7 +42,7 @@
 }
 
 /*
- * Table container
+ * Table frame
  */
 .spui-Table-frame {
   position: relative;

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -44,12 +44,12 @@
 /*
  * Table container
  */
-.spui-Table-container {
+.spui-Table-frame {
   position: relative;
   width: 100%;
 }
 
-.spui-Table-container--scrollable {
+.spui-Table-frame--scrollable {
   overflow-x: auto;
 }
 

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -229,6 +229,26 @@
   border-bottom-right-radius: calc(var(--Table-borderRadius) - 1px);
 }
 
+.spui-Table--rounded:has(.spui-Table-footer)
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-head:first-child,
+.spui-Table--rounded:has(.spui-Table-footer)
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-cell:first-child,
+.spui-Table--rounded:has(.spui-Table-footer)
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-head:last-child,
+.spui-Table--rounded:has(.spui-Table-footer)
+  .spui-Table-body
+  .spui-Table-row:last-child
+  .spui-Table-cell:last-child {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 /* footerがある場合の角丸処理 */
 .spui-Table--rounded
   .spui-Table-footer

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -8,16 +8,20 @@
   --Table-head-backgroundColor: var(--color-surface-tertiary);
   --Table-cell-backgroundColor: var(--color-surface-primary);
   --Table-row-striped-backgroundColor: var(--color-background);
-  --Table-row-hover-backgroundColor: var(--color-surface-secondary);
 
   /* Text・テキスト関連 */
   --Table-head-color: var(--color-text-high-emphasis);
   --Table-cell-color: var(--color-text-high-emphasis);
+  --Table-footer-color: var(--color-text-high-emphasis);
   --Table-head-fontWeight: bold;
+  --Table-cell-fontWeight: normal;
+  --Table-footer-fontWeight: normal;
   --Table-head-fontSize: 14px;
   --Table-cell-fontSize: 14px;
+  --Table-footer-fontSize: 14px;
   --Table-head-lineHeight: 1.4;
   --Table-cell-lineHeight: 1.4;
+  --Table-footer-lineHeight: 1.4;
 
   /* Border・ボーダー関連 */
   --Table-outlineColor: var(--color-border-strong-emphasis);
@@ -28,22 +32,13 @@
   /* Layout・レイアウト関連 */
   --Table-head-padding: 12px;
   --Table-cell-padding: 12px;
-  --Table-sticky-shadow: var(--box-shadow-lv2-normal);
-  --Table-sticky-z-index: 1;
+  --Table-footer-padding: 12px;
 
   /* Caption・キャプション関連 */
   --Table-caption-color: var(--color-text-low-emphasis);
   --Table-caption-fontSize: 12px;
   --Table-caption-lineHeight: 1.6;
   --Table-caption-fontWeight: normal;
-
-  /* Footer・フッター関連 */
-  --Table-footer-backgroundColor: var(--Table-cell-backgroundColor);
-  --Table-footer-color: var(--Table-cell-color);
-  --Table-footer-fontWeight: normal;
-  --Table-footer-fontSize: var(--Table-cell-fontSize);
-  --Table-footer-lineHeight: var(--Table-cell-lineHeight);
-  --Table-footer-padding: var(--Table-cell-padding);
 }
 
 /*
@@ -78,7 +73,7 @@
 }
 
 /*
- * Border patterns - Array-based system
+ * Border patterns
  */
 
 /* horizontal: 水平線 */
@@ -87,7 +82,7 @@
   border-bottom: 1px solid var(--Table-cell-borderColor);
 }
 
-/* tbody の最後の行のみ bottom border を削除 */
+/* tbodyの最後の行のbottom borderを削除 */
 .spui-Table--horizontal
   .spui-Table-body
   .spui-Table-row:last-child
@@ -99,7 +94,7 @@
   border-bottom: none;
 }
 
-/* footer の最初の行に強調された区切り線 */
+/* footerの最初の行に強調された区切り線 */
 .spui-Table--horizontal
   .spui-Table-footer
   .spui-Table-row:first-child
@@ -111,7 +106,7 @@
   border-top: 2px solid var(--Table-footer-separatorColor);
 }
 
-/* footer の最後の行のみ bottom border を削除 */
+/* footerの最後の行のbottom borderを削除 */
 .spui-Table--horizontal
   .spui-Table-footer
   .spui-Table-row:last-child
@@ -140,11 +135,10 @@
 }
 
 /*
- * Footer 固有のスタイル
- * フッターは合計・集計行として目立たせる
+ * Footer
  */
 .spui-Table-footer .spui-Table-cell {
-  background-color: var(--Table-footer-backgroundColor);
+  background-color: var(--Table-cell-backgroundColor);
   color: var(--Table-footer-color);
   font-size: var(--Table-footer-fontSize);
   font-weight: var(--Table-footer-fontWeight);
@@ -169,7 +163,7 @@
   border-spacing: 0;
 }
 
-/* rounded + outlined の組み合わせでborder-radiusを適用 */
+/* rounded + outlinedの組み合わせでborder-radiusを適用 */
 .spui-Table--rounded.spui-Table--outlined {
   border-radius: var(--Table-borderRadius);
 }
@@ -258,7 +252,7 @@
 }
 
 /*
- * Striped rows - セルのみ、行見出しは除外
+ * ストライプ行 - セルのみ、行見出しは除外
  */
 .spui-Table--striped
   .spui-Table-body
@@ -268,7 +262,7 @@
 }
 
 /*
- * Table elements
+ * テーブル要素
  */
 .spui-Table-caption {
   caption-side: bottom;
@@ -278,22 +272,6 @@
   line-height: var(--Table-caption-lineHeight);
   margin-top: 12px;
   text-align: left;
-}
-
-.spui-Table-header {
-  /* thead element - no specific styles, semantic structure only */
-}
-
-.spui-Table-body {
-  /* tbody element - no specific styles, semantic structure only */
-}
-
-.spui-Table-footer {
-  /* tfoot element - no specific styles, semantic structure only */
-}
-
-.spui-Table-row {
-  /* tr element - no specific styles, semantic structure only */
 }
 
 /*
@@ -329,6 +307,7 @@
   background-color: var(--Table-cell-backgroundColor);
   color: var(--Table-cell-color);
   font-size: var(--Table-cell-fontSize);
+  font-weight: var(--Table-cell-fontWeight);
   line-height: var(--Table-cell-lineHeight);
   padding: var(--Table-cell-padding);
   text-align: left;
@@ -345,21 +324,4 @@
 
 .spui-Table-cell--alignRight {
   text-align: right;
-}
-
-/*
- * Print styles
- */
-@media print {
-  .spui-Table-container {
-    overflow: visible;
-  }
-
-  .spui-Table {
-    break-inside: auto;
-  }
-
-  .spui-Table-row {
-    break-inside: avoid;
-  }
 }

--- a/packages/spindle-ui/src/Table/Table.css
+++ b/packages/spindle-ui/src/Table/Table.css
@@ -284,6 +284,7 @@
   font-size: var(--Table-head-fontSize);
   font-weight: var(--Table-head-fontWeight);
   line-height: var(--Table-head-lineHeight);
+  overflow-wrap: break-word;
   padding: var(--Table-head-padding);
   text-align: left;
   vertical-align: middle;
@@ -310,6 +311,7 @@
   font-size: var(--Table-cell-fontSize);
   font-weight: var(--Table-cell-fontWeight);
   line-height: var(--Table-cell-lineHeight);
+  overflow-wrap: break-word;
   padding: var(--Table-cell-padding);
   text-align: left;
   vertical-align: middle;

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -503,31 +503,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
 </Table.Frame>`}
 />
 
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--outlined">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head">売上</th>
-      <th class="spui-Table-head">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell">1,200,000</td>
-      <td class="spui-Table-cell">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell">980,000</td>
-      <td class="spui-Table-cell">-3%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
-
 ## 固定レイアウト
 
 `layout="fixed"` を指定すると、テーブルの各列の幅を固定できます。
@@ -553,26 +528,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
     </Table.Row>
   </Table.Body>
 </Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal spui-Table--fixed">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" style="width: 30%">商品名</th>
-      <th class="spui-Table-head" style="width: 50%">説明</th>
-      <th class="spui-Table-head" style="width: 20%">価格</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell">高品質な商品Aの詳細説明文です。長いテキストも固定幅で表示されます。</td>
-      <td class="spui-Table-cell">¥1,200,000</td>
-    </tr>
-  </tbody>
-</table>`}
 />
 
 ## スクロール可能なテーブル
@@ -610,36 +565,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
 </Table.Frame>`}
 />
 
-<Source
-  language="html"
-  code={`<div class="spui-Table-frame spui-Table-frame--scrollable">
-  <table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--scrollable">
-    <thead class="spui-Table-header">
-      <tr class="spui-Table-row">
-        <th class="spui-Table-head" style="width: 150px">商品名</th>
-        <th class="spui-Table-head" style="width: 100px">Q1売上</th>
-        <th class="spui-Table-head" style="width: 100px">Q2売上</th>
-        <th class="spui-Table-head" style="width: 100px">Q3売上</th>
-        <th class="spui-Table-head" style="width: 100px">Q4売上</th>
-        <th class="spui-Table-head" style="width: 110px">年間合計</th>
-        <th class="spui-Table-head" style="width: 80px">前年比</th>
-      </tr>
-    </thead>
-    <tbody class="spui-Table-body">
-      <tr class="spui-Table-row">
-        <th class="spui-Table-head" scope="row">スマートフォン</th>
-        <td class="spui-Table-cell">3,000,000</td>
-        <td class="spui-Table-cell">3,500,000</td>
-        <td class="spui-Table-cell">3,200,000</td>
-        <td class="spui-Table-cell">4,000,000</td>
-        <td class="spui-Table-cell">13,700,000</td>
-        <td class="spui-Table-cell">+12%</td>
-      </tr>
-    </tbody>
-  </table>
-</div>`}
-/>
-
 ## テキスト配置
 
 `align` propを使用して、セル内のテキスト配置を指定できます。
@@ -675,36 +600,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
     </Table.Row>
   </Table.Body>
 </Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal spui-Table--vertical">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head spui-Table-head--alignCenter">ステータス</th>
-      <th class="spui-Table-head spui-Table-head--alignRight">価格</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">販売中</td>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">¥1,200,000</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">準備中</td>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">¥980,000</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品C</th>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">完売</td>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">¥1,500</td>
-    </tr>
-  </tbody>
-</table>`}
 />
 
 ## スタイルバリエーション
@@ -759,36 +654,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
 />
 
 <Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal spui-Table--striped">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head">売上</th>
-      <th class="spui-Table-head">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell">1,200,000</td>
-      <td class="spui-Table-cell">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell">980,000</td>
-      <td class="spui-Table-cell">-3%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品C</th>
-      <td class="spui-Table-cell">750,000</td>
-      <td class="spui-Table-cell">+5%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
-
-<Source
   code={`<Table.Frame borderTypes={['outlined']} rounded>
   <Table.Header>
     <Table.Row>
@@ -810,31 +675,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
     </Table.Row>
   </Table.Body>
 </Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--outlined spui-Table--rounded">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head">売上</th>
-      <th class="spui-Table-head">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell">1,200,000</td>
-      <td class="spui-Table-cell">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell">980,000</td>
-      <td class="spui-Table-cell">-3%</td>
-    </tr>
-  </tbody>
-</table>`}
 />
 
 ## セル結合
@@ -1026,32 +866,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
 </Table.Frame>`}
 />
 
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal">
-  <caption class="spui-Table-caption">売上データ（2023年第4四半期）</caption>
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head spui-Table-head--alignRight">売上（円）</th>
-      <th class="spui-Table-head spui-Table-head--alignCenter">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">1,200,000</td>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">980,000</td>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">-3%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
-
 ### With Footer
 
 <Story of={TableStories.WithFooter} />
@@ -1090,38 +904,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
     </Table.Row>
   </Table.Footer>
 </Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head spui-Table-head--alignRight">売上（円）</th>
-      <th class="spui-Table-head spui-Table-head--alignCenter">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">1,200,000</td>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">980,000</td>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">-3%</td>
-    </tr>
-  </tbody>
-  <tfoot class="spui-Table-footer">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">合計</th>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">2,930,000</td>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">+4.7%</td>
-    </tr>
-  </tfoot>
-</table>`}
 />
 
 ## カスタムテーマ

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -1,0 +1,1679 @@
+import { Meta, Primary, Controls, Story, Source } from '@storybook/blocks';
+import { Table } from './Table';
+import * as TableStories from './Table.stories';
+
+<Meta of={TableStories} />
+
+# Table
+
+構造化されたデータを表形式で表示するためのコンポーネントです。Web標準の`<table>`要素をベースとしたラッパーコンポーネントとして設計されており、デザインシステムSpindleに準拠した基本スタイリングを提供しつつ、高い拡張性を持つことが特徴です。
+
+## 使用上の注意
+
+### スタイルのカスタマイズについて
+
+Tableコンポーネントは、CSS Variablesを使用してスタイルをカスタマイズできます。詳細は「[CSS Variables リファレンス](#css-variables-リファレンス)」を参照してください。
+
+```css
+/* プロダクト全体でのカスタマイズ */
+:root {
+  --Table-head-backgroundColor: var(--color-surface-accent-primary);
+  --Table-head-color: var(--color-text-high-emphasis-inverse);
+}
+
+/* 個別のテーブルでのカスタマイズ */
+.custom-table {
+  --Table-cell-padding: 16px 12px;
+  --Table-borderRadius: 8px;
+}
+```
+
+### セル結合時の注意点
+
+基本的なセル結合（`colSpan`、`rowSpan`）は、標準的なHTML属性としてそのまま使用できます。ただし、複雑なセル結合パターンでは、ボーダーが意図しない表示になることがあります。
+
+#### なぜボーダー調整が必要になるのか
+
+セル結合を行うと、隣接するセルのボーダーが重なったり、期待する位置にボーダーが表示されない場合があります。これは、CSSのボーダーモデルと`borderTypes`の組み合わせにより、結合されたセルの境界線の処理が複雑になるためです。
+
+特に以下のような場合に調整が必要です：
+
+- 縦横両方向にセル結合を組み合わせる場合
+- `borderTypes`で複数のボーダータイプを指定している場合
+- 結合セルが表の端に位置する場合
+
+```tsx
+// セル結合時のボーダー調整例
+<Table.Cell colSpan={2} className="merged-cell">
+  結合セル
+</Table.Cell>
+```
+
+## CSS Variables リファレンス
+
+Tableコンポーネントは、以下のCSS Variablesでカスタマイズできます。これらの変数をオーバーライドすることで、プロダクト独自のデザインに対応できます。
+
+### Surface・背景関連
+
+<table>
+  <thead>
+    <tr>
+      <th>変数名</th>
+      <th>デフォルト値</th>
+      <th>用途</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--Table-backgroundColor</code>
+      </td>
+      <td>
+        <code>var(--color-surface-primary)</code>
+      </td>
+      <td>テーブル全体の背景色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-head-backgroundColor</code>
+      </td>
+      <td>
+        <code>var(--color-surface-tertiary)</code>
+      </td>
+      <td>ヘッダー背景色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-cell-backgroundColor</code>
+      </td>
+      <td>
+        <code>var(--color-surface-primary)</code>
+      </td>
+      <td>セル背景色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-row-striped-backgroundColor</code>
+      </td>
+      <td>
+        <code>var(--color-background)</code>
+      </td>
+      <td>ストライプ行背景色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-row-hover-backgroundColor</code>
+      </td>
+      <td>
+        <code>var(--color-surface-secondary)</code>
+      </td>
+      <td>行ホバー時背景色</td>
+    </tr>
+  </tbody>
+</table>
+
+### Text・テキスト関連
+
+<table>
+  <thead>
+    <tr>
+      <th>変数名</th>
+      <th>デフォルト値</th>
+      <th>用途</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--Table-head-color</code>
+      </td>
+      <td>
+        <code>var(--color-text-high-emphasis)</code>
+      </td>
+      <td>ヘッダーテキスト色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-cell-color</code>
+      </td>
+      <td>
+        <code>var(--color-text-high-emphasis)</code>
+      </td>
+      <td>セルテキスト色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-head-fontWeight</code>
+      </td>
+      <td>
+        <code>bold</code>
+      </td>
+      <td>ヘッダーフォント太さ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-head-fontSize</code>
+      </td>
+      <td>
+        <code>14px</code>
+      </td>
+      <td>ヘッダーフォントサイズ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-cell-fontSize</code>
+      </td>
+      <td>
+        <code>14px</code>
+      </td>
+      <td>セルフォントサイズ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-head-lineHeight</code>
+      </td>
+      <td>
+        <code>1.4</code>
+      </td>
+      <td>ヘッダー行間</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-cell-lineHeight</code>
+      </td>
+      <td>
+        <code>1.4</code>
+      </td>
+      <td>セル行間</td>
+    </tr>
+  </tbody>
+</table>
+
+### Border・ボーダー関連
+
+<table>
+  <thead>
+    <tr>
+      <th>変数名</th>
+      <th>デフォルト値</th>
+      <th>用途</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--Table-outlineColor</code>
+      </td>
+      <td>
+        <code>var(--color-border-strong-emphasis)</code>
+      </td>
+      <td>アウトライン色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-cell-borderColor</code>
+      </td>
+      <td>
+        <code>var(--color-border-low-emphasis)</code>
+      </td>
+      <td>セル罫線色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-separatorColor</code>
+      </td>
+      <td>
+        <code>var(--color-border-medium-emphasis)</code>
+      </td>
+      <td>フッター上部区切り線</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-borderRadius</code>
+      </td>
+      <td>
+        <code>16px</code>
+      </td>
+      <td>外枠の角丸</td>
+    </tr>
+  </tbody>
+</table>
+
+### Layout・レイアウト関連
+
+<table>
+  <thead>
+    <tr>
+      <th>変数名</th>
+      <th>デフォルト値</th>
+      <th>用途</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--Table-head-padding</code>
+      </td>
+      <td>
+        <code>12px</code>
+      </td>
+      <td>ヘッダーパディング</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-cell-padding</code>
+      </td>
+      <td>
+        <code>12px</code>
+      </td>
+      <td>セルパディング</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-sticky-shadow</code>
+      </td>
+      <td>
+        <code>var(--box-shadow-lv2-normal)</code>
+      </td>
+      <td>固定列の影</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-sticky-z-index</code>
+      </td>
+      <td>
+        <code>1</code>
+      </td>
+      <td>固定列のz-index</td>
+    </tr>
+  </tbody>
+</table>
+
+### Caption・キャプション関連
+
+<table>
+  <thead>
+    <tr>
+      <th>変数名</th>
+      <th>デフォルト値</th>
+      <th>用途</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--Table-caption-color</code>
+      </td>
+      <td>
+        <code>var(--color-text-low-emphasis)</code>
+      </td>
+      <td>キャプションテキスト色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-caption-fontSize</code>
+      </td>
+      <td>
+        <code>12px</code>
+      </td>
+      <td>キャプションフォントサイズ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-caption-lineHeight</code>
+      </td>
+      <td>
+        <code>1.6</code>
+      </td>
+      <td>キャプション行間</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-caption-fontWeight</code>
+      </td>
+      <td>
+        <code>normal</code>
+      </td>
+      <td>キャプションフォント太さ</td>
+    </tr>
+  </tbody>
+</table>
+
+### Footer・フッター関連
+
+<table>
+  <thead>
+    <tr>
+      <th>変数名</th>
+      <th>デフォルト値</th>
+      <th>用途</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--Table-footer-backgroundColor</code>
+      </td>
+      <td>
+        <code>var(--Table-cell-backgroundColor)</code>
+      </td>
+      <td>フッター背景色（td）</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-color</code>
+      </td>
+      <td>
+        <code>var(--Table-cell-color)</code>
+      </td>
+      <td>フッターテキスト色</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-fontWeight</code>
+      </td>
+      <td>
+        <code>normal</code>
+      </td>
+      <td>フッターフォント太さ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-fontSize</code>
+      </td>
+      <td>
+        <code>var(--Table-cell-fontSize)</code>
+      </td>
+      <td>フッターフォントサイズ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-lineHeight</code>
+      </td>
+      <td>
+        <code>var(--Table-cell-lineHeight)</code>
+      </td>
+      <td>フッター行間</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-padding</code>
+      </td>
+      <td>
+        <code>var(--Table-cell-padding)</code>
+      </td>
+      <td>フッターパディング</td>
+    </tr>
+  </tbody>
+</table>
+
+```tsx
+import { Table } from '@openameba/spindle-ui';
+import '@openameba/spindle-ui/Table/Table.css';
+```
+
+```css
+@import './node_modules/@openameba/spindle-ui/Table/Table.css';
+```
+
+```html
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@openameba/spindle-ui/Table/Table.css"
+/>
+```
+
+## Basic
+
+<Story of={TableStories.Basic} />
+
+<Source
+  code={`<Table.Frame striped>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上（円）</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>商品A</Table.Cell>
+      <Table.Cell>1,200,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>商品B</Table.Cell>
+      <Table.Cell>980,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>商品C</Table.Cell>
+      <Table.Cell>750,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>商品D</Table.Cell>
+      <Table.Cell>650,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>商品E</Table.Cell>
+      <Table.Cell>850,000</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--striped">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上（円）</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品A</td>
+      <td class="spui-Table-cell">1,200,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品B</td>
+      <td class="spui-Table-cell">980,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品C</td>
+      <td class="spui-Table-cell">750,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品D</td>
+      <td class="spui-Table-cell">650,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品E</td>
+      <td class="spui-Table-cell">850,000</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+## Header Patterns
+
+### No Headers
+
+<Story of={TableStories.NoHeaders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>商品A</Table.Cell>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>商品B</Table.Cell>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>商品C</Table.Cell>
+      <Table.Cell>750,000</Table.Cell>
+      <Table.Cell>+5%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<div class="spui-Table-container">
+  <table class="spui-Table spui-Table--horizontal spui-Table--outlined spui-Table--rounded">
+    <tbody class="spui-Table-body">
+      <tr class="spui-Table-row">
+        <td class="spui-Table-cell">商品A</td>
+        <td class="spui-Table-cell">1,200,000</td>
+        <td class="spui-Table-cell">+12%</td>
+      </tr>
+      <tr class="spui-Table-row">
+        <td class="spui-Table-cell">商品B</td>
+        <td class="spui-Table-cell">980,000</td>
+        <td class="spui-Table-cell">-3%</td>
+      </tr>
+      <tr class="spui-Table-row">
+        <td class="spui-Table-cell">商品C</td>
+        <td class="spui-Table-cell">750,000</td>
+        <td class="spui-Table-cell">+5%</td>
+      </tr>
+    </tbody>
+  </table>
+</div>`}
+/>
+
+### Column Headers
+
+<Story of={TableStories.ColumnHeaders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上（円）</Table.Head>
+      <Table.Head>前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>商品A</Table.Cell>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>商品B</Table.Cell>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--outlined spui-Table--rounded">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上（円）</th>
+      <th class="spui-Table-head">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品A</td>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品B</td>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Row Headers
+
+<Story of={TableStories.RowHeaders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品C</Table.Head>
+      <Table.Cell>750,000</Table.Cell>
+      <Table.Cell>+5%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--outlined spui-Table--rounded">
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品C</th>
+      <td class="spui-Table-cell">750,000</td>
+      <td class="spui-Table-cell">+5%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Both Headers
+
+<Story of={TableStories.BothHeaders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上（円）</Table.Head>
+      <Table.Head>前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--outlined spui-Table--rounded">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上（円）</th>
+      <th class="spui-Table-head">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+## Border Styles
+
+### Horizontal Borders
+
+<Story of={TableStories.HorizontalBorders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head align="right">売上（円）</Table.Head>
+      <Table.Head align="center">前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell align="right">1,200,000</Table.Cell>
+      <Table.Cell align="center">+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell align="right">980,000</Table.Cell>
+      <Table.Cell align="center">-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head spui-Table-head--alignRight">売上（円）</th>
+      <th class="spui-Table-head spui-Table-head--alignCenter">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">1,200,000</td>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">980,000</td>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Vertical Borders
+
+<Story of={TableStories.VerticalBorders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['vertical']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上</Table.Head>
+      <Table.Head>前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>商品A</Table.Cell>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>商品B</Table.Cell>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--vertical">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上</th>
+      <th class="spui-Table-head">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品A</td>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">商品B</td>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Outline Borders
+
+<Story of={TableStories.OutlineBorders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['outlined']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上</Table.Head>
+      <Table.Head>前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--outlined">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上</th>
+      <th class="spui-Table-head">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Grid Borders
+
+<Story of={TableStories.GridBorders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'vertical']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上</Table.Head>
+      <Table.Head>前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--vertical">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上</th>
+      <th class="spui-Table-head">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### All Borders
+
+<Story of={TableStories.AllBorders} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上</Table.Head>
+      <Table.Head>前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--outlined">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上</th>
+      <th class="spui-Table-head">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+## Layout Variations
+
+### Fixed Layout
+
+<Story of={TableStories.FixedLayout} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal']} layout="fixed">
+  <Table.Header>
+    <Table.Row>
+      <Table.Head width="30%">商品名</Table.Head>
+      <Table.Head width="50%">説明</Table.Head>
+      <Table.Head width="20%">価格</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell>高品質な商品Aの詳細説明文です。長いテキストも固定幅で表示されます。</Table.Cell>
+      <Table.Cell>¥1,200,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell>商品Bの説明文</Table.Cell>
+      <Table.Cell>¥980,000</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--fixed">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" style="width: 30%">商品名</th>
+      <th class="spui-Table-head" style="width: 50%">説明</th>
+      <th class="spui-Table-head" style="width: 20%">価格</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell">高品質な商品Aの詳細説明文です。長いテキストも固定幅で表示されます。</td>
+      <td class="spui-Table-cell">¥1,200,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell">商品Bの説明文</td>
+      <td class="spui-Table-cell">¥980,000</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Text Alignment
+
+<Story of={TableStories.TextAlignment} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'vertical']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head align="center">ステータス</Table.Head>
+      <Table.Head align="right">価格</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell align="center">販売中</Table.Cell>
+      <Table.Cell align="right">¥1,200,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell align="center">準備中</Table.Cell>
+      <Table.Cell align="right">¥980,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品C</Table.Head>
+      <Table.Cell align="center">完売</Table.Cell>
+      <Table.Cell align="right">¥1,500</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--vertical">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head spui-Table-head--alignCenter">ステータス</th>
+      <th class="spui-Table-head spui-Table-head--alignRight">価格</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">販売中</td>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">¥1,200,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">準備中</td>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">¥980,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品C</th>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">完売</td>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">¥1,500</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Scrollable
+
+<Story of={TableStories.Scrollable} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'vertical']} layout="scrollable">
+  <Table.Header>
+    <Table.Row>
+      <Table.Head width="150px">商品名</Table.Head>
+      <Table.Head width="100px">Q1売上</Table.Head>
+      <Table.Head width="100px">Q2売上</Table.Head>
+      <Table.Head width="100px">Q3売上</Table.Head>
+      <Table.Head width="100px">Q4売上</Table.Head>
+      <Table.Head width="110px">年間合計</Table.Head>
+      <Table.Head width="80px">前年比</Table.Head>
+      <Table.Head width="100px">カテゴリ</Table.Head>
+      <Table.Head width="120px">販売地域</Table.Head>
+      <Table.Head width="100px">在庫状況</Table.Head>
+      <Table.Head width="120px">次回入荷予定</Table.Head>
+      <Table.Head width="100px">備考</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">スマートフォン</Table.Head>
+      <Table.Cell>3,000,000</Table.Cell>
+      <Table.Cell>3,500,000</Table.Cell>
+      <Table.Cell>3,200,000</Table.Cell>
+      <Table.Cell>4,000,000</Table.Cell>
+      <Table.Cell>13,700,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+      <Table.Cell>電子機器</Table.Cell>
+      <Table.Cell>全国</Table.Cell>
+      <Table.Cell>在庫あり</Table.Cell>
+      <Table.Cell>2024年2月予定</Table.Cell>
+      <Table.Cell>好調</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">タブレット</Table.Head>
+      <Table.Cell>2,800,000</Table.Cell>
+      <Table.Cell>3,100,000</Table.Cell>
+      <Table.Cell>2,900,000</Table.Cell>
+      <Table.Cell>3,500,000</Table.Cell>
+      <Table.Cell>12,300,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+      <Table.Cell>電子機器</Table.Cell>
+      <Table.Cell>関東・関西</Table.Cell>
+      <Table.Cell>残りわずか</Table.Cell>
+      <Table.Cell>2024年3月予定</Table.Cell>
+      <Table.Cell>やや減少</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<div class="spui-Table-container spui-Table-container--scrollable">
+  <table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--scrollable">
+    <thead class="spui-Table-header">
+      <tr class="spui-Table-row">
+        <th class="spui-Table-head" style="width: 150px">商品名</th>
+        <th class="spui-Table-head" style="width: 100px">Q1売上</th>
+        <th class="spui-Table-head" style="width: 100px">Q2売上</th>
+        <th class="spui-Table-head" style="width: 100px">Q3売上</th>
+        <th class="spui-Table-head" style="width: 100px">Q4売上</th>
+        <th class="spui-Table-head" style="width: 110px">年間合計</th>
+        <th class="spui-Table-head" style="width: 80px">前年比</th>
+        <th class="spui-Table-head" style="width: 100px">カテゴリ</th>
+        <th class="spui-Table-head" style="width: 120px">販売地域</th>
+        <th class="spui-Table-head" style="width: 100px">在庫状況</th>
+        <th class="spui-Table-head" style="width: 120px">次回入荷予定</th>
+        <th class="spui-Table-head" style="width: 100px">備考</th>
+      </tr>
+    </thead>
+    <tbody class="spui-Table-body">
+      <tr class="spui-Table-row">
+        <th class="spui-Table-head" scope="row">スマートフォン</th>
+        <td class="spui-Table-cell">3,000,000</td>
+        <td class="spui-Table-cell">3,500,000</td>
+        <td class="spui-Table-cell">3,200,000</td>
+        <td class="spui-Table-cell">4,000,000</td>
+        <td class="spui-Table-cell">13,700,000</td>
+        <td class="spui-Table-cell">+12%</td>
+        <td class="spui-Table-cell">電子機器</td>
+        <td class="spui-Table-cell">全国</td>
+        <td class="spui-Table-cell">在庫あり</td>
+        <td class="spui-Table-cell">2024年2月予定</td>
+        <td class="spui-Table-cell">好調</td>
+      </tr>
+      <tr class="spui-Table-row">
+        <th class="spui-Table-head" scope="row">タブレット</th>
+        <td class="spui-Table-cell">2,800,000</td>
+        <td class="spui-Table-cell">3,100,000</td>
+        <td class="spui-Table-cell">2,900,000</td>
+        <td class="spui-Table-cell">3,500,000</td>
+        <td class="spui-Table-cell">12,300,000</td>
+        <td class="spui-Table-cell">-3%</td>
+        <td class="spui-Table-cell">電子機器</td>
+        <td class="spui-Table-cell">関東・関西</td>
+        <td class="spui-Table-cell">残りわずか</td>
+        <td class="spui-Table-cell">2024年3月予定</td>
+        <td class="spui-Table-cell">やや減少</td>
+      </tr>
+    </tbody>
+  </table>
+</div>`}
+/>
+
+## Style Variations
+
+### Striped
+
+<Story of={TableStories.Striped} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal']} striped>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上</Table.Head>
+      <Table.Head>前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品C</Table.Head>
+      <Table.Cell>750,000</Table.Cell>
+      <Table.Cell>+5%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品D</Table.Head>
+      <Table.Cell>650,000</Table.Cell>
+      <Table.Cell>-8%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品E</Table.Head>
+      <Table.Cell>850,000</Table.Cell>
+      <Table.Cell>+15%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--striped">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上</th>
+      <th class="spui-Table-head">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品C</th>
+      <td class="spui-Table-cell">750,000</td>
+      <td class="spui-Table-cell">+5%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品D</th>
+      <td class="spui-Table-cell">650,000</td>
+      <td class="spui-Table-cell">-8%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品E</th>
+      <td class="spui-Table-cell">850,000</td>
+      <td class="spui-Table-cell">+15%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Rounded
+
+<Story of={TableStories.Rounded} />
+
+<Source
+  code={`<Table.Frame borderTypes={['outlined']} rounded>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上</Table.Head>
+      <Table.Head>前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell>1,200,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell>980,000</Table.Cell>
+      <Table.Cell>-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--outlined spui-Table--rounded">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上</th>
+      <th class="spui-Table-head">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell">1,200,000</td>
+      <td class="spui-Table-cell">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell">980,000</td>
+      <td class="spui-Table-cell">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+## Cell Merging Examples
+
+### Column Span
+
+<Story of={TableStories.ColumnSpan} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head colSpan={2}>上半期</Table.Head>
+      <Table.Head colSpan={2}>下半期</Table.Head>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head>Q1</Table.Head>
+      <Table.Head>Q2</Table.Head>
+      <Table.Head>Q3</Table.Head>
+      <Table.Head>Q4</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>300</Table.Cell>
+      <Table.Cell>350</Table.Cell>
+      <Table.Cell>320</Table.Cell>
+      <Table.Cell>400</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>280</Table.Cell>
+      <Table.Cell>310</Table.Cell>
+      <Table.Cell>290</Table.Cell>
+      <Table.Cell>350</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--outlined">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" colspan="2">上半期</th>
+      <th class="spui-Table-head" colspan="2">下半期</th>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">Q1</th>
+      <th class="spui-Table-head">Q2</th>
+      <th class="spui-Table-head">Q3</th>
+      <th class="spui-Table-head">Q4</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">300</td>
+      <td class="spui-Table-cell">350</td>
+      <td class="spui-Table-cell">320</td>
+      <td class="spui-Table-cell">400</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">280</td>
+      <td class="spui-Table-cell">310</td>
+      <td class="spui-Table-cell">290</td>
+      <td class="spui-Table-cell">350</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### Row Span
+
+<Story of={TableStories.RowSpan} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>カテゴリ</Table.Head>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row" rowSpan={2}>
+        電子機器
+      </Table.Head>
+      <Table.Cell>スマートフォン</Table.Cell>
+      <Table.Cell>1,200,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>タブレット</Table.Cell>
+      <Table.Cell>980,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row" rowSpan={2}>
+        家電
+      </Table.Head>
+      <Table.Cell>冷蔵庫</Table.Cell>
+      <Table.Cell>750,000</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>洗濯機</Table.Cell>
+      <Table.Cell>650,000</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--outlined">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">カテゴリ</th>
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head">売上</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row" rowspan="2">
+        電子機器
+      </th>
+      <td class="spui-Table-cell">スマートフォン</td>
+      <td class="spui-Table-cell">1,200,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">タブレット</td>
+      <td class="spui-Table-cell">980,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row" rowspan="2">
+        家電
+      </th>
+      <td class="spui-Table-cell">冷蔵庫</td>
+      <td class="spui-Table-cell">750,000</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <td class="spui-Table-cell">洗濯機</td>
+      <td class="spui-Table-cell">650,000</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+## Semantic Components
+
+### With Caption
+
+<Story of={TableStories.WithCaption} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal']}>
+  <Table.Caption>売上データ（2023年第4四半期）</Table.Caption>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head align="right">売上（円）</Table.Head>
+      <Table.Head align="center">前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell align="right">1,200,000</Table.Cell>
+      <Table.Cell align="center">+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell align="right">980,000</Table.Cell>
+      <Table.Cell align="center">-3%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal">
+  <caption class="spui-Table-caption">売上データ（2023年第4四半期）</caption>
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head spui-Table-head--alignRight">売上（円）</th>
+      <th class="spui-Table-head spui-Table-head--alignCenter">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">1,200,000</td>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">980,000</td>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">-3%</td>
+    </tr>
+  </tbody>
+</table>`}
+/>
+
+### With Footer
+
+<Story of={TableStories.WithFooter} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal']}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head align="right">売上（円）</Table.Head>
+      <Table.Head align="center">前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">商品A</Table.Head>
+      <Table.Cell align="right">1,200,000</Table.Cell>
+      <Table.Cell align="center">+12%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品B</Table.Head>
+      <Table.Cell align="right">980,000</Table.Cell>
+      <Table.Cell align="center">-3%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Head scope="row">商品C</Table.Head>
+      <Table.Cell align="right">750,000</Table.Cell>
+      <Table.Cell align="center">+5%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+  <Table.Footer>
+    <Table.Row>
+      <Table.Head>合計</Table.Head>
+      <Table.Cell align="right">2,930,000</Table.Cell>
+      <Table.Cell align="center">+4.7%</Table.Cell>
+    </Table.Row>
+  </Table.Footer>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<table class="spui-Table spui-Table--horizontal">
+  <thead class="spui-Table-header">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">商品名</th>
+      <th class="spui-Table-head spui-Table-head--alignRight">売上（円）</th>
+      <th class="spui-Table-head spui-Table-head--alignCenter">前年比</th>
+    </tr>
+  </thead>
+  <tbody class="spui-Table-body">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品A</th>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">1,200,000</td>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">+12%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品B</th>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">980,000</td>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">-3%</td>
+    </tr>
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head" scope="row">商品C</th>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">750,000</td>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">+5%</td>
+    </tr>
+  </tbody>
+  <tfoot class="spui-Table-footer">
+    <tr class="spui-Table-row">
+      <th class="spui-Table-head">合計</th>
+      <td class="spui-Table-cell spui-Table-cell--alignRight">2,930,000</td>
+      <td class="spui-Table-cell spui-Table-cell--alignCenter">+4.7%</td>
+    </tr>
+  </tfoot>
+</table>`}
+/>
+
+## Custom Theme
+
+<Story of={TableStories.CustomTheme} />
+
+<Source
+  code={`<div
+  style={{
+    '--Table-head-backgroundColor': 'var(--color-surface-accent-primary)',
+    '--Table-head-color': 'var(--color-text-high-emphasis-inverse)',
+    '--Table-outlineColor': 'var(--color-border-low-emphasis)',
+    '--Table-cell-borderColor': 'var(--color-border-low-emphasis)',
+  }}
+>
+  <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']} rounded>
+    <Table.Header>
+      <Table.Row>
+        <Table.Head>商品名</Table.Head>
+        <Table.Head>売上</Table.Head>
+        <Table.Head>前年比</Table.Head>
+      </Table.Row>
+    </Table.Header>
+    <Table.Body>
+      <Table.Row>
+        <Table.Head scope="row">商品A</Table.Head>
+        <Table.Cell>1,200,000</Table.Cell>
+        <Table.Cell>+12%</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Head scope="row">商品B</Table.Head>
+        <Table.Cell>980,000</Table.Cell>
+        <Table.Cell>-3%</Table.Cell>
+      </Table.Row>
+    </Table.Body>
+  </Table.Frame>
+</div>`}
+/>
+
+<Source
+  language="html"
+  code={`<div style="--Table-head-backgroundColor: var(--color-surface-accent-primary); --Table-head-color: var(--color-text-high-emphasis-inverse); --Table-outlineColor: var(--color-border-low-emphasis); --Table-cell-borderColor: var(--color-border-low-emphasis);">
+  <table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--outlined spui-Table--rounded">
+    <thead class="spui-Table-header">
+      <tr class="spui-Table-row">
+        <th class="spui-Table-head">商品名</th>
+        <th class="spui-Table-head">売上</th>
+        <th class="spui-Table-head">前年比</th>
+      </tr>
+    </thead>
+    <tbody class="spui-Table-body">
+      <tr class="spui-Table-row">
+        <th class="spui-Table-head" scope="row">商品A</th>
+        <td class="spui-Table-cell">1,200,000</td>
+        <td class="spui-Table-cell">+12%</td>
+      </tr>
+      <tr class="spui-Table-row">
+        <th class="spui-Table-head" scope="row">商品B</th>
+        <td class="spui-Table-cell">980,000</td>
+        <td class="spui-Table-cell">-3%</td>
+      </tr>
+    </tbody>
+  </table>
+</div>`}
+/>

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -43,10 +43,16 @@ Tableコンポーネントは、CSS Variablesを使用してスタイルをカ�
 - 結合セルが表の端に位置する場合
 
 ```tsx
-// セル結合時のボーダー調整例
-<Table.Cell colSpan={2} className="merged-cell">
-  結合セル
-</Table.Cell>
+<Table.Head scope="row" rowSpan={2} className="row-span-cell">
+  カテゴリ名
+</Table.Head>
+```
+
+```css
+/* rowSpan使用時のボーダー調整 */
+.row-span-cell {
+  border-bottom: none !important;
+}
 ```
 
 ## CSS Variables リファレンス
@@ -909,39 +915,47 @@ import '@openameba/spindle-ui/Table/Table.css';
 <Story of={TableStories.RowSpan} />
 
 <Source
-  code={`<Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head>カテゴリ</Table.Head>
-      <Table.Head>商品名</Table.Head>
-      <Table.Head>売上</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Head scope="row" rowSpan={2}>
-        電子機器
-      </Table.Head>
-      <Table.Cell>スマートフォン</Table.Cell>
-      <Table.Cell>1,200,000</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>タブレット</Table.Cell>
-      <Table.Cell>980,000</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Head scope="row" rowSpan={2}>
-        家電
-      </Table.Head>
-      <Table.Cell>冷蔵庫</Table.Cell>
-      <Table.Cell>750,000</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>洗濯機</Table.Cell>
-      <Table.Cell>650,000</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
+  code={`<>
+  <style>{\`
+    /* rowSpanセルのボーダー調整 */
+    .no-border-bottom {
+      border-bottom: none !important;
+    }
+  \`}</style>
+  <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+    <Table.Header>
+      <Table.Row>
+        <Table.Head>カテゴリ</Table.Head>
+        <Table.Head>商品名</Table.Head>
+        <Table.Head>売上</Table.Head>
+      </Table.Row>
+    </Table.Header>
+    <Table.Body>
+      <Table.Row>
+        <Table.Head scope="row" rowSpan={2}>
+          電子機器
+        </Table.Head>
+        <Table.Cell>スマートフォン</Table.Cell>
+        <Table.Cell>1,200,000</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>タブレット</Table.Cell>
+        <Table.Cell>980,000</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Head scope="row" rowSpan={2} className="no-border-bottom">
+          家電
+        </Table.Head>
+        <Table.Cell>冷蔵庫</Table.Cell>
+        <Table.Cell>750,000</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>洗濯機</Table.Cell>
+        <Table.Cell>650,000</Table.Cell>
+      </Table.Row>
+    </Table.Body>
+  </Table.Frame>
+</>`}
 />
 
 <Source
@@ -1112,7 +1126,7 @@ import '@openameba/spindle-ui/Table/Table.css';
 </table>`}
 />
 
-## Custom Theme
+## カスタムテーマ
 
 <Story of={TableStories.CustomTheme} />
 

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -100,15 +100,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
       </td>
       <td>ストライプ行背景色</td>
     </tr>
-    <tr>
-      <td>
-        <code>--Table-row-hover-backgroundColor</code>
-      </td>
-      <td>
-        <code>var(--color-surface-secondary)</code>
-      </td>
-      <td>行ホバー時背景色</td>
-    </tr>
   </tbody>
 </table>
 
@@ -143,12 +134,39 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
     </tr>
     <tr>
       <td>
+        <code>--Table-footer-color</code>
+      </td>
+      <td>
+        <code>var(--color-text-high-emphasis)</code>
+      </td>
+      <td>フッターテキスト色</td>
+    </tr>
+    <tr>
+      <td>
         <code>--Table-head-fontWeight</code>
       </td>
       <td>
         <code>bold</code>
       </td>
       <td>ヘッダーフォント太さ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-cell-fontWeight</code>
+      </td>
+      <td>
+        <code>normal</code>
+      </td>
+      <td>セルフォント太さ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-fontWeight</code>
+      </td>
+      <td>
+        <code>normal</code>
+      </td>
+      <td>フッターフォント太さ</td>
     </tr>
     <tr>
       <td>
@@ -185,6 +203,24 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
         <code>1.4</code>
       </td>
       <td>セル行間</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-fontSize</code>
+      </td>
+      <td>
+        <code>14px</code>
+      </td>
+      <td>フッターフォントサイズ</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--Table-footer-lineHeight</code>
+      </td>
+      <td>
+        <code>1.4</code>
+      </td>
+      <td>フッター行間</td>
     </tr>
   </tbody>
 </table>
@@ -270,21 +306,12 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
     </tr>
     <tr>
       <td>
-        <code>--Table-sticky-shadow</code>
+        <code>--Table-footer-padding</code>
       </td>
       <td>
-        <code>var(--box-shadow-lv2-normal)</code>
+        <code>12px</code>
       </td>
-      <td>固定列の影</td>
-    </tr>
-    <tr>
-      <td>
-        <code>--Table-sticky-z-index</code>
-      </td>
-      <td>
-        <code>1</code>
-      </td>
-      <td>固定列のz-index</td>
+      <td>フッターパディング</td>
     </tr>
   </tbody>
 </table>
@@ -339,73 +366,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
   </tbody>
 </table>
 
-### Footer・フッター関連
-
-<table>
-  <thead>
-    <tr>
-      <th>変数名</th>
-      <th>デフォルト値</th>
-      <th>用途</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>--Table-footer-backgroundColor</code>
-      </td>
-      <td>
-        <code>var(--Table-cell-backgroundColor)</code>
-      </td>
-      <td>フッター背景色（td）</td>
-    </tr>
-    <tr>
-      <td>
-        <code>--Table-footer-color</code>
-      </td>
-      <td>
-        <code>var(--Table-cell-color)</code>
-      </td>
-      <td>フッターテキスト色</td>
-    </tr>
-    <tr>
-      <td>
-        <code>--Table-footer-fontWeight</code>
-      </td>
-      <td>
-        <code>normal</code>
-      </td>
-      <td>フッターフォント太さ</td>
-    </tr>
-    <tr>
-      <td>
-        <code>--Table-footer-fontSize</code>
-      </td>
-      <td>
-        <code>var(--Table-cell-fontSize)</code>
-      </td>
-      <td>フッターフォントサイズ</td>
-    </tr>
-    <tr>
-      <td>
-        <code>--Table-footer-lineHeight</code>
-      </td>
-      <td>
-        <code>var(--Table-cell-lineHeight)</code>
-      </td>
-      <td>フッター行間</td>
-    </tr>
-    <tr>
-      <td>
-        <code>--Table-footer-padding</code>
-      </td>
-      <td>
-        <code>var(--Table-cell-padding)</code>
-      </td>
-      <td>フッターパディング</td>
-    </tr>
-  </tbody>
-</table>
 
 ```tsx
 import { Table } from '@openameba/spindle-ui';

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -614,7 +614,7 @@ import '@openameba/spindle-ui/Table/Table.css';
 
 <Source
   language="html"
-  code={`<div class="spui-Table-container spui-Table-container--scrollable">
+  code={`<div class="spui-Table-frame spui-Table-frame--scrollable">
   <table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--scrollable">
     <thead class="spui-Table-header">
       <tr class="spui-Table-row">

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -179,7 +179,7 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
         <code>--Table-head-fontSize</code>
       </td>
       <td>
-        <code>14px</code>
+        <code>0.875em</code>
       </td>
       <td>ヘッダーフォントサイズ</td>
     </tr>
@@ -188,7 +188,7 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
         <code>--Table-cell-fontSize</code>
       </td>
       <td>
-        <code>14px</code>
+        <code>0.875em</code>
       </td>
       <td>セルフォントサイズ</td>
     </tr>
@@ -215,7 +215,7 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
         <code>--Table-footer-fontSize</code>
       </td>
       <td>
-        <code>14px</code>
+        <code>0.875em</code>
       </td>
       <td>フッターフォントサイズ</td>
     </tr>
@@ -297,7 +297,7 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
         <code>--Table-head-padding</code>
       </td>
       <td>
-        <code>12px</code>
+        <code>0.75em</code>
       </td>
       <td>ヘッダーパディング</td>
     </tr>
@@ -306,7 +306,7 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
         <code>--Table-cell-padding</code>
       </td>
       <td>
-        <code>12px</code>
+        <code>0.75em</code>
       </td>
       <td>セルパディング</td>
     </tr>
@@ -315,7 +315,7 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
         <code>--Table-footer-padding</code>
       </td>
       <td>
-        <code>12px</code>
+        <code>0.75em</code>
       </td>
       <td>フッターパディング</td>
     </tr>
@@ -347,7 +347,7 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
         <code>--Table-caption-fontSize</code>
       </td>
       <td>
-        <code>12px</code>
+        <code>0.75em</code>
       </td>
       <td>キャプションフォントサイズ</td>
     </tr>

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -366,7 +366,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
   </tbody>
 </table>
 
-
 ```tsx
 import { Table } from '@openameba/spindle-ui';
 import '@openameba/spindle-ui/Table/Table.css';
@@ -383,231 +382,21 @@ import '@openameba/spindle-ui/Table/Table.css';
 />
 ```
 
-## Basic
+## ヘッダーパターン
 
-<Story of={TableStories.Basic} />
-
-<Source
-  code={`<Table.Frame striped>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head>商品名</Table.Head>
-      <Table.Head>売上（円）</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Cell>商品A</Table.Cell>
-      <Table.Cell>1,200,000</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>商品B</Table.Cell>
-      <Table.Cell>980,000</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>商品C</Table.Cell>
-      <Table.Cell>750,000</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>商品D</Table.Cell>
-      <Table.Cell>650,000</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>商品E</Table.Cell>
-      <Table.Cell>850,000</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--striped">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head">売上（円）</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品A</td>
-      <td class="spui-Table-cell">1,200,000</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品B</td>
-      <td class="spui-Table-cell">980,000</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品C</td>
-      <td class="spui-Table-cell">750,000</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品D</td>
-      <td class="spui-Table-cell">650,000</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品E</td>
-      <td class="spui-Table-cell">850,000</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
-
-## Header Patterns
+テーブルのヘッダーは、データの構造に応じて適切に配置する必要があります。
 
 ### No Headers
 
 <Story of={TableStories.NoHeaders} />
 
-<Source
-  code={`<Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
-  <Table.Body>
-    <Table.Row>
-      <Table.Cell>商品A</Table.Cell>
-      <Table.Cell>1,200,000</Table.Cell>
-      <Table.Cell>+12%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>商品B</Table.Cell>
-      <Table.Cell>980,000</Table.Cell>
-      <Table.Cell>-3%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>商品C</Table.Cell>
-      <Table.Cell>750,000</Table.Cell>
-      <Table.Cell>+5%</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<div class="spui-Table-container">
-  <table class="spui-Table spui-Table--horizontal spui-Table--outlined spui-Table--rounded">
-    <tbody class="spui-Table-body">
-      <tr class="spui-Table-row">
-        <td class="spui-Table-cell">商品A</td>
-        <td class="spui-Table-cell">1,200,000</td>
-        <td class="spui-Table-cell">+12%</td>
-      </tr>
-      <tr class="spui-Table-row">
-        <td class="spui-Table-cell">商品B</td>
-        <td class="spui-Table-cell">980,000</td>
-        <td class="spui-Table-cell">-3%</td>
-      </tr>
-      <tr class="spui-Table-row">
-        <td class="spui-Table-cell">商品C</td>
-        <td class="spui-Table-cell">750,000</td>
-        <td class="spui-Table-cell">+5%</td>
-      </tr>
-    </tbody>
-  </table>
-</div>`}
-/>
-
 ### Column Headers
 
 <Story of={TableStories.ColumnHeaders} />
 
-<Source
-  code={`<Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head>商品名</Table.Head>
-      <Table.Head>売上（円）</Table.Head>
-      <Table.Head>前年比</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Cell>商品A</Table.Cell>
-      <Table.Cell>1,200,000</Table.Cell>
-      <Table.Cell>+12%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>商品B</Table.Cell>
-      <Table.Cell>980,000</Table.Cell>
-      <Table.Cell>-3%</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal spui-Table--outlined spui-Table--rounded">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head">売上（円）</th>
-      <th class="spui-Table-head">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品A</td>
-      <td class="spui-Table-cell">1,200,000</td>
-      <td class="spui-Table-cell">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品B</td>
-      <td class="spui-Table-cell">980,000</td>
-      <td class="spui-Table-cell">-3%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
-
 ### Row Headers
 
 <Story of={TableStories.RowHeaders} />
-
-<Source
-  code={`<Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
-  <Table.Body>
-    <Table.Row>
-      <Table.Head scope="row">商品A</Table.Head>
-      <Table.Cell>1,200,000</Table.Cell>
-      <Table.Cell>+12%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Head scope="row">商品B</Table.Head>
-      <Table.Cell>980,000</Table.Cell>
-      <Table.Cell>-3%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Head scope="row">商品C</Table.Head>
-      <Table.Cell>750,000</Table.Cell>
-      <Table.Cell>+5%</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal spui-Table--outlined spui-Table--rounded">
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell">1,200,000</td>
-      <td class="spui-Table-cell">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell">980,000</td>
-      <td class="spui-Table-cell">-3%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品C</th>
-      <td class="spui-Table-cell">750,000</td>
-      <td class="spui-Table-cell">+5%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
 
 ### Both Headers
 
@@ -662,219 +451,25 @@ import '@openameba/spindle-ui/Table/Table.css';
 </table>`}
 />
 
-## Border Styles
+## ボーダースタイル
+
+`borderTypes` propを使用して、テーブルの罫線スタイルをカスタマイズできます。
 
 ### Horizontal Borders
 
 <Story of={TableStories.HorizontalBorders} />
 
-<Source
-  code={`<Table.Frame borderTypes={['horizontal']}>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head>商品名</Table.Head>
-      <Table.Head align="right">売上（円）</Table.Head>
-      <Table.Head align="center">前年比</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Head scope="row">商品A</Table.Head>
-      <Table.Cell align="right">1,200,000</Table.Cell>
-      <Table.Cell align="center">+12%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Head scope="row">商品B</Table.Head>
-      <Table.Cell align="right">980,000</Table.Cell>
-      <Table.Cell align="center">-3%</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head spui-Table-head--alignRight">売上（円）</th>
-      <th class="spui-Table-head spui-Table-head--alignCenter">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">1,200,000</td>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">980,000</td>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">-3%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
-
 ### Vertical Borders
 
 <Story of={TableStories.VerticalBorders} />
-
-<Source
-  code={`<Table.Frame borderTypes={['vertical']}>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head>商品名</Table.Head>
-      <Table.Head>売上</Table.Head>
-      <Table.Head>前年比</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Cell>商品A</Table.Cell>
-      <Table.Cell>1,200,000</Table.Cell>
-      <Table.Cell>+12%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>商品B</Table.Cell>
-      <Table.Cell>980,000</Table.Cell>
-      <Table.Cell>-3%</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--vertical">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head">売上</th>
-      <th class="spui-Table-head">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品A</td>
-      <td class="spui-Table-cell">1,200,000</td>
-      <td class="spui-Table-cell">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <td class="spui-Table-cell">商品B</td>
-      <td class="spui-Table-cell">980,000</td>
-      <td class="spui-Table-cell">-3%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
 
 ### Outline Borders
 
 <Story of={TableStories.OutlineBorders} />
 
-<Source
-  code={`<Table.Frame borderTypes={['outlined']}>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head>商品名</Table.Head>
-      <Table.Head>売上</Table.Head>
-      <Table.Head>前年比</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Head scope="row">商品A</Table.Head>
-      <Table.Cell>1,200,000</Table.Cell>
-      <Table.Cell>+12%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Head scope="row">商品B</Table.Head>
-      <Table.Cell>980,000</Table.Cell>
-      <Table.Cell>-3%</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--outlined">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head">売上</th>
-      <th class="spui-Table-head">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell">1,200,000</td>
-      <td class="spui-Table-cell">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell">980,000</td>
-      <td class="spui-Table-cell">-3%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
-
 ### Grid Borders
 
 <Story of={TableStories.GridBorders} />
-
-<Source
-  code={`<Table.Frame borderTypes={['horizontal', 'vertical']}>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head>商品名</Table.Head>
-      <Table.Head>売上</Table.Head>
-      <Table.Head>前年比</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Head scope="row">商品A</Table.Head>
-      <Table.Cell>1,200,000</Table.Cell>
-      <Table.Cell>+12%</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Head scope="row">商品B</Table.Head>
-      <Table.Cell>980,000</Table.Cell>
-      <Table.Cell>-3%</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<table class="spui-Table spui-Table--horizontal spui-Table--vertical">
-  <thead class="spui-Table-header">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head">商品名</th>
-      <th class="spui-Table-head">売上</th>
-      <th class="spui-Table-head">前年比</th>
-    </tr>
-  </thead>
-  <tbody class="spui-Table-body">
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品A</th>
-      <td class="spui-Table-cell">1,200,000</td>
-      <td class="spui-Table-cell">+12%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell">980,000</td>
-      <td class="spui-Table-cell">-3%</td>
-    </tr>
-  </tbody>
-</table>`}
-/>
 
 ### All Borders
 
@@ -929,7 +524,9 @@ import '@openameba/spindle-ui/Table/Table.css';
 </table>`}
 />
 
-## Layout Variations
+## 固定レイアウト
+
+`layout="fixed"` を指定すると、テーブルの各列の幅を固定できます。
 
 ### Fixed Layout
 
@@ -949,11 +546,6 @@ import '@openameba/spindle-ui/Table/Table.css';
       <Table.Head scope="row">商品A</Table.Head>
       <Table.Cell>高品質な商品Aの詳細説明文です。長いテキストも固定幅で表示されます。</Table.Cell>
       <Table.Cell>¥1,200,000</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Head scope="row">商品B</Table.Head>
-      <Table.Cell>商品Bの説明文</Table.Cell>
-      <Table.Cell>¥980,000</Table.Cell>
     </Table.Row>
   </Table.Body>
 </Table.Frame>`}
@@ -975,14 +567,78 @@ import '@openameba/spindle-ui/Table/Table.css';
       <td class="spui-Table-cell">高品質な商品Aの詳細説明文です。長いテキストも固定幅で表示されます。</td>
       <td class="spui-Table-cell">¥1,200,000</td>
     </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品B</th>
-      <td class="spui-Table-cell">商品Bの説明文</td>
-      <td class="spui-Table-cell">¥980,000</td>
-    </tr>
   </tbody>
 </table>`}
 />
+
+## スクロール可能なテーブル
+
+`layout="scrollable"` を指定すると、幅の広いテーブルを水平スクロールで表示できます。
+
+### Scrollable
+
+<Story of={TableStories.Scrollable} />
+
+<Source
+  code={`<Table.Frame borderTypes={['horizontal', 'vertical']} layout="scrollable">
+  <Table.Header>
+    <Table.Row>
+      <Table.Head width="150px">商品名</Table.Head>
+      <Table.Head width="100px">Q1売上</Table.Head>
+      <Table.Head width="100px">Q2売上</Table.Head>
+      <Table.Head width="100px">Q3売上</Table.Head>
+      <Table.Head width="100px">Q4売上</Table.Head>
+      <Table.Head width="110px">年間合計</Table.Head>
+      <Table.Head width="80px">前年比</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Head scope="row">スマートフォン</Table.Head>
+      <Table.Cell>3,000,000</Table.Cell>
+      <Table.Cell>3,500,000</Table.Cell>
+      <Table.Cell>3,200,000</Table.Cell>
+      <Table.Cell>4,000,000</Table.Cell>
+      <Table.Cell>13,700,000</Table.Cell>
+      <Table.Cell>+12%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>`}
+/>
+
+<Source
+  language="html"
+  code={`<div class="spui-Table-container spui-Table-container--scrollable">
+  <table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--scrollable">
+    <thead class="spui-Table-header">
+      <tr class="spui-Table-row">
+        <th class="spui-Table-head" style="width: 150px">商品名</th>
+        <th class="spui-Table-head" style="width: 100px">Q1売上</th>
+        <th class="spui-Table-head" style="width: 100px">Q2売上</th>
+        <th class="spui-Table-head" style="width: 100px">Q3売上</th>
+        <th class="spui-Table-head" style="width: 100px">Q4売上</th>
+        <th class="spui-Table-head" style="width: 110px">年間合計</th>
+        <th class="spui-Table-head" style="width: 80px">前年比</th>
+      </tr>
+    </thead>
+    <tbody class="spui-Table-body">
+      <tr class="spui-Table-row">
+        <th class="spui-Table-head" scope="row">スマートフォン</th>
+        <td class="spui-Table-cell">3,000,000</td>
+        <td class="spui-Table-cell">3,500,000</td>
+        <td class="spui-Table-cell">3,200,000</td>
+        <td class="spui-Table-cell">4,000,000</td>
+        <td class="spui-Table-cell">13,700,000</td>
+        <td class="spui-Table-cell">+12%</td>
+      </tr>
+    </tbody>
+  </table>
+</div>`}
+/>
+
+## テキスト配置
+
+`align` propを使用して、セル内のテキスト配置を指定できます。
 
 ### Text Alignment
 
@@ -1047,120 +703,17 @@ import '@openameba/spindle-ui/Table/Table.css';
 </table>`}
 />
 
-### Scrollable
+## スタイルバリエーション
 
-<Story of={TableStories.Scrollable} />
-
-<Source
-  code={`<Table.Frame borderTypes={['horizontal', 'vertical']} layout="scrollable">
-  <Table.Header>
-    <Table.Row>
-      <Table.Head width="150px">商品名</Table.Head>
-      <Table.Head width="100px">Q1売上</Table.Head>
-      <Table.Head width="100px">Q2売上</Table.Head>
-      <Table.Head width="100px">Q3売上</Table.Head>
-      <Table.Head width="100px">Q4売上</Table.Head>
-      <Table.Head width="110px">年間合計</Table.Head>
-      <Table.Head width="80px">前年比</Table.Head>
-      <Table.Head width="100px">カテゴリ</Table.Head>
-      <Table.Head width="120px">販売地域</Table.Head>
-      <Table.Head width="100px">在庫状況</Table.Head>
-      <Table.Head width="120px">次回入荷予定</Table.Head>
-      <Table.Head width="100px">備考</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Head scope="row">スマートフォン</Table.Head>
-      <Table.Cell>3,000,000</Table.Cell>
-      <Table.Cell>3,500,000</Table.Cell>
-      <Table.Cell>3,200,000</Table.Cell>
-      <Table.Cell>4,000,000</Table.Cell>
-      <Table.Cell>13,700,000</Table.Cell>
-      <Table.Cell>+12%</Table.Cell>
-      <Table.Cell>電子機器</Table.Cell>
-      <Table.Cell>全国</Table.Cell>
-      <Table.Cell>在庫あり</Table.Cell>
-      <Table.Cell>2024年2月予定</Table.Cell>
-      <Table.Cell>好調</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Head scope="row">タブレット</Table.Head>
-      <Table.Cell>2,800,000</Table.Cell>
-      <Table.Cell>3,100,000</Table.Cell>
-      <Table.Cell>2,900,000</Table.Cell>
-      <Table.Cell>3,500,000</Table.Cell>
-      <Table.Cell>12,300,000</Table.Cell>
-      <Table.Cell>-3%</Table.Cell>
-      <Table.Cell>電子機器</Table.Cell>
-      <Table.Cell>関東・関西</Table.Cell>
-      <Table.Cell>残りわずか</Table.Cell>
-      <Table.Cell>2024年3月予定</Table.Cell>
-      <Table.Cell>やや減少</Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table.Frame>`}
-/>
-
-<Source
-  language="html"
-  code={`<div class="spui-Table-container spui-Table-container--scrollable">
-  <table class="spui-Table spui-Table--horizontal spui-Table--vertical spui-Table--scrollable">
-    <thead class="spui-Table-header">
-      <tr class="spui-Table-row">
-        <th class="spui-Table-head" style="width: 150px">商品名</th>
-        <th class="spui-Table-head" style="width: 100px">Q1売上</th>
-        <th class="spui-Table-head" style="width: 100px">Q2売上</th>
-        <th class="spui-Table-head" style="width: 100px">Q3売上</th>
-        <th class="spui-Table-head" style="width: 100px">Q4売上</th>
-        <th class="spui-Table-head" style="width: 110px">年間合計</th>
-        <th class="spui-Table-head" style="width: 80px">前年比</th>
-        <th class="spui-Table-head" style="width: 100px">カテゴリ</th>
-        <th class="spui-Table-head" style="width: 120px">販売地域</th>
-        <th class="spui-Table-head" style="width: 100px">在庫状況</th>
-        <th class="spui-Table-head" style="width: 120px">次回入荷予定</th>
-        <th class="spui-Table-head" style="width: 100px">備考</th>
-      </tr>
-    </thead>
-    <tbody class="spui-Table-body">
-      <tr class="spui-Table-row">
-        <th class="spui-Table-head" scope="row">スマートフォン</th>
-        <td class="spui-Table-cell">3,000,000</td>
-        <td class="spui-Table-cell">3,500,000</td>
-        <td class="spui-Table-cell">3,200,000</td>
-        <td class="spui-Table-cell">4,000,000</td>
-        <td class="spui-Table-cell">13,700,000</td>
-        <td class="spui-Table-cell">+12%</td>
-        <td class="spui-Table-cell">電子機器</td>
-        <td class="spui-Table-cell">全国</td>
-        <td class="spui-Table-cell">在庫あり</td>
-        <td class="spui-Table-cell">2024年2月予定</td>
-        <td class="spui-Table-cell">好調</td>
-      </tr>
-      <tr class="spui-Table-row">
-        <th class="spui-Table-head" scope="row">タブレット</th>
-        <td class="spui-Table-cell">2,800,000</td>
-        <td class="spui-Table-cell">3,100,000</td>
-        <td class="spui-Table-cell">2,900,000</td>
-        <td class="spui-Table-cell">3,500,000</td>
-        <td class="spui-Table-cell">12,300,000</td>
-        <td class="spui-Table-cell">-3%</td>
-        <td class="spui-Table-cell">電子機器</td>
-        <td class="spui-Table-cell">関東・関西</td>
-        <td class="spui-Table-cell">残りわずか</td>
-        <td class="spui-Table-cell">2024年3月予定</td>
-        <td class="spui-Table-cell">やや減少</td>
-      </tr>
-    </tbody>
-  </table>
-</div>`}
-/>
-
-## Style Variations
+テーブルの表示スタイルをカスタマイズするためのオプションです。
 
 ### Striped
 
 <Story of={TableStories.Striped} />
+
+### Rounded
+
+<Story of={TableStories.Rounded} />
 
 <Source
   code={`<Table.Frame borderTypes={['horizontal']} striped>
@@ -1227,23 +780,9 @@ import '@openameba/spindle-ui/Table/Table.css';
       <td class="spui-Table-cell">750,000</td>
       <td class="spui-Table-cell">+5%</td>
     </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品D</th>
-      <td class="spui-Table-cell">650,000</td>
-      <td class="spui-Table-cell">-8%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品E</th>
-      <td class="spui-Table-cell">850,000</td>
-      <td class="spui-Table-cell">+15%</td>
-    </tr>
   </tbody>
 </table>`}
 />
-
-### Rounded
-
-<Story of={TableStories.Rounded} />
 
 <Source
   code={`<Table.Frame borderTypes={['outlined']} rounded>
@@ -1294,7 +833,9 @@ import '@openameba/spindle-ui/Table/Table.css';
 </table>`}
 />
 
-## Cell Merging Examples
+## セル結合
+
+`colSpan` や `rowSpan` を使用して、セルを結合できます。
 
 ### Column Span
 
@@ -1440,7 +981,9 @@ import '@openameba/spindle-ui/Table/Table.css';
 </table>`}
 />
 
-## Semantic Components
+## セマンティックコンポーネント
+
+テーブルにキャプションやフッターを追加して、より意味的な情報を提供できます。
 
 ### With Caption
 
@@ -1557,11 +1100,6 @@ import '@openameba/spindle-ui/Table/Table.css';
       <th class="spui-Table-head" scope="row">商品B</th>
       <td class="spui-Table-cell spui-Table-cell--alignRight">980,000</td>
       <td class="spui-Table-cell spui-Table-cell--alignCenter">-3%</td>
-    </tr>
-    <tr class="spui-Table-row">
-      <th class="spui-Table-head" scope="row">商品C</th>
-      <td class="spui-Table-cell spui-Table-cell--alignRight">750,000</td>
-      <td class="spui-Table-cell spui-Table-cell--alignCenter">+5%</td>
     </tr>
   </tbody>
   <tfoot class="spui-Table-footer">

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -372,21 +372,23 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
   </tbody>
 </table>
 
-```tsx
+<Source
+  language='javascript'
+  code={`
 import { Table } from '@openameba/spindle-ui';
 import '@openameba/spindle-ui/Table/Table.css';
-```
-
-```css
-@import './node_modules/@openameba/spindle-ui/Table/Table.css';
-```
-
-```html
-<link
-  rel="stylesheet"
-  href="https://unpkg.com/@openameba/spindle-ui/Table/Table.css"
+  `}
 />
-```
+
+<Source
+  language='css'
+  code={`@import './node_modules/@openameba/spindle-ui/Table/Table.css'`}
+/>
+
+<Source
+  language='html'
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Table/Table.css">`}
+/>
 
 ## ヘッダーパターン
 

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -373,7 +373,7 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
 </table>
 
 <Source
-  language='javascript'
+  language="javascript"
   code={`
 import { Table } from '@openameba/spindle-ui';
 import '@openameba/spindle-ui/Table/Table.css';
@@ -381,22 +381,18 @@ import '@openameba/spindle-ui/Table/Table.css';
 />
 
 <Source
-  language='css'
+  language="css"
   code={`@import './node_modules/@openameba/spindle-ui/Table/Table.css'`}
 />
 
 <Source
-  language='html'
+  language="html"
   code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Table/Table.css">`}
 />
 
 ## ヘッダーパターン
 
-テーブルのヘッダーは、データの構造に応じて適切に配置する必要があります。
-
-### No Headers
-
-<Story of={TableStories.NoHeaders} />
+テーブルのヘッダーは、データの構造に応じて適切に配置する必要があります。見出しのないテーブルは非推奨です。
 
 ### Column Headers
 

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -8,6 +8,24 @@ import * as TableStories from './Table.stories';
 
 構造化されたデータを表形式で表示するためのコンポーネントです。Web標準の`<table>`要素をベースとしたラッパーコンポーネントとして設計されており、デザインシステムSpindleに準拠した基本スタイリングを提供しつつ、高い拡張性を持つことが特徴です。
 
+<Source
+  language="javascript"
+  code={`
+import { Table } from '@openameba/spindle-ui';
+import '@openameba/spindle-ui/Table/Table.css';
+  `}
+/>
+
+<Source
+  language="css"
+  code={`@import './node_modules/@openameba/spindle-ui/Table/Table.css'`}
+/>
+
+<Source
+  language="html"
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Table/Table.css">`}
+/>
+
 ## 使用上の注意
 
 ### スタイルのカスタマイズについて
@@ -371,24 +389,6 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
     </tr>
   </tbody>
 </table>
-
-<Source
-  language="javascript"
-  code={`
-import { Table } from '@openameba/spindle-ui';
-import '@openameba/spindle-ui/Table/Table.css';
-  `}
-/>
-
-<Source
-  language="css"
-  code={`@import './node_modules/@openameba/spindle-ui/Table/Table.css'`}
-/>
-
-<Source
-  language="html"
-  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/Table/Table.css">`}
-/>
 
 ## ヘッダーパターン
 

--- a/packages/spindle-ui/src/Table/Table.mdx
+++ b/packages/spindle-ui/src/Table/Table.mdx
@@ -906,9 +906,9 @@ Tableコンポーネントは、以下のCSS Variablesでカスタマイズで�
 </Table.Frame>`}
 />
 
-## カスタムテーマ
+## スタイルのカスタマイズ
 
-<Story of={TableStories.CustomTheme} />
+<Story of={TableStories.CustomStyle} />
 
 <Source
   code={`<div

--- a/packages/spindle-ui/src/Table/Table.stories.tsx
+++ b/packages/spindle-ui/src/Table/Table.stories.tsx
@@ -229,7 +229,7 @@ export const FixedLayout: Story = {
         <Table.Row>
           <Table.Head scope="row">商品A</Table.Head>
           <Table.Cell>
-            高品質な商品Aの詳細説明文です。長いテキストも固定幅で表示されます。
+            高品質な商品Aの詳細説明文です。テキストが長くてもレイアウトは固定です。
           </Table.Cell>
           <Table.Cell>¥1,200,000</Table.Cell>
         </Table.Row>

--- a/packages/spindle-ui/src/Table/Table.stories.tsx
+++ b/packages/spindle-ui/src/Table/Table.stories.tsx
@@ -550,18 +550,28 @@ export const LongText: Story = {
       <Table.Body>
         <Table.Row>
           <Table.Head scope="row">通常のテキスト</Table.Head>
-          <Table.Cell>これは通常の長さのテキストです。問題なく表示されます。</Table.Cell>
+          <Table.Cell>
+            これは通常の長さのテキストです。問題なく表示されます。
+          </Table.Cell>
           <Table.Cell>normaltext</Table.Cell>
         </Table.Row>
         <Table.Row>
           <Table.Head scope="row">長い連続文字</Table.Head>
-          <Table.Cell>123123123123123123123123123123123123123123123123123123123123123</Table.Cell>
-          <Table.Cell>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</Table.Cell>
+          <Table.Cell>
+            123123123123123123123123123123123123123123123123123123123123123
+          </Table.Cell>
+          <Table.Cell>
+            AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          </Table.Cell>
         </Table.Row>
         <Table.Row>
           <Table.Head scope="row">URL</Table.Head>
-          <Table.Cell>https://example.com/very/long/path/to/some/resource/that/might/break/layout</Table.Cell>
-          <Table.Cell>https://github.com/openameba/spindle/tree/main/packages/spindle-ui/src/Table</Table.Cell>
+          <Table.Cell>
+            https://example.com/very/long/path/to/some/resource/that/might/break/layout
+          </Table.Cell>
+          <Table.Cell>
+            https://github.com/openameba/spindle/tree/main/packages/spindle-ui/src/Table
+          </Table.Cell>
         </Table.Row>
       </Table.Body>
     </Table.Frame>

--- a/packages/spindle-ui/src/Table/Table.stories.tsx
+++ b/packages/spindle-ui/src/Table/Table.stories.tsx
@@ -453,39 +453,46 @@ export const ColumnSpan: Story = {
 
 export const RowSpan: Story = {
   render: () => (
-    <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
-      <Table.Header>
-        <Table.Row>
-          <Table.Head>カテゴリ</Table.Head>
-          <Table.Head>商品名</Table.Head>
-          <Table.Head>売上</Table.Head>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        <Table.Row>
-          <Table.Head scope="row" rowSpan={2}>
-            電子機器
-          </Table.Head>
-          <Table.Cell>スマートフォン</Table.Cell>
-          <Table.Cell>1,200,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>タブレット</Table.Cell>
-          <Table.Cell>980,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Head scope="row" rowSpan={2}>
-            家電
-          </Table.Head>
-          <Table.Cell>冷蔵庫</Table.Cell>
-          <Table.Cell>750,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>洗濯機</Table.Cell>
-          <Table.Cell>650,000</Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table.Frame>
+    <>
+      <style>{`
+        .no-border-bottom {
+          border-bottom: none !important;
+        }
+      `}</style>
+      <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+        <Table.Header>
+          <Table.Row>
+            <Table.Head>カテゴリ</Table.Head>
+            <Table.Head>商品名</Table.Head>
+            <Table.Head>売上</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Head scope="row" rowSpan={2}>
+              電子機器
+            </Table.Head>
+            <Table.Cell>スマートフォン</Table.Cell>
+            <Table.Cell>1,200,000</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>タブレット</Table.Cell>
+            <Table.Cell>980,000</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Head scope="row" rowSpan={2} className="no-border-bottom">
+              家電
+            </Table.Head>
+            <Table.Cell>冷蔵庫</Table.Cell>
+            <Table.Cell>750,000</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>洗濯機</Table.Cell>
+            <Table.Cell>650,000</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table.Frame>
+    </>
   ),
 };
 

--- a/packages/spindle-ui/src/Table/Table.stories.tsx
+++ b/packages/spindle-ui/src/Table/Table.stories.tsx
@@ -1,0 +1,625 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Table } from './Table';
+
+const meta: Meta<typeof Table> = {
+  title: 'Table',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => (
+    <Table.Frame striped>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上（円）</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>商品A</Table.Cell>
+          <Table.Cell>1,200,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>商品B</Table.Cell>
+          <Table.Cell>980,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>商品C</Table.Cell>
+          <Table.Cell>750,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>商品D</Table.Cell>
+          <Table.Cell>650,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>商品E</Table.Cell>
+          <Table.Cell>850,000</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const NoHeaders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>商品A</Table.Cell>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>商品B</Table.Cell>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>商品C</Table.Cell>
+          <Table.Cell>750,000</Table.Cell>
+          <Table.Cell>+5%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const ColumnHeaders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上（円）</Table.Head>
+          <Table.Head>前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>商品A</Table.Cell>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>商品B</Table.Cell>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const RowHeaders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品C</Table.Head>
+          <Table.Cell>750,000</Table.Cell>
+          <Table.Cell>+5%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const BothHeaders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上（円）</Table.Head>
+          <Table.Head>前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const HorizontalBorders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head align="right">売上（円）</Table.Head>
+          <Table.Head align="center">前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell align="right">1,200,000</Table.Cell>
+          <Table.Cell align="center">+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell align="right">980,000</Table.Cell>
+          <Table.Cell align="center">-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const VerticalBorders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['vertical']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上</Table.Head>
+          <Table.Head>前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>商品A</Table.Cell>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>商品B</Table.Cell>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const OutlineBorders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['outlined']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上</Table.Head>
+          <Table.Head>前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const GridBorders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'vertical']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上</Table.Head>
+          <Table.Head>前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const AllBorders: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上</Table.Head>
+          <Table.Head>前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const FixedLayout: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal']} layout="fixed">
+      <Table.Header>
+        <Table.Row>
+          <Table.Head width="30%">商品名</Table.Head>
+          <Table.Head width="50%">説明</Table.Head>
+          <Table.Head width="20%">価格</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell>
+            高品質な商品Aの詳細説明文です。長いテキストも固定幅で表示されます。
+          </Table.Cell>
+          <Table.Cell>¥1,200,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell>商品Bの説明文</Table.Cell>
+          <Table.Cell>¥980,000</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const TextAlignment: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'vertical']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head align="center">ステータス</Table.Head>
+          <Table.Head align="right">価格</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell align="center">販売中</Table.Cell>
+          <Table.Cell align="right">¥1,200,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell align="center">準備中</Table.Cell>
+          <Table.Cell align="right">¥980,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品C</Table.Head>
+          <Table.Cell align="center">完売</Table.Cell>
+          <Table.Cell align="right">¥1,500</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const Scrollable: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'vertical']} layout="scrollable">
+      <Table.Header>
+        <Table.Row>
+          <Table.Head width="150px">商品名</Table.Head>
+          <Table.Head width="100px">Q1売上</Table.Head>
+          <Table.Head width="100px">Q2売上</Table.Head>
+          <Table.Head width="100px">Q3売上</Table.Head>
+          <Table.Head width="100px">Q4売上</Table.Head>
+          <Table.Head width="110px">年間合計</Table.Head>
+          <Table.Head width="80px">前年比</Table.Head>
+          <Table.Head width="100px">カテゴリ</Table.Head>
+          <Table.Head width="120px">販売地域</Table.Head>
+          <Table.Head width="100px">在庫状況</Table.Head>
+          <Table.Head width="120px">次回入荷予定</Table.Head>
+          <Table.Head width="100px">備考</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">スマートフォン</Table.Head>
+          <Table.Cell>3,000,000</Table.Cell>
+          <Table.Cell>3,500,000</Table.Cell>
+          <Table.Cell>3,200,000</Table.Cell>
+          <Table.Cell>4,000,000</Table.Cell>
+          <Table.Cell>13,700,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+          <Table.Cell>電子機器</Table.Cell>
+          <Table.Cell>全国</Table.Cell>
+          <Table.Cell>在庫あり</Table.Cell>
+          <Table.Cell>2024年2月予定</Table.Cell>
+          <Table.Cell>好調</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">タブレット</Table.Head>
+          <Table.Cell>2,800,000</Table.Cell>
+          <Table.Cell>3,100,000</Table.Cell>
+          <Table.Cell>2,900,000</Table.Cell>
+          <Table.Cell>3,500,000</Table.Cell>
+          <Table.Cell>12,300,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+          <Table.Cell>電子機器</Table.Cell>
+          <Table.Cell>関東・関西</Table.Cell>
+          <Table.Cell>残りわずか</Table.Cell>
+          <Table.Cell>2024年3月予定</Table.Cell>
+          <Table.Cell>やや減少</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const Striped: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal']} striped>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上</Table.Head>
+          <Table.Head>前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品C</Table.Head>
+          <Table.Cell>750,000</Table.Cell>
+          <Table.Cell>+5%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品D</Table.Head>
+          <Table.Cell>650,000</Table.Cell>
+          <Table.Cell>-8%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品E</Table.Head>
+          <Table.Cell>850,000</Table.Cell>
+          <Table.Cell>+15%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const Rounded: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['outlined']} rounded>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上</Table.Head>
+          <Table.Head>前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell>1,200,000</Table.Cell>
+          <Table.Cell>+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell>980,000</Table.Cell>
+          <Table.Cell>-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const ColumnSpan: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head colSpan={2}>上半期</Table.Head>
+          <Table.Head colSpan={2}>下半期</Table.Head>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head>Q1</Table.Head>
+          <Table.Head>Q2</Table.Head>
+          <Table.Head>Q3</Table.Head>
+          <Table.Head>Q4</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>300</Table.Cell>
+          <Table.Cell>350</Table.Cell>
+          <Table.Cell>320</Table.Cell>
+          <Table.Cell>400</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>280</Table.Cell>
+          <Table.Cell>310</Table.Cell>
+          <Table.Cell>290</Table.Cell>
+          <Table.Cell>350</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const RowSpan: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>カテゴリ</Table.Head>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head>売上</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row" rowSpan={2}>
+            電子機器
+          </Table.Head>
+          <Table.Cell>スマートフォン</Table.Cell>
+          <Table.Cell>1,200,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>タブレット</Table.Cell>
+          <Table.Cell>980,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row" rowSpan={2}>
+            家電
+          </Table.Head>
+          <Table.Cell>冷蔵庫</Table.Cell>
+          <Table.Cell>750,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>洗濯機</Table.Cell>
+          <Table.Cell>650,000</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const WithCaption: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal']}>
+      <Table.Caption>売上データ（2023年第4四半期）</Table.Caption>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head align="right">売上（円）</Table.Head>
+          <Table.Head align="center">前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell align="right">1,200,000</Table.Cell>
+          <Table.Cell align="center">+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell align="right">980,000</Table.Cell>
+          <Table.Cell align="center">-3%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head align="right">売上（円）</Table.Head>
+          <Table.Head align="center">前年比</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell align="right">1,200,000</Table.Cell>
+          <Table.Cell align="center">+12%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell align="right">980,000</Table.Cell>
+          <Table.Cell align="center">-3%</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品C</Table.Head>
+          <Table.Cell align="right">750,000</Table.Cell>
+          <Table.Cell align="center">+5%</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+      <Table.Footer>
+        <Table.Row>
+          <Table.Head>合計</Table.Head>
+          <Table.Cell align="right">2,930,000</Table.Cell>
+          <Table.Cell align="center">+4.7%</Table.Cell>
+        </Table.Row>
+      </Table.Footer>
+    </Table.Frame>
+  ),
+};
+
+export const CustomTheme: Story = {
+  render: () => (
+    <div
+      style={{
+        '--Table-head-backgroundColor': 'var(--color-surface-accent-primary)',
+        '--Table-head-color': 'var(--color-text-high-emphasis-inverse)',
+        '--Table-outlineColor': 'var(--color-border-low-emphasis)',
+        '--Table-cell-borderColor': 'var(--color-border-low-emphasis)',
+      }}
+    >
+      <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']} rounded>
+        <Table.Header>
+          <Table.Row>
+            <Table.Head>商品名</Table.Head>
+            <Table.Head>売上</Table.Head>
+            <Table.Head>前年比</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Head scope="row">商品A</Table.Head>
+            <Table.Cell>1,200,000</Table.Cell>
+            <Table.Cell>+12%</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Head scope="row">商品B</Table.Head>
+            <Table.Cell>980,000</Table.Cell>
+            <Table.Cell>-3%</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table.Frame>
+    </div>
+  ),
+};

--- a/packages/spindle-ui/src/Table/Table.stories.tsx
+++ b/packages/spindle-ui/src/Table/Table.stories.tsx
@@ -9,30 +9,6 @@ const meta: Meta<typeof Table> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const NoHeaders: Story = {
-  render: () => (
-    <Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
-      <Table.Body>
-        <Table.Row>
-          <Table.Cell>商品A</Table.Cell>
-          <Table.Cell>1,200,000</Table.Cell>
-          <Table.Cell>+12%</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>商品B</Table.Cell>
-          <Table.Cell>980,000</Table.Cell>
-          <Table.Cell>-3%</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>商品C</Table.Cell>
-          <Table.Cell>750,000</Table.Cell>
-          <Table.Cell>+5%</Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table.Frame>
-  ),
-};
-
 export const ColumnHeaders: Story = {
   render: () => (
     <Table.Frame borderTypes={['horizontal', 'outlined']} rounded>

--- a/packages/spindle-ui/src/Table/Table.stories.tsx
+++ b/packages/spindle-ui/src/Table/Table.stories.tsx
@@ -9,41 +9,6 @@ const meta: Meta<typeof Table> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {
-  render: () => (
-    <Table.Frame striped>
-      <Table.Header>
-        <Table.Row>
-          <Table.Head>商品名</Table.Head>
-          <Table.Head>売上（円）</Table.Head>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        <Table.Row>
-          <Table.Cell>商品A</Table.Cell>
-          <Table.Cell>1,200,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>商品B</Table.Cell>
-          <Table.Cell>980,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>商品C</Table.Cell>
-          <Table.Cell>750,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>商品D</Table.Cell>
-          <Table.Cell>650,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>商品E</Table.Cell>
-          <Table.Cell>850,000</Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table.Frame>
-  ),
-};
-
 export const NoHeaders: Story = {
   render: () => (
     <Table.Frame borderTypes={['horizontal', 'outlined']} rounded>
@@ -302,37 +267,6 @@ export const FixedLayout: Story = {
   ),
 };
 
-export const TextAlignment: Story = {
-  render: () => (
-    <Table.Frame borderTypes={['horizontal', 'vertical']}>
-      <Table.Header>
-        <Table.Row>
-          <Table.Head>商品名</Table.Head>
-          <Table.Head align="center">ステータス</Table.Head>
-          <Table.Head align="right">価格</Table.Head>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        <Table.Row>
-          <Table.Head scope="row">商品A</Table.Head>
-          <Table.Cell align="center">販売中</Table.Cell>
-          <Table.Cell align="right">¥1,200,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Head scope="row">商品B</Table.Head>
-          <Table.Cell align="center">準備中</Table.Cell>
-          <Table.Cell align="right">¥980,000</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Head scope="row">商品C</Table.Head>
-          <Table.Cell align="center">完売</Table.Cell>
-          <Table.Cell align="right">¥1,500</Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table.Frame>
-  ),
-};
-
 export const Scrollable: Story = {
   render: () => (
     <Table.Frame borderTypes={['horizontal', 'vertical']} layout="scrollable">
@@ -380,6 +314,37 @@ export const Scrollable: Story = {
           <Table.Cell>残りわずか</Table.Cell>
           <Table.Cell>2024年3月予定</Table.Cell>
           <Table.Cell>やや減少</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
+export const TextAlignment: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'vertical']}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>商品名</Table.Head>
+          <Table.Head align="center">ステータス</Table.Head>
+          <Table.Head align="right">価格</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">商品A</Table.Head>
+          <Table.Cell align="center">販売中</Table.Cell>
+          <Table.Cell align="right">¥1,200,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品B</Table.Head>
+          <Table.Cell align="center">準備中</Table.Cell>
+          <Table.Cell align="right">¥980,000</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">商品C</Table.Head>
+          <Table.Cell align="center">完売</Table.Cell>
+          <Table.Cell align="right">¥1,500</Table.Cell>
         </Table.Row>
       </Table.Body>
     </Table.Frame>

--- a/packages/spindle-ui/src/Table/Table.stories.tsx
+++ b/packages/spindle-ui/src/Table/Table.stories.tsx
@@ -537,7 +537,7 @@ export const WithFooter: Story = {
   ),
 };
 
-export const CustomTheme: Story = {
+export const CustomStyle: Story = {
   render: () => (
     <div
       style={{

--- a/packages/spindle-ui/src/Table/Table.stories.tsx
+++ b/packages/spindle-ui/src/Table/Table.stories.tsx
@@ -537,6 +537,37 @@ export const WithFooter: Story = {
   ),
 };
 
+export const LongText: Story = {
+  render: () => (
+    <Table.Frame borderTypes={['horizontal', 'vertical']} layout="fixed">
+      <Table.Header>
+        <Table.Row>
+          <Table.Head width="25%">項目名</Table.Head>
+          <Table.Head width="35%">長いテキスト</Table.Head>
+          <Table.Head width="40%">改行されないテキスト</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Head scope="row">通常のテキスト</Table.Head>
+          <Table.Cell>これは通常の長さのテキストです。問題なく表示されます。</Table.Cell>
+          <Table.Cell>normaltext</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">長い連続文字</Table.Head>
+          <Table.Cell>123123123123123123123123123123123123123123123123123123123123123</Table.Cell>
+          <Table.Cell>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Head scope="row">URL</Table.Head>
+          <Table.Cell>https://example.com/very/long/path/to/some/resource/that/might/break/layout</Table.Cell>
+          <Table.Cell>https://github.com/openameba/spindle/tree/main/packages/spindle-ui/src/Table</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Frame>
+  ),
+};
+
 export const CustomStyle: Story = {
   render: () => (
     <div

--- a/packages/spindle-ui/src/Table/Table.test.tsx
+++ b/packages/spindle-ui/src/Table/Table.test.tsx
@@ -94,7 +94,7 @@ describe('<Table />', () => {
       );
 
       const wrapper = container.querySelector(
-        '.spui-Table-container--scrollable',
+        '.spui-Table-frame--scrollable',
       );
       expect(wrapper).toBeInTheDocument();
 

--- a/packages/spindle-ui/src/Table/Table.test.tsx
+++ b/packages/spindle-ui/src/Table/Table.test.tsx
@@ -93,9 +93,7 @@ describe('<Table />', () => {
         </Table.Frame>,
       );
 
-      const wrapper = container.querySelector(
-        '.spui-Table-frame--scrollable',
-      );
+      const wrapper = container.querySelector('.spui-Table-frame--scrollable');
       expect(wrapper).toBeInTheDocument();
 
       const table = wrapper?.querySelector('table');

--- a/packages/spindle-ui/src/Table/Table.test.tsx
+++ b/packages/spindle-ui/src/Table/Table.test.tsx
@@ -1,0 +1,447 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Table } from './Table';
+
+describe('<Table />', () => {
+  describe('Table.Frame', () => {
+    test('renders table element', () => {
+      render(
+        <Table.Frame>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Test Cell</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByText('Test Cell')).toBeInTheDocument();
+    });
+
+    test('applies border type classes', () => {
+      const { container } = render(
+        <Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Test</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const table = container.querySelector('table');
+      expect(table).toHaveClass('spui-Table--horizontal');
+      expect(table).toHaveClass('spui-Table--vertical');
+      expect(table).toHaveClass('spui-Table--outlined');
+    });
+
+    test('applies rounded class', () => {
+      const { container } = render(
+        <Table.Frame rounded>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Test</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const table = container.querySelector('table');
+      expect(table).toHaveClass('spui-Table--rounded');
+    });
+
+    test('applies striped class', () => {
+      const { container } = render(
+        <Table.Frame striped>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Test</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const table = container.querySelector('table');
+      expect(table).toHaveClass('spui-Table--striped');
+    });
+
+    test('applies fixed layout class', () => {
+      const { container } = render(
+        <Table.Frame layout="fixed">
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Test</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const table = container.querySelector('table');
+      expect(table).toHaveClass('spui-Table--fixed');
+    });
+
+    test('wraps table in container for scrollable layout', () => {
+      const { container } = render(
+        <Table.Frame layout="scrollable">
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Test</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const wrapper = container.querySelector(
+        '.spui-Table-container--scrollable',
+      );
+      expect(wrapper).toBeInTheDocument();
+
+      const table = wrapper?.querySelector('table');
+      expect(table).toHaveClass('spui-Table--scrollable');
+    });
+
+    test('forward ref', () => {
+      const ref = React.createRef<HTMLTableElement>();
+
+      render(<Table.Frame ref={ref} />);
+
+      expect(screen.getByRole('table')).toEqual(ref.current);
+    });
+  });
+
+  describe('Table.Caption', () => {
+    test('renders caption element', () => {
+      render(
+        <Table.Frame>
+          <Table.Caption>Test Caption</Table.Caption>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Test</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      expect(screen.getByText('Test Caption')).toBeInTheDocument();
+    });
+
+    test('forward ref', () => {
+      const ref = React.createRef<HTMLTableCaptionElement>();
+
+      render(
+        <Table.Frame>
+          <Table.Caption ref={ref}>Caption</Table.Caption>
+        </Table.Frame>,
+      );
+
+      expect(screen.getByText('Caption')).toEqual(ref.current);
+    });
+  });
+
+  describe('Table.Header', () => {
+    test('renders thead element', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Header>
+            <Table.Row>
+              <Table.Head>Header</Table.Head>
+            </Table.Row>
+          </Table.Header>
+        </Table.Frame>,
+      );
+
+      const thead = container.querySelector('thead');
+      expect(thead).toBeInTheDocument();
+      expect(thead).toHaveClass('spui-Table-header');
+    });
+
+    test('forward ref', () => {
+      const ref = React.createRef<HTMLTableSectionElement>();
+      const { container } = render(
+        <Table.Frame>
+          <Table.Header ref={ref}>
+            <Table.Row>
+              <Table.Head>Header</Table.Head>
+            </Table.Row>
+          </Table.Header>
+        </Table.Frame>,
+      );
+
+      const thead = container.querySelector('thead');
+      expect(thead).toEqual(ref.current);
+    });
+  });
+
+  describe('Table.Body', () => {
+    test('renders tbody element', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Cell</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const tbody = container.querySelector('tbody');
+      expect(tbody).toBeInTheDocument();
+      expect(tbody).toHaveClass('spui-Table-body');
+    });
+
+    test('forward ref', () => {
+      const ref = React.createRef<HTMLTableSectionElement>();
+      const { container } = render(
+        <Table.Frame>
+          <Table.Body ref={ref}>
+            <Table.Row>
+              <Table.Cell>Cell</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const tbody = container.querySelector('tbody');
+      expect(tbody).toEqual(ref.current);
+    });
+  });
+
+  describe('Table.Footer', () => {
+    test('renders tfoot element', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Footer>
+            <Table.Row>
+              <Table.Cell>Footer</Table.Cell>
+            </Table.Row>
+          </Table.Footer>
+        </Table.Frame>,
+      );
+
+      const tfoot = container.querySelector('tfoot');
+      expect(tfoot).toBeInTheDocument();
+      expect(tfoot).toHaveClass('spui-Table-footer');
+    });
+
+    test('forward ref', () => {
+      const ref = React.createRef<HTMLTableSectionElement>();
+      const { container } = render(
+        <Table.Frame>
+          <Table.Footer ref={ref}>
+            <Table.Row>
+              <Table.Cell>Footer</Table.Cell>
+            </Table.Row>
+          </Table.Footer>
+        </Table.Frame>,
+      );
+
+      const tfoot = container.querySelector('tfoot');
+      expect(tfoot).toEqual(ref.current);
+    });
+  });
+
+  describe('Table.Row', () => {
+    test('renders tr element', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Cell</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const tr = container.querySelector('tr');
+      expect(tr).toBeInTheDocument();
+      expect(tr).toHaveClass('spui-Table-row');
+    });
+
+    test('forward ref', () => {
+      const ref = React.createRef<HTMLTableRowElement>();
+      const { container } = render(
+        <Table.Frame>
+          <Table.Body>
+            <Table.Row ref={ref}>
+              <Table.Cell>Cell</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const tr = container.querySelector('tr');
+      expect(tr).toEqual(ref.current);
+    });
+  });
+
+  describe('Table.Head', () => {
+    test('renders th element', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Header>
+            <Table.Row>
+              <Table.Head>Header Cell</Table.Head>
+            </Table.Row>
+          </Table.Header>
+        </Table.Frame>,
+      );
+
+      const th = container.querySelector('th');
+      expect(th).toBeInTheDocument();
+      expect(th).toHaveClass('spui-Table-head');
+      expect(screen.getByText('Header Cell')).toBeInTheDocument();
+    });
+
+    test('applies align classes', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Header>
+            <Table.Row>
+              <Table.Head align="left">Left</Table.Head>
+              <Table.Head align="center">Center</Table.Head>
+              <Table.Head align="right">Right</Table.Head>
+            </Table.Row>
+          </Table.Header>
+        </Table.Frame>,
+      );
+
+      const ths = container.querySelectorAll('th');
+      expect(ths[0]).toHaveClass('spui-Table-head--alignLeft');
+      expect(ths[1]).toHaveClass('spui-Table-head--alignCenter');
+      expect(ths[2]).toHaveClass('spui-Table-head--alignRight');
+    });
+
+    test('applies width style', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Header>
+            <Table.Row>
+              <Table.Head width="100px">Fixed Width</Table.Head>
+              <Table.Head width="50%">Percentage Width</Table.Head>
+            </Table.Row>
+          </Table.Header>
+        </Table.Frame>,
+      );
+
+      const ths = container.querySelectorAll('th');
+      expect(ths[0]).toHaveStyle({ width: '100px' });
+      expect(ths[1]).toHaveStyle({ width: '50%' });
+    });
+
+    test('forward ref', () => {
+      const ref = React.createRef<HTMLTableCellElement>();
+      const { container } = render(
+        <Table.Frame>
+          <Table.Header>
+            <Table.Row>
+              <Table.Head ref={ref}>Header</Table.Head>
+            </Table.Row>
+          </Table.Header>
+        </Table.Frame>,
+      );
+
+      const th = container.querySelector('th');
+      expect(th).toEqual(ref.current);
+    });
+  });
+
+  describe('Table.Cell', () => {
+    test('renders td element', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Cell Content</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const td = container.querySelector('td');
+      expect(td).toBeInTheDocument();
+      expect(td).toHaveClass('spui-Table-cell');
+      expect(screen.getByText('Cell Content')).toBeInTheDocument();
+    });
+
+    test('applies align classes', () => {
+      const { container } = render(
+        <Table.Frame>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell align="left">Left</Table.Cell>
+              <Table.Cell align="center">Center</Table.Cell>
+              <Table.Cell align="right">Right</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const tds = container.querySelectorAll('td');
+      expect(tds[0]).toHaveClass('spui-Table-cell--alignLeft');
+      expect(tds[1]).toHaveClass('spui-Table-cell--alignCenter');
+      expect(tds[2]).toHaveClass('spui-Table-cell--alignRight');
+    });
+
+    test('forward ref', () => {
+      const ref = React.createRef<HTMLTableCellElement>();
+      const { container } = render(
+        <Table.Frame>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell ref={ref}>Cell</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Frame>,
+      );
+
+      const td = container.querySelector('td');
+      expect(td).toEqual(ref.current);
+    });
+  });
+
+  describe('Complete table structure', () => {
+    test('renders all components together', () => {
+      render(
+        <Table.Frame borderTypes={['horizontal']} striped rounded>
+          <Table.Caption>Sales Data</Table.Caption>
+          <Table.Header>
+            <Table.Row>
+              <Table.Head>Product</Table.Head>
+              <Table.Head align="right">Sales</Table.Head>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Head scope="row">Product A</Table.Head>
+              <Table.Cell align="right">1,000</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Head scope="row">Product B</Table.Head>
+              <Table.Cell align="right">2,000</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+          <Table.Footer>
+            <Table.Row>
+              <Table.Head>Total</Table.Head>
+              <Table.Cell align="right">3,000</Table.Cell>
+            </Table.Row>
+          </Table.Footer>
+        </Table.Frame>,
+      );
+
+      // Check structure
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByText('Sales Data')).toBeInTheDocument();
+      expect(screen.getByText('Product')).toBeInTheDocument();
+      expect(screen.getByText('Sales')).toBeInTheDocument();
+      expect(screen.getByText('Product A')).toBeInTheDocument();
+      expect(screen.getByText('Product B')).toBeInTheDocument();
+      expect(screen.getByText('Total')).toBeInTheDocument();
+      expect(screen.getByText('1,000')).toBeInTheDocument();
+      expect(screen.getByText('2,000')).toBeInTheDocument();
+      expect(screen.getByText('3,000')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/spindle-ui/src/Table/Table.tsx
+++ b/packages/spindle-ui/src/Table/Table.tsx
@@ -148,7 +148,7 @@ const Frame = forwardRef<HTMLTableElement, TableFrameProps>(function TableFrame(
     .join(' ')
     .trim();
 
-  const frameClasses = [
+  const scrollContainerClasses = [
     `${BLOCK_NAME}-frame`,
     layout === 'scrollable' && `${BLOCK_NAME}-frame--scrollable`,
   ]
@@ -164,7 +164,7 @@ const Frame = forwardRef<HTMLTableElement, TableFrameProps>(function TableFrame(
 
   // Wrap in container if layout is scrollable
   if (layout === 'scrollable') {
-    return <div className={frameClasses}>{tableElement}</div>;
+    return <div className={scrollContainerClasses}>{tableElement}</div>;
   }
 
   return tableElement;

--- a/packages/spindle-ui/src/Table/Table.tsx
+++ b/packages/spindle-ui/src/Table/Table.tsx
@@ -1,0 +1,311 @@
+import React, { forwardRef, ReactNode, CSSProperties } from 'react';
+
+type BorderType = 'horizontal' | 'vertical' | 'outlined';
+
+type Layout = 'auto' | 'fixed' | 'scrollable';
+
+type Align = 'left' | 'center' | 'right';
+
+// Table
+type TableProps = {
+  borderTypes?: Array<BorderType>;
+  rounded?: boolean;
+  striped?: boolean;
+  layout?: Layout;
+  children?: ReactNode;
+  className?: string;
+} & Omit<React.TableHTMLAttributes<HTMLTableElement>, 'style' | 'className'>;
+
+// Table.Caption
+interface TableCaptionProps
+  extends Omit<
+    React.HTMLAttributes<HTMLTableCaptionElement>,
+    'style' | 'className'
+  > {
+  children?: ReactNode;
+  className?: string;
+}
+
+// Table.Header
+interface TableHeaderProps
+  extends Omit<
+    React.HTMLAttributes<HTMLTableSectionElement>,
+    'style' | 'className'
+  > {
+  children?: ReactNode;
+  className?: string;
+}
+
+// Table.Body
+interface TableBodyProps
+  extends Omit<
+    React.HTMLAttributes<HTMLTableSectionElement>,
+    'style' | 'className'
+  > {
+  children?: ReactNode;
+  className?: string;
+}
+
+// Table.Footer
+interface TableFooterProps
+  extends Omit<
+    React.HTMLAttributes<HTMLTableSectionElement>,
+    'style' | 'className'
+  > {
+  children?: ReactNode;
+  className?: string;
+}
+
+// Table.Row
+interface TableRowProps
+  extends Omit<
+    React.HTMLAttributes<HTMLTableRowElement>,
+    'style' | 'className'
+  > {
+  children?: ReactNode;
+  className?: string;
+}
+
+// Table.Head
+interface TableHeadProps
+  extends Omit<
+    React.ThHTMLAttributes<HTMLTableCellElement>,
+    'style' | 'className'
+  > {
+  align?: Align;
+  width?: CSSProperties['width'];
+  minWidth?: CSSProperties['minWidth'];
+  children?: ReactNode;
+  className?: string;
+}
+
+// Table.Cell
+interface TableCellProps
+  extends Omit<
+    React.TdHTMLAttributes<HTMLTableCellElement>,
+    'style' | 'className'
+  > {
+  align?: Align;
+  children?: ReactNode;
+  className?: string;
+}
+
+const BLOCK_NAME = 'spui-Table';
+
+const getAlignClassName = (align: Align, elementType: 'head' | 'cell') => {
+  switch (align) {
+    case 'left':
+      return `${BLOCK_NAME}-${elementType}--alignLeft`;
+    case 'center':
+      return `${BLOCK_NAME}-${elementType}--alignCenter`;
+    case 'right':
+      return `${BLOCK_NAME}-${elementType}--alignRight`;
+    default:
+      return null;
+  }
+};
+
+const getBorderClassNames = (borderTypes: Array<BorderType>) => {
+  return borderTypes
+    .map((type) => {
+      switch (type) {
+        case 'horizontal':
+          return `${BLOCK_NAME}--horizontal`;
+        case 'vertical':
+          return `${BLOCK_NAME}--vertical`;
+        case 'outlined':
+          return `${BLOCK_NAME}--outlined`;
+        default:
+          return null;
+      }
+    })
+    .filter(Boolean);
+};
+
+// Main Table component
+const Frame = forwardRef<HTMLTableElement, TableProps>(function TableFrame(
+  {
+    borderTypes = [],
+    rounded = false,
+    striped = false,
+    layout = 'auto',
+    children,
+    className,
+    ...rest
+  },
+  ref,
+) {
+  const classes = [
+    BLOCK_NAME,
+    ...getBorderClassNames(borderTypes),
+    rounded && `${BLOCK_NAME}--rounded`,
+    striped && `${BLOCK_NAME}--striped`,
+    layout === 'fixed' && `${BLOCK_NAME}--fixed`,
+    layout === 'scrollable' && `${BLOCK_NAME}--scrollable`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const containerClasses = [
+    `${BLOCK_NAME}-container`,
+    layout === 'scrollable' && `${BLOCK_NAME}-container--scrollable`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const tableElement = (
+    <table ref={ref} className={classes} {...rest}>
+      {children}
+    </table>
+  );
+
+  // Wrap in container if layout is scrollable
+  if (layout === 'scrollable') {
+    return <div className={containerClasses}>{tableElement}</div>;
+  }
+
+  return tableElement;
+});
+
+// Table.Caption
+const Caption = forwardRef<HTMLTableCaptionElement, TableCaptionProps>(
+  function TableCaption({ children, className, ...rest }, ref) {
+    return (
+      <caption
+        ref={ref}
+        className={[`${BLOCK_NAME}-caption`, className]
+          .filter(Boolean)
+          .join(' ')}
+        {...rest}
+      >
+        {children}
+      </caption>
+    );
+  },
+);
+
+// Table.Header
+const Header = forwardRef<HTMLTableSectionElement, TableHeaderProps>(
+  function TableHeader({ children, className, ...rest }, ref) {
+    return (
+      <thead
+        ref={ref}
+        className={[`${BLOCK_NAME}-header`, className]
+          .filter(Boolean)
+          .join(' ')}
+        {...rest}
+      >
+        {children}
+      </thead>
+    );
+  },
+);
+
+// Table.Body
+const Body = forwardRef<HTMLTableSectionElement, TableBodyProps>(
+  function TableBody({ children, className, ...rest }, ref) {
+    return (
+      <tbody
+        ref={ref}
+        className={[`${BLOCK_NAME}-body`, className].filter(Boolean).join(' ')}
+        {...rest}
+      >
+        {children}
+      </tbody>
+    );
+  },
+);
+
+// Table.Footer
+const Footer = forwardRef<HTMLTableSectionElement, TableFooterProps>(
+  function TableFooter({ children, className, ...rest }, ref) {
+    return (
+      <tfoot
+        ref={ref}
+        className={[`${BLOCK_NAME}-footer`, className]
+          .filter(Boolean)
+          .join(' ')}
+        {...rest}
+      >
+        {children}
+      </tfoot>
+    );
+  },
+);
+
+// Table.Row
+const Row = forwardRef<HTMLTableRowElement, TableRowProps>(function TableRow(
+  { children, className, ...rest },
+  ref,
+) {
+  return (
+    <tr
+      ref={ref}
+      className={[`${BLOCK_NAME}-row`, className].filter(Boolean).join(' ')}
+      {...rest}
+    >
+      {children}
+    </tr>
+  );
+});
+
+// Table.Head
+const Head = forwardRef<HTMLTableCellElement, TableHeadProps>(
+  function TableHead(
+    { children, align, width, minWidth, className, ...rest },
+    ref,
+  ) {
+    const classes = [
+      `${BLOCK_NAME}-head`,
+      align && getAlignClassName(align, 'head'),
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const headStyle: React.CSSProperties | undefined =
+      width || minWidth
+        ? {
+            ...(width && { width }),
+            ...(minWidth && { minWidth }),
+          }
+        : undefined;
+
+    return (
+      <th ref={ref} className={classes} style={headStyle} {...rest}>
+        {children}
+      </th>
+    );
+  },
+);
+
+// Table.Cell
+const Cell = forwardRef<HTMLTableCellElement, TableCellProps>(
+  function TableCell({ children, align, className, ...rest }, ref) {
+    const classes = [
+      `${BLOCK_NAME}-cell`,
+      align && getAlignClassName(align, 'cell'),
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <td ref={ref} className={classes} {...rest}>
+        {children}
+      </td>
+    );
+  },
+);
+
+export const Table = {
+  Frame,
+  Caption,
+  Header,
+  Body,
+  Footer,
+  Row,
+  Head,
+  Cell,
+};

--- a/packages/spindle-ui/src/Table/Table.tsx
+++ b/packages/spindle-ui/src/Table/Table.tsx
@@ -147,9 +147,9 @@ const Frame = forwardRef<HTMLTableElement, TableFrameProps>(function TableFrame(
     .filter(Boolean)
     .join(' ');
 
-  const containerClasses = [
-    `${BLOCK_NAME}-container`,
-    layout === 'scrollable' && `${BLOCK_NAME}-container--scrollable`,
+  const frameClasses = [
+    `${BLOCK_NAME}-frame`,
+    layout === 'scrollable' && `${BLOCK_NAME}-frame--scrollable`,
   ]
     .filter(Boolean)
     .join(' ');
@@ -162,7 +162,7 @@ const Frame = forwardRef<HTMLTableElement, TableFrameProps>(function TableFrame(
 
   // Wrap in container if layout is scrollable
   if (layout === 'scrollable') {
-    return <div className={containerClasses}>{tableElement}</div>;
+    return <div className={frameClasses}>{tableElement}</div>;
   }
 
   return tableElement;

--- a/packages/spindle-ui/src/Table/Table.tsx
+++ b/packages/spindle-ui/src/Table/Table.tsx
@@ -145,14 +145,16 @@ const Frame = forwardRef<HTMLTableElement, TableFrameProps>(function TableFrame(
     className,
   ]
     .filter(Boolean)
-    .join(' ');
+    .join(' ')
+    .trim();
 
   const frameClasses = [
     `${BLOCK_NAME}-frame`,
     layout === 'scrollable' && `${BLOCK_NAME}-frame--scrollable`,
   ]
     .filter(Boolean)
-    .join(' ');
+    .join(' ')
+    .trim();
 
   const tableElement = (
     <table ref={ref} className={classes} {...rest}>
@@ -176,7 +178,8 @@ const Caption = forwardRef<HTMLTableCaptionElement, TableCaptionProps>(
         ref={ref}
         className={[`${BLOCK_NAME}-caption`, className]
           .filter(Boolean)
-          .join(' ')}
+          .join(' ')
+          .trim()}
         {...rest}
       >
         {children}
@@ -193,7 +196,8 @@ const Header = forwardRef<HTMLTableSectionElement, TableHeaderProps>(
         ref={ref}
         className={[`${BLOCK_NAME}-header`, className]
           .filter(Boolean)
-          .join(' ')}
+          .join(' ')
+          .trim()}
         {...rest}
       >
         {children}
@@ -225,7 +229,8 @@ const Footer = forwardRef<HTMLTableSectionElement, TableFooterProps>(
         ref={ref}
         className={[`${BLOCK_NAME}-footer`, className]
           .filter(Boolean)
-          .join(' ')}
+          .join(' ')
+          .trim()}
         {...rest}
       >
         {children}
@@ -242,7 +247,10 @@ const Row = forwardRef<HTMLTableRowElement, TableRowProps>(function TableRow(
   return (
     <tr
       ref={ref}
-      className={[`${BLOCK_NAME}-row`, className].filter(Boolean).join(' ')}
+      className={[`${BLOCK_NAME}-row`, className]
+        .filter(Boolean)
+        .join(' ')
+        .trim()}
       {...rest}
     >
       {children}
@@ -262,7 +270,8 @@ const Head = forwardRef<HTMLTableCellElement, TableHeadProps>(
       className,
     ]
       .filter(Boolean)
-      .join(' ');
+      .join(' ')
+      .trim();
 
     const headStyle: React.CSSProperties | undefined =
       width || minWidth
@@ -289,7 +298,8 @@ const Cell = forwardRef<HTMLTableCellElement, TableCellProps>(
       className,
     ]
       .filter(Boolean)
-      .join(' ');
+      .join(' ')
+      .trim();
 
     return (
       <td ref={ref} className={classes} {...rest}>

--- a/packages/spindle-ui/src/Table/Table.tsx
+++ b/packages/spindle-ui/src/Table/Table.tsx
@@ -6,8 +6,8 @@ type Layout = 'auto' | 'fixed' | 'scrollable';
 
 type Align = 'left' | 'center' | 'right';
 
-// Table
-type TableProps = {
+// Table.Frame
+type TableFrameProps = {
   borderTypes?: Array<BorderType>;
   rounded?: boolean;
   striped?: boolean;
@@ -123,7 +123,7 @@ const getBorderClassNames = (borderTypes: Array<BorderType>) => {
 };
 
 // Main Table component
-const Frame = forwardRef<HTMLTableElement, TableProps>(function TableFrame(
+const Frame = forwardRef<HTMLTableElement, TableFrameProps>(function TableFrame(
   {
     borderTypes = [],
     rounded = false,

--- a/packages/spindle-ui/src/Table/design-doc.md
+++ b/packages/spindle-ui/src/Table/design-doc.md
@@ -305,7 +305,7 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 ```css
 .custom-table {
   --Table-head-backgroundColor: var(--color-surface-tertiary);
-  --Table-head-fontSize: 0.875rem;
+  --Table-head-fontSize: 0.875em;
   --Table-cell-padding: 16px 12px;
 }
 ```
@@ -360,9 +360,9 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | --Table-head-fontWeight | bold                            | ヘッダーフォント太さ   |
 | --Table-cell-fontWeight | normal                          | セルフォント太さ       |
 | --Table-footer-fontWeight | normal                        | フッターフォント太さ   |
-| --Table-head-fontSize   | 0.875rem                        | ヘッダーフォントサイズ |
-| --Table-cell-fontSize   | 0.875rem                        | セルフォントサイズ     |
-| --Table-footer-fontSize | 0.875rem                        | フッターフォントサイズ |
+| --Table-head-fontSize   | 0.875em                         | ヘッダーフォントサイズ |
+| --Table-cell-fontSize   | 0.875em                         | セルフォントサイズ     |
+| --Table-footer-fontSize | 0.875em                         | フッターフォントサイズ |
 | --Table-head-lineHeight | 1.4                             | ヘッダー行間           |
 | --Table-cell-lineHeight | 1.4                             | セル行間               |
 | --Table-footer-lineHeight | 1.4                           | フッター行間           |
@@ -389,7 +389,7 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | 変数名                     | デフォルト値                  | 用途                   |
 | :------------------------- | :---------------------------- | :--------------------- |
 | --Table-caption-color      | var(--color-text-low-emphasis) | キャプションテキスト色 |
-| --Table-caption-fontSize   | 0.75rem                       | キャプションフォントサイズ |
+| --Table-caption-fontSize   | 0.75em                        | キャプションフォントサイズ |
 | --Table-caption-lineHeight | 1.6                           | キャプション行間       |
 | --Table-caption-fontWeight | normal                        | キャプションフォント太さ |
 

--- a/packages/spindle-ui/src/Table/design-doc.md
+++ b/packages/spindle-ui/src/Table/design-doc.md
@@ -170,6 +170,35 @@
 </Table.Frame>
 ```
 
+#### 見出しセルの適切な使用
+```tsx
+// ❌ Bad: 見出しセルが全くない（NoHeadersパターン）
+<Table.Frame>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>商品A</Table.Cell>
+      <Table.Cell>1,200,000</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>
+
+// ✅ Good: 適切な列見出しまたは行見出しを設定
+<Table.Frame>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head>商品名</Table.Head>
+      <Table.Head>売上</Table.Head>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>商品A</Table.Cell>
+      <Table.Cell>1,200,000</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table.Frame>
+```
+
 #### セマンティクスの適切な使用
 ```tsx
 // ❌ Bad: 行見出しの未指定
@@ -479,6 +508,7 @@ Tableコンポーネントでは、Web標準のtable要素の機能を最大限�
 - [情報や関係性を明確にする](https://a11y-guidelines.ameba.design/1/3/1/)[基本必須]
   - [ ] `<table>`, `<thead>`, `<tbody>`, `<caption>`要素を適切に使用している
   - [ ] 列見出しは`<th>`、行見出しは`<th scope="row">`で実装している
+  - [ ] 全てのテーブルに適切な見出しセル（`<th>`）が存在する
   - [ ] 複雑な表では`id`と`headers`属性で関連性を明示している
 - [テキストや文字画像のコントラストを確保する](https://a11y-guidelines.ameba.design/1/4/3/)[基本必須]
   - [ ] SpindleのカラーパレットのTheme Colorsを適切に使い分け、コントラスト比を確保している（Text 4.5:1, Object 3:1）

--- a/packages/spindle-ui/src/Table/design-doc.md
+++ b/packages/spindle-ui/src/Table/design-doc.md
@@ -349,7 +349,6 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | --Table-head-backgroundColor        | var(--color-surface-tertiary) | ヘッダー背景色       |
 | --Table-cell-backgroundColor        | var(--color-surface-primary)  | セル背景色           |
 | --Table-row-striped-backgroundColor | var(--color-background)       | ストライプ行背景色   |
-| --Table-row-hover-backgroundColor   | var(--color-surface-secondary) | 行ホバー時背景色     |
 
 #### Text・テキスト関連
 
@@ -357,11 +356,16 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | :---------------------- | :------------------------------ | :--------------------- |
 | --Table-head-color      | var(--color-text-high-emphasis) | ヘッダーテキスト色     |
 | --Table-cell-color      | var(--color-text-high-emphasis) | セルテキスト色         |
+| --Table-footer-color    | var(--color-text-high-emphasis) | フッターテキスト色     |
 | --Table-head-fontWeight | bold                            | ヘッダーフォント太さ   |
+| --Table-cell-fontWeight | normal                          | セルフォント太さ       |
+| --Table-footer-fontWeight | normal                        | フッターフォント太さ   |
 | --Table-head-fontSize   | 14px                            | ヘッダーフォントサイズ |
 | --Table-cell-fontSize   | 14px                            | セルフォントサイズ     |
+| --Table-footer-fontSize | 14px                            | フッターフォントサイズ |
 | --Table-head-lineHeight | 1.4                             | ヘッダー行間           |
 | --Table-cell-lineHeight | 1.4                             | セル行間               |
+| --Table-footer-lineHeight | 1.4                           | フッター行間           |
 
 #### Border・ボーダー関連
 
@@ -378,8 +382,7 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | :--------------------- | :--------------------------- | :----------------- |
 | --Table-head-padding   | 12px                         | ヘッダーパディング |
 | --Table-cell-padding   | 12px                         | セルパディング     |
-| --Table-sticky-shadow  | var(--box-shadow-lv2-normal) | 固定列の影         |
-| --Table-sticky-z-index | 1                            | 固定列のz-index    |
+| --Table-footer-padding | 12px                         | フッターパディング   |
 
 #### Caption・キャプション関連
 
@@ -389,17 +392,6 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | --Table-caption-fontSize   | 12px                          | キャプションフォントサイズ |
 | --Table-caption-lineHeight | 1.6                           | キャプション行間       |
 | --Table-caption-fontWeight | normal                        | キャプションフォント太さ |
-
-#### Footer・フッター関連
-
-| 変数名                          | デフォルト値                          | 用途                   |
-| :------------------------------ | :------------------------------------ | :--------------------- |
-| --Table-footer-backgroundColor  | var(--Table-cell-backgroundColor)     | フッター背景色（td）   |
-| --Table-footer-color            | var(--Table-cell-color)               | フッターテキスト色     |
-| --Table-footer-fontWeight       | normal                                  | フッターフォント太さ   |
-| --Table-footer-fontSize         | var(--Table-cell-fontSize)            | フッターフォントサイズ |
-| --Table-footer-lineHeight       | var(--Table-cell-lineHeight)          | フッター行間           |
-| --Table-footer-padding          | var(--Table-cell-padding)             | フッターパディング     |
 
 ## 設計判断
 

--- a/packages/spindle-ui/src/Table/design-doc.md
+++ b/packages/spindle-ui/src/Table/design-doc.md
@@ -19,7 +19,7 @@
 ### 基本的な使用方法
 
 ```tsx
-<Table borderTypes={['horizontal']} striped>
+<Table.Frame borderTypes={['horizontal']} striped>
   <Table.Caption>売上データ（2023年第4四半期）</Table.Caption>
   <Table.Header>
     <Table.Row>
@@ -40,13 +40,13 @@
       <Table.Cell align="center">-3%</Table.Cell>
     </Table.Row>
   </Table.Body>
-</Table>
+</Table.Frame>
 ```
 
 ### 横スクロール対応テーブル
 
 ```tsx
-<Table
+<Table.Frame
   borderTypes={['horizontal', 'vertical']}
   layout="scrollable"
 >
@@ -70,7 +70,7 @@
       <Table.Cell>1,370</Table.Cell>
     </Table.Row>
   </Table.Body>
-</Table>
+</Table.Frame>
 ```
 
 ### CSS Variablesによるスタイルのカスタマイズ
@@ -81,9 +81,9 @@
   '--Table-head-color': 'var(--color-text-high-emphasis-inverse)',
   '--Table-cell-borderColor': 'var(--color-border-accent-primary)'
 }}>
-  <Table borderTypes={['outlined']} rounded>
+  <Table.Frame borderTypes={['outlined']} rounded>
     ...
-  </Table>
+  </Table.Frame>
 </div>
 ```
 
@@ -114,9 +114,9 @@
 }
 
 // Component
-<Table borderTypes={['horizontal']}>
+<Table.Frame borderTypes={['horizontal']}>
   ...
-</Table>
+</Table.Frame>
 ```
 
 ### DO NOT
@@ -124,14 +124,14 @@
 #### レイアウト目的での使用を避ける
 ```tsx
 // ❌ Bad: フォームレイアウトでのテーブル使用
-<Table>
+<Table.Frame>
   <Table.Body>
     <Table.Row>
       <Table.Cell>ラベル:</Table.Cell>
       <Table.Cell><input /></Table.Cell>
     </Table.Row>
   </Table.Body>
-</Table>
+</Table.Frame>
 
 // ✅ Good: 適切なフォームレイアウト
 <div className="form-field">
@@ -143,31 +143,31 @@
 #### 個別セルでのボーダー指定
 ```tsx
 // ❌ Bad: 通常のテーブルで個別セルにボーダーを指定
-<Table>
+<Table.Frame>
   <Table.Body>
     <Table.Row>
       <Table.Cell className="border-red">データ</Table.Cell>
     </Table.Row>
   </Table.Body>
-</Table>
+</Table.Frame>
 
 // ✅ Good: borderTypes propを使用
-<Table borderTypes={['horizontal']}>
+<Table.Frame borderTypes={['horizontal']}>
   <Table.Body>
     <Table.Row>
       <Table.Cell>データ</Table.Cell>
     </Table.Row>
   </Table.Body>
-</Table>
+</Table.Frame>
 
 // ✅ Good: セル結合時は個別調整も可能
-<Table borderTypes={['horizontal', 'vertical']}>
+<Table.Frame borderTypes={['horizontal', 'vertical']}>
   <Table.Body>
     <Table.Row>
       <Table.Cell colSpan={2} className="merged-cell">結合セル</Table.Cell>
     </Table.Row>
   </Table.Body>
-</Table>
+</Table.Frame>
 ```
 
 #### セマンティクスの適切な使用
@@ -191,15 +191,16 @@ Tableコンポーネントで使用しているDesign Tokensは、CSS Variables�
 
 ### プロパティ
 
-#### Table
+#### Table.Frame
 ```typescript
-type TableProps = {
+type TableFrameProps = {
   borderTypes?: Array<'horizontal' | 'vertical' | 'outlined'>;
   rounded?: boolean;
   striped?: boolean;
   layout?: 'auto' | 'fixed' | 'scrollable';
   children?: ReactNode;
-} & Omit<React.TableHTMLAttributes<HTMLTableElement>, 'style'>;
+  className?: string;
+} & Omit<React.TableHTMLAttributes<HTMLTableElement>, 'style' | 'className'>;
 ```
 
 ##### layout
@@ -210,11 +211,12 @@ type TableProps = {
 #### Table.Head
 ```typescript
 interface TableHeadProps
-  extends Omit<React.ThHTMLAttributes<HTMLTableCellElement>, 'style'> {
+  extends Omit<React.ThHTMLAttributes<HTMLTableCellElement>, 'style' | 'className'> {
   align?: 'left' | 'center' | 'right';
   width?: CSSProperties['width'];
   minWidth?: CSSProperties['minWidth'];
   children?: ReactNode;
+  className?: string;
 }
 ```
 
@@ -233,9 +235,10 @@ interface TableHeadProps
 #### Table.Cell
 ```typescript
 interface TableCellProps
-  extends Omit<React.TdHTMLAttributes<HTMLTableCellElement>, 'style'> {
+  extends Omit<React.TdHTMLAttributes<HTMLTableCellElement>, 'style' | 'className'> {
   align?: 'left' | 'center' | 'right';
   children?: ReactNode;
+  className?: string;
 }
 ```
 
@@ -243,8 +246,9 @@ interface TableCellProps
 `<tfoot>`要素として出力。テーブルのフッター情報（合計、集計など）を格納。
 ```typescript
 interface TableFooterProps
-  extends Omit<React.HTMLAttributes<HTMLTableSectionElement>, 'style'> {
+  extends Omit<React.HTMLAttributes<HTMLTableSectionElement>, 'style' | 'className'> {
   children?: ReactNode;
+  className?: string;
 }
 ```
 
@@ -308,9 +312,9 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 
 ```tsx
 <div className="custom-table">
-  <Table borderTypes={['outlined']} rounded>
+  <Table.Frame borderTypes={['outlined']} rounded>
     {/* テーブル内容 */}
-  </Table>
+  </Table.Frame>
 </div>
 ```
 
@@ -354,8 +358,8 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | --Table-head-color      | var(--color-text-high-emphasis) | ヘッダーテキスト色     |
 | --Table-cell-color      | var(--color-text-high-emphasis) | セルテキスト色         |
 | --Table-head-fontWeight | bold                            | ヘッダーフォント太さ   |
-| --Table-head-fontSize   | 13px                            | ヘッダーフォントサイズ |
-| --Table-cell-fontSize   | 13px                            | セルフォントサイズ     |
+| --Table-head-fontSize   | 14px                            | ヘッダーフォントサイズ |
+| --Table-cell-fontSize   | 14px                            | セルフォントサイズ     |
 | --Table-head-lineHeight | 1.4                             | ヘッダー行間           |
 | --Table-cell-lineHeight | 1.4                             | セル行間               |
 
@@ -372,8 +376,8 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 
 | 変数名                 | デフォルト値                 | 用途               |
 | :--------------------- | :--------------------------- | :----------------- |
-| --Table-head-padding   | 8px 12px                     | ヘッダーパディング |
-| --Table-cell-padding   | 8px 12px                     | セルパディング     |
+| --Table-head-padding   | 12px                         | ヘッダーパディング |
+| --Table-cell-padding   | 12px                         | セルパディング     |
 | --Table-sticky-shadow  | var(--box-shadow-lv2-normal) | 固定列の影         |
 | --Table-sticky-z-index | 1                            | 固定列のz-index    |
 
@@ -421,16 +425,16 @@ Tableコンポーネントでは、Web標準のtable要素の機能を最大限�
 #### 使用例
 ```tsx
 // 横罫線のみ
-<Table borderTypes={['horizontal']}>
+<Table.Frame borderTypes={['horizontal']}>
 
 // 縦横罫線
-<Table borderTypes={['horizontal', 'vertical']}>
+<Table.Frame borderTypes={['horizontal', 'vertical']}>
 
 // 外枠付き
-<Table borderTypes={['outlined']}>
+<Table.Frame borderTypes={['outlined']}>
 
 // 全てのボーダー
-<Table borderTypes={['horizontal', 'vertical', 'outlined']}>
+<Table.Frame borderTypes={['horizontal', 'vertical', 'outlined']}>
 ```
 
 ### CSS Variables中心の設計

--- a/packages/spindle-ui/src/Table/design-doc.md
+++ b/packages/spindle-ui/src/Table/design-doc.md
@@ -305,7 +305,7 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 ```css
 .custom-table {
   --Table-head-backgroundColor: var(--color-surface-tertiary);
-  --Table-head-fontSize: 14px;
+  --Table-head-fontSize: 0.875rem;
   --Table-cell-padding: 16px 12px;
 }
 ```
@@ -360,9 +360,9 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | --Table-head-fontWeight | bold                            | ヘッダーフォント太さ   |
 | --Table-cell-fontWeight | normal                          | セルフォント太さ       |
 | --Table-footer-fontWeight | normal                        | フッターフォント太さ   |
-| --Table-head-fontSize   | 14px                            | ヘッダーフォントサイズ |
-| --Table-cell-fontSize   | 14px                            | セルフォントサイズ     |
-| --Table-footer-fontSize | 14px                            | フッターフォントサイズ |
+| --Table-head-fontSize   | 0.875rem                        | ヘッダーフォントサイズ |
+| --Table-cell-fontSize   | 0.875rem                        | セルフォントサイズ     |
+| --Table-footer-fontSize | 0.875rem                        | フッターフォントサイズ |
 | --Table-head-lineHeight | 1.4                             | ヘッダー行間           |
 | --Table-cell-lineHeight | 1.4                             | セル行間               |
 | --Table-footer-lineHeight | 1.4                           | フッター行間           |
@@ -389,7 +389,7 @@ Tableコンポーネントは基本的なスタイルを提供しますが、プ
 | 変数名                     | デフォルト値                  | 用途                   |
 | :------------------------- | :---------------------------- | :--------------------- |
 | --Table-caption-color      | var(--color-text-low-emphasis) | キャプションテキスト色 |
-| --Table-caption-fontSize   | 12px                          | キャプションフォントサイズ |
+| --Table-caption-fontSize   | 0.75rem                       | キャプションフォントサイズ |
 | --Table-caption-lineHeight | 1.6                           | キャプション行間       |
 | --Table-caption-fontWeight | normal                        | キャプションフォント太さ |
 

--- a/packages/spindle-ui/src/Table/design-doc.md
+++ b/packages/spindle-ui/src/Table/design-doc.md
@@ -256,7 +256,7 @@ interface TableFooterProps
 実際に書き出されるマークアップの例です。
 
 ```html
-<div class="spui-Table-container spui-Table-container--scrollable">
+<div class="spui-Table-frame spui-Table-frame--scrollable">
   <table
     class="spui-Table spui-Table--horizontal spui-Table--striped spui-Table--scrollable"
     style="--Table-min-cell-width: 80px;"

--- a/packages/spindle-ui/src/Table/index.ts
+++ b/packages/spindle-ui/src/Table/index.ts
@@ -1,0 +1,1 @@
+export { Table } from './Table';

--- a/packages/spindle-ui/src/index.css
+++ b/packages/spindle-ui/src/index.css
@@ -11,6 +11,7 @@
 @import './LinkButton/LinkButton.css';
 @import './Modal/index.css';
 @import './SubtleButton/SubtleButton.css';
+@import './Table/Table.css';
 @import './TextButton/TextButton.css';
 @import './TextLink/TextLink.css';
 @import './Toast/Toast.css';


### PR DESCRIPTION
Spindleに `Table` コンポーネントを追加します。
DesignDocのPRは #1324 です。

## DesignDocからの変更点
- 親コンポーネントの命名を `<Table>` -> `<Table.Frame>` に変更
  - 他のコンポーネントの命名に揃える
- CSS Variablesの値を修正
  - デザイナーと議論した上での修正
  - Footer周りのCSS Variablesを刷新。headerと同じような設計に。