### PR TITLE
feat(spindle-ui): react-merge-refsをuse-callback-refに置き換え

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@openameba/spindle-hooks": "^1.6.0",
     "ameba-color-palette.css": "^4.17.0",
-    "react-merge-refs": "^1.1.0"
+    "use-callback-ref": "^1.3.3"
   },
   "devDependencies": {
     "@figma/code-connect": "1.1.3",

--- a/packages/spindle-ui/src/Dialog/Dialog.tsx
+++ b/packages/spindle-ui/src/Dialog/Dialog.tsx
@@ -5,19 +5,13 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import mergeRefs from 'react-merge-refs';
+import { useMergeRefs } from 'use-callback-ref';
 import { ButtonGroup as Group } from '../ButtonGroup';
 
 interface DialogProps extends React.DialogHTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
   onCancel?: (event: React.BaseSyntheticEvent) => void;
   onClose?: (event: React.BaseSyntheticEvent) => void;
-}
-
-export interface DialogHTMLElement extends HTMLElement {
-  close?: () => void;
-  showModal?: (returnValue?: string) => void;
-  open?: boolean;
 }
 
 interface PartsProps {
@@ -29,19 +23,19 @@ interface PartsProps {
 const BLOCK_NAME = 'spui-Dialog';
 const FADE_OUT_ANIMATION = 'spui-Dialog-fade-out';
 
-const Frame = forwardRef<DialogHTMLElement, DialogProps>(function Dialog(
+const Frame = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
   { children, className, open, onClose, ...rest },
   ref,
 ) {
   const [closing, setClosing] = useState(false);
-  const dialogEl = useRef<DialogHTMLElement>(null);
+  const dialogEl = useRef<HTMLDialogElement>(null);
 
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault(); // To be closed with the open prop
     typeof onClose === 'function' && onClose(event);
   };
 
-  const handleDialogClick = (event: React.MouseEvent<DialogHTMLElement>) => {
+  const handleDialogClick = (event: React.MouseEvent<HTMLDialogElement>) => {
     // Detect backdrop click
     if (event.target === dialogEl.current) {
       onClose && onClose(event);
@@ -49,7 +43,7 @@ const Frame = forwardRef<DialogHTMLElement, DialogProps>(function Dialog(
   };
 
   const handleDialogClose = (
-    event: React.SyntheticEvent<DialogHTMLElement>,
+    event: React.SyntheticEvent<HTMLDialogElement>,
   ) => {
     // Detect escape key type
     if (event.target === dialogEl.current) {
@@ -103,7 +97,7 @@ const Frame = forwardRef<DialogHTMLElement, DialogProps>(function Dialog(
 
   return (
     <dialog
-      ref={mergeRefs([dialogEl, ref])}
+      ref={useMergeRefs([dialogEl, ref])}
       className={[BLOCK_NAME, closing && `${BLOCK_NAME}--closing`, className]
         .filter(Boolean)
         .join(' ')

--- a/packages/spindle-ui/src/Form/DropDown.tsx
+++ b/packages/spindle-ui/src/Form/DropDown.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
-import mergeRefs from 'react-merge-refs';
+import { useMergeRefs } from 'use-callback-ref';
 
 import ChevronDownBold from '../Icon/ChevronDownBold';
 
@@ -58,7 +58,7 @@ export const DropDown = forwardRef<HTMLSelectElement, Props>(function DropDown(
       </span>
       <select
         className={`${BLOCK_NAME}-select`}
-        ref={mergeRefs([selectEl, ref])}
+        ref={useMergeRefs([selectEl, ref])}
         onChange={handleChange}
         {...rest}
       >

--- a/packages/spindle-ui/src/Form/InlineDropDown.tsx
+++ b/packages/spindle-ui/src/Form/InlineDropDown.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
-import mergeRefs from 'react-merge-refs';
+import { useMergeRefs } from 'use-callback-ref';
 
 import ChevronDownBold from '../Icon/ChevronDownBold';
 
@@ -58,7 +58,7 @@ export const InlineDropDown = forwardRef<HTMLSelectElement, Props>(
         </span>
         <select
           className={`${BLOCK_NAME}-select ${BLOCK_NAME}-select--${visualSize}`}
-          ref={mergeRefs([selectEl, ref])}
+          ref={useMergeRefs([selectEl, ref])}
           onChange={handleChange}
           {...rest}
         >

--- a/packages/spindle-ui/src/Modal/AppealModal.tsx
+++ b/packages/spindle-ui/src/Modal/AppealModal.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import mergeRefs from 'react-merge-refs';
+import { useMergeRefs } from 'use-callback-ref';
 import { ButtonGroup as Group } from '../ButtonGroup';
 import CrossBold from '../Icon/CrossBold';
 import { IconButton } from '../IconButton';
@@ -20,29 +20,23 @@ interface AppealModalProps extends React.DialogHTMLAttributes<HTMLElement> {
   onClose?: (event: React.BaseSyntheticEvent) => void;
 }
 
-export interface DialogHTMLElement extends HTMLElement {
-  close?: () => void;
-  showModal?: (returnValue?: string) => void;
-  open?: boolean;
-}
-
 const BLOCK_NAME = 'spui-AppealModal';
 const FADE_OUT_ANIMATION = 'spui-AppealModal-fade-out';
 
-const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
+const Frame = forwardRef<HTMLDialogElement, AppealModalProps>(
   function AppealModal(
     { children, className, open, size = 'large', onClose, ...rest },
     ref,
   ) {
     const [closing, setClosing] = useState(false);
-    const dialogEl = useRef<DialogHTMLElement>(null);
+    const dialogEl = useRef<HTMLDialogElement>(null);
 
     const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault(); // To be closed with the open prop
       onClose && onClose(event);
     };
 
-    const handleDialogClick = (event: React.MouseEvent<DialogHTMLElement>) => {
+    const handleDialogClick = (event: React.MouseEvent<HTMLDialogElement>) => {
       // Detect backdrop click
       if (event.target === dialogEl.current) {
         onClose && onClose(event);
@@ -50,7 +44,7 @@ const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
     };
 
     const handleDialogClose = (
-      event: React.SyntheticEvent<DialogHTMLElement>,
+      event: React.SyntheticEvent<HTMLDialogElement>,
     ) => {
       // Detect escape key type
       if (event.target === dialogEl.current) {
@@ -114,7 +108,7 @@ const Frame = forwardRef<DialogHTMLElement, AppealModalProps>(
           .filter(Boolean)
           .join(' ')
           .trim()}
-        ref={mergeRefs([dialogEl, ref])}
+        ref={useMergeRefs([dialogEl, ref])}
         onClick={handleDialogClick}
         onClose={handleDialogClose}
         {...rest}

--- a/packages/spindle-ui/src/Modal/SemiModal.tsx
+++ b/packages/spindle-ui/src/Modal/SemiModal.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import mergeRefs from 'react-merge-refs';
+import { useMergeRefs } from 'use-callback-ref';
 import CrossBold from '../Icon/CrossBold';
 import { IconButton } from '../IconButton';
 
@@ -22,24 +22,18 @@ interface SemiModalProps
   onClose?: (event: React.BaseSyntheticEvent) => void;
 }
 
-export interface DialogHTMLElement extends HTMLElement {
-  close?: () => void;
-  showModal?: (returnValue?: string) => void;
-  open?: boolean;
-}
-
 const BLOCK_NAME = 'spui-SemiModal';
 const ANIMATION_NAME_LIST = [
   `${BLOCK_NAME}-fade-out`,
   `${BLOCK_NAME}-slide-out`,
 ];
 
-const Frame = forwardRef<DialogHTMLElement, SemiModalProps>(function SemiModal(
+const Frame = forwardRef<HTMLDialogElement, SemiModalProps>(function SemiModal(
   { children, open, size = 'medium', type = 'popup', onClose, ...rest },
   ref,
 ) {
   const [closing, setClosing] = useState(false);
-  const dialogEl = useRef<DialogHTMLElement>(null);
+  const dialogEl = useRef<HTMLDialogElement>(null);
 
   // 閉じるアイコンを押した時
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -48,7 +42,7 @@ const Frame = forwardRef<DialogHTMLElement, SemiModalProps>(function SemiModal(
   };
 
   // backdropを押した時
-  const handleDialogClick = (event: React.MouseEvent<DialogHTMLElement>) => {
+  const handleDialogClick = (event: React.MouseEvent<HTMLDialogElement>) => {
     // Detect backdrop click
     if (event.target === dialogEl.current) {
       onClose?.(event);
@@ -57,7 +51,7 @@ const Frame = forwardRef<DialogHTMLElement, SemiModalProps>(function SemiModal(
 
   //EscKeyを押したとき
   const handleDialogClose = (
-    event: React.SyntheticEvent<DialogHTMLElement>,
+    event: React.SyntheticEvent<HTMLDialogElement>,
   ) => {
     // Detect escape key type
     if (event.target === dialogEl.current) {
@@ -115,7 +109,7 @@ const Frame = forwardRef<DialogHTMLElement, SemiModalProps>(function SemiModal(
         .filter(Boolean)
         .join(' ')
         .trim()}
-      ref={mergeRefs([dialogEl, ref])}
+      ref={useMergeRefs([dialogEl, ref])}
       onClick={handleDialogClick}
       onClose={handleDialogClose}
       data-type={type}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17988,11 +17988,6 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-merge-refs@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
-  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
-
 react@18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
@@ -21839,6 +21834,13 @@ url@^0.11.3:
   dependencies:
     punycode "^1.4.1"
     qs "^6.12.3"
+
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
+  dependencies:
+    tslib "^2.0.0"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## 概要

ViteでSSRを実行した際に以下のようなエラーが出ていました。

```
TypeError: __vite_ssr_import_1__.default is not a function
      at SemiModal (/path_to/node_modules/@openameba/spindle-ui/Modal
  /SemiModal.mjs:64:36)
```

原因としては、react-merge-refsがCommonJS モジュールで、default exportを持たない形式で配布されているためだと考えられたため、ESM対応の別の手段に置き換えました。

## やったこと

use-callback-refから提供されるuseMergeRefsを利用するようにしました。
必要十分な機能をシンプルな実装で提供されているので、自前で実装することも少し考えたものの、メンテコストと天秤にかけて依存を追加する選択を取ってます。

## 確認方法

(こちらは僕の方で実施済みなんですが、気になる方は試しても良いと思います。)

- viteでSSRできるパッケージを用意
- SemiModal等を読み込み問題のエラーが発生するかを確認
- spindleでこのブランチをチェックアウトし、spindle-uiでbuildを実行
- dist内の成果物を用意したパッケージのnode_modules内に上書き
- 再度確認してエラーが消えていることを確認