### PR TITLE
fix(spindle-ui): スマホ幅の時にSemiModalコンテンツ領域がスクロールバー分寄っている

### DIFF
--- a/packages/spindle-ui/src/Modal/SemiModal.css
+++ b/packages/spindle-ui/src/Modal/SemiModal.css
@@ -279,7 +279,7 @@ html.spui-SemiModal--open {
   }
 
   .spui-SemiModal-frame {
-    padding: 0 20px 24px;
+    padding: 0 12px 24px 20px;
   }
 
   .spui-SemiModal-footer {


### PR DESCRIPTION
SemiModal利用時に、SP幅の表示の際、コンテンツ領域が若干左寄りになっているのを修正しました。


before|after
---|---
<img width="319" height="567" alt="image" src="https://github.com/user-attachments/assets/5b6e9025-d719-48e4-9c48-ba856e68c820" />|<img width="318" height="565" alt="image" src="https://github.com/user-attachments/assets/7bc1905e-b452-435c-9014-1d6b498a8a75" />

## 対応方針

現状のPC幅の実装を見ると、スクロールバーの幅分右paddingを調整している↓ようだったので、SP幅もそれに倣ってpaddingを調整しました。

https://github.com/openameba/spindle/blob/main/packages/spindle-ui/src/Modal/SemiModal.css#L139

疑問１：
- でもなんで左右均等の幅にしないんだろう？？
- Figmaではスクロールバーの領域は8pxじゃなくて12pxに見える 🤔 

<img width="789" height="549" alt="image" src="https://github.com/user-attachments/assets/be3f0bef-66e9-4ddc-bce6-9774d4e3de66" />



### その他の方法

スクロールバーが不要なときにもスクロールバーの領域（8px）を取る実装になっている↓ので、

https://github.com/openameba/spindle/blob/main/packages/spindle-ui/src/Modal/SemiModal.css#L176

`overflow: hidden auto;` にすることで、必要な時だけスクロールバーの領域を取るのでも良さそう？
ただ、スクロールバーの有無でコンテンツの表示領域にブレが出るのが嫌で現状のpaddingの調整にしているのかなと想像し、選択しませんでした 🙏 もし意図わかる方がいれば 🙏 

