### PR TITLE
fix(spindle-ui): ページの背景色に隠れてフォーカスリングが表示されないことがある問題を修正

### DIFF
--- a/packages/spindle-ui/src/Form/ToggleSwitch.css
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.css
@@ -69,7 +69,6 @@
   position: absolute;
   right: -2px;
   top: -2px;
-  z-index: -1;
 }
 
 /* box-shadow is used to apply border-radius as outline */


### PR DESCRIPTION
## 概要

AmebaでToggleSwitchを利用している箇所で、ToggleSwitchをフォーカスしてもフォーカスリングが表示されない問題があった。
原因を調査したところ、 `.spui-ToggleSwitch-outline` に `z-index: -1` がついているせいだった。これは、`.spui-ToggleSwitch-outline` が `.spui-ToggleSwitch-visual` などの上に重なることで ToggleSwitchをクリックしても反応しなくなることを危惧しての指定と想定されるが、ToggleSwichは親要素のlabel自体をクリックしている扱いのため、この懸念ない。
そのため、`.spui-ToggleSwitch-outline` から `z-index: -1` の指定を外すこととした。

なお、Storybookには背景色が指定されていなかったため、従来より正常にフォーカスリングが表示されていた。