### PR TITLE
chore: update renovate settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,6 +2,8 @@
   "extends": [
     "local>openameba/renovate-config:main.json5",
     "local>openameba/renovate-config:npm.json5",
+    "local>openameba/renovate-config:npm-app.json5",
+    "local>openameba/renovate-config:npm-monorepo.json5",
     "local>openameba/renovate-config:automerge-minor.json5"
   ],
   "reviewers": [

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-save-prefix false


### PR DESCRIPTION
- モジュールを追加するとき常にバージョンを固定するのをやめました
- モジュールによってバージョンを固定するかどうかの設定を変えました
    - ルートのpackage.jsonはバージョンを固定します
    - packages配下のpackage.jsonはライブラリとして使用されるのでdevDependencies以外はバージョンを固定しません
