### PR TITLE
ci: update Node.js version to 22 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-icon-from-figma.yml
+++ b/.github/workflows/build-icon-from-figma.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/.github/workflows/build-icon.yml
+++ b/.github/workflows/build-icon.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/.github/workflows/build-tokens.yml
+++ b/.github/workflows/build-tokens.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/.github/workflows/deploy-highlightjs-styles-preview.yml
+++ b/.github/workflows/deploy-highlightjs-styles-preview.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - run: yarn install --frozen-lockfile
       - run: yarn build:example
       - name: deploy to preview channel

--- a/.github/workflows/deploy-highlightjs-styles.yml
+++ b/.github/workflows/deploy-highlightjs-styles.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - run: yarn install --frozen-lockfile
       - run: yarn build:example
       - name: deploy to live channel

--- a/.github/workflows/deploy-hooks-catalog.yml
+++ b/.github/workflows/deploy-hooks-catalog.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/.github/workflows/deploy-hoooks-preview.yml
+++ b/.github/workflows/deploy-hoooks-preview.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - run: yarn install --frozen-lockfile
       - run: yarn storybook:build
       - name: deploy to preview channel

--- a/.github/workflows/deploy-theme-switch-preview.yml
+++ b/.github/workflows/deploy-theme-switch-preview.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn cp

--- a/.github/workflows/deploy-theme-switch.yml
+++ b/.github/workflows/deploy-theme-switch.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: deploy to live channel

--- a/.github/workflows/deploy-ui-catalog.yml
+++ b/.github/workflows/deploy-ui-catalog.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/.github/workflows/deploy-ui-preview.yml
+++ b/.github/workflows/deploy-ui-preview.yml
@@ -39,7 +39,7 @@ jobs:
           ref: 'refs/pull/${{ github.event.number }}/merge'
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - run: yarn install --frozen-lockfile
       - run: |
           yarn lerna run --scope @openameba/spindle-hooks build

--- a/.github/workflows/figma-code-connect.yml
+++ b/.github/workflows/figma-code-connect.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - run: npm i -g @figma/code-connect
       - run: figma connect publish
         env:

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 18
+          node-version-file: package.json
       - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
           registry-url: 'https://registry.npmjs.org'
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: restore lerna
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "typescript": "4.8.2",
     "yaml-lint": "1.7.0"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "workspaces": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
- Add engines field to package.json specifying Node.js >=22
- Update all 17 GitHub Actions workflows to use node-version-file: package.json
- Centralize Node.js version management in package.json for easier maintenance