### PR TITLE
ci: adopt npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
+      id-token: write # Needed for npm Trusted Publishing (OIDC)
       pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -34,7 +34,9 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-v2
-      - run: npm install -g npm@9
+      # Update npm (>=11.5.1 required for OIDC/provenance); install latest
+      - name: Update npm
+        run: npm install -g npm@latest
       - run: yarn install --frozen-lockfile
       - run: yarn lerna run --scope @openameba/spindle-hooks build
       - name: Set git user
@@ -51,7 +53,7 @@ jobs:
         run: yarn lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
         env:
           GH_TOKEN: ${{ github.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC: do not set NODE_AUTH_TOKEN
           NPM_CONFIG_PROVENANCE: true
       - name: Create Pull Request
         run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - name: Extract branch from git ref
         run: |
-          echo "::set-output name=name::${GITHUB_REF#refs/*/}"
-          echo "::set-output name=version::${GITHUB_REF##*/}"
+          echo "name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
+          echo "version=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
         id: extract_branch
       - name: Releaseing with lerna
         # also see some options in lerna.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
     permissions:
       contents: write
       id-token: write # Needed for npm Trusted Publishing (OIDC)
-      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -60,6 +59,6 @@ jobs:
           curl
           -X POST
           -H "Accept: application/vnd.github.v3+json"
-          -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          -H "Authorization: token ${{ github.token }}"
           https://api.github.com/repos/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}/pulls
           -d '{"head":"${{ steps.extract_branch.outputs.name }}","base":"${{ github.event.repository.default_branch }}","title":"chore: publish"}'

--- a/packages/spindle-hooks/package.json
+++ b/packages/spindle-hooks/package.json
@@ -30,7 +30,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openameba/spindle.git"
+    "url": "https://github.com/openameba/spindle",
+    "directory": "packages/spindle-hooks"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/spindle-icons/package.json
+++ b/packages/spindle-icons/package.json
@@ -17,7 +17,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openameba/spindle.git"
+    "url": "https://github.com/openameba/spindle",
+    "directory": "packages/spindle-icons"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/spindle-syntax-themes/package.json
+++ b/packages/spindle-syntax-themes/package.json
@@ -11,7 +11,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openameba/spindle.git"
+    "url": "https://github.com/openameba/spindle",
+    "directory": "packages/spindle-syntax-themes"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/spindle-theme-switch/package.json
+++ b/packages/spindle-theme-switch/package.json
@@ -12,7 +12,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openameba/spindle.git"
+    "url": "https://github.com/openameba/spindle",
+    "directory": "packages/spindle-theme-switch"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/spindle-tokens/package.json
+++ b/packages/spindle-tokens/package.json
@@ -15,7 +15,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openameba/spindle.git"
+    "url": "https://github.com/openameba/spindle",
+    "directory": "packages/spindle-tokens"
   },
   "scripts": {
     "test": "tsc --noEmit && yarn jest",

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -44,7 +44,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openameba/spindle.git"
+    "url": "https://github.com/openameba/spindle",
+    "directory": "packages/spindle-ui"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
[textlint-rule-preset-ameba](https://github.com/openameba/textlint-rule-preset-ameba/pull/97)でうまくいったので、こちらでもOIDC対応します。

- npm Trusted Publishing (OIDC) を採用し、パーソナルアクセストークンからOpenID Connectに移行
- PR作成で`PERSONAL_ACCESS_TOKEN`から`github.token`に切り替え (GitHub Actionsが自動で動かないかもですが、token消したいモチベーションの方が強いです)
- 不要な`pull-requests: write`権限を削除
- 非推奨の`::set-output`から`GITHUB_OUTPUT`環境変数に移行
- リポジトリURLのHTTPS形式化により、npm provenanceの正確な検証を実現
  - すべてのpackage.jsonのリポジトリURLを`git+https`形式から`https`形式に更新
  - モノレポ構造のためにディレクトリプロパティを各パッケージに追加

ref: https://docs.npmjs.com/trusted-publishers

---

This pull request updates the release workflow and improves package metadata for all sub-packages. The most significant changes ensure compatibility with npm's OIDC Trusted Publishing and enhance the accuracy of repository information in each package.

**Release workflow improvements:**

* Updated `.github/workflows/release.yml` to use the latest npm version (required for OIDC/provenance), removed unnecessary permissions, and stopped setting `NODE_AUTH_TOKEN` for OIDC publishing. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L20-R20) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R38) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L46-R62)

**Package metadata updates:**

* Added the `directory` field to the `repository` object in all sub-package `package.json` files (`spindle-hooks`, `spindle-icons`, `spindle-syntax-themes`, `spindle-theme-switch`, `spindle-tokens`, `spindle-ui`) to accurately reflect each package's location in the monorepo. [[1]](diffhunk://#diff-1231197ebccb1972b8298d18f887be7268c257dc9b7ba3c3ebca5ae157b8c072L33-R34) [[2]](diffhunk://#diff-f4dce6f1436e35ae686428a0e46ac2238a3b8b882d1de62b789abf59b42fdc6bL20-R21) [[3]](diffhunk://#diff-8b2790666299162386c478084132c7d96580fd9a9e2c5d4a72570345f0c92922L14-R15) [[4]](diffhunk://#diff-5e596f2158fc0b1a8ad5bb15cc9ff25a52581cb911d4c5cc1cf8f5f8659dd29eL15-R16) [[5]](diffhunk://#diff-818aee630d8304c718beb7025acb61ded4860bbd8a4ac277c35230c842ce19aaL18-R19) [[6]](diffhunk://#diff-7ba32fbf877f643d9857bf8a4416de182d4bc9e94d0f80062106242e726d6ec9L47-R48)