### PR TITLE
chore: update stylelint to v16.24.0

### DIFF
--- a/packages/spindle-ui/.stylelintrc.json
+++ b/packages/spindle-ui/.stylelintrc.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "stylelint-config-standard",
-    "stylelint-config-prettier"
-  ],
+  "extends": "stylelint-config-standard",
   "plugins": [
     "stylelint-prettier",
     "stylelint-order",
@@ -23,6 +20,14 @@
     }],
     "color-function-notation": "legacy",
     "alpha-value-notation": "number",
-    "color-hex-length": "long"
+    "selector-class-pattern": null,
+    "custom-property-pattern": null,
+    "keyframes-name-pattern": null,
+    "import-notation": null,
+    "color-function-alias-notation": null,
+    "comment-empty-line-before": null,
+    "media-feature-range-notation": null,
+    "no-descending-specificity": null,
+    "property-no-deprecated": null
   }
 }

--- a/packages/spindle-ui/.stylelintrc.json
+++ b/packages/spindle-ui/.stylelintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": "stylelint-config-prettier",
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-prettier"
+  ],
   "plugins": [
     "stylelint-prettier",
     "stylelint-order",
@@ -17,6 +20,9 @@
     },
     "value-keyword-case": ["lower", {
       "ignoreKeywords": ["/^--/"]
-    }]
+    }],
+    "color-function-notation": "legacy",
+    "alpha-value-notation": "number",
+    "color-hex-length": "long"
   }
 }

--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -102,13 +102,13 @@
     "reg-publish-gcs-plugin": "0.14.4",
     "reg-suit": "0.14.5",
     "scaffdog": "4.1.0",
-    "storybook": "8.6.14",
-    "stylelint": "^15.0.0",
+    "storybook": "^8.6.14",
+    "stylelint": "^16.0.0",
     "stylelint-config-prettier": "^9.0.0",
-    "stylelint-config-standard": "^34.0.0",
-    "stylelint-order": "^6.0.0",
-    "stylelint-prettier": "^4.0.0",
-    "stylelint-selector-bem-pattern": "^3.0.0",
+    "stylelint-config-standard": "^39.0.0",
+    "stylelint-order": "^7.0.0",
+    "stylelint-prettier": "^5.0.0",
+    "stylelint-selector-bem-pattern": "^4.0.0",
     "ts-jest": "29.4.1"
   }
 }

--- a/packages/spindle-ui/src/Button/Button.css
+++ b/packages/spindle-ui/src/Button/Button.css
@@ -5,7 +5,6 @@
 :root {
   --Button-tapHighlightColor: var(--gray-5-alpha);
   --Button-onFocus-outlineColor: var(--color-focus-clarity);
-
   --Button--contained-backgroundColor: var(--color-surface-accent-primary);
   --Button--contained-color: var(--color-text-high-emphasis-inverse);
   --Button--contained-onActive-backgroundColor: var(
@@ -14,7 +13,6 @@
   --Button--contained-onHover-backgroundColor: var(
     --color-hover-contained-button
   );
-
   --Button--outlined-borderColor: var(--color-border-accent-primary);
   --Button--outlined-color: var(--color-text-accent-primary);
   --Button--outlined-onActive-backgroundColor: var(
@@ -23,21 +21,18 @@
   --Button--outlined-onHover-backgroundColor: var(
     --color-hover-outlined-button
   );
-
   --Button--lighted-backgroundColor: var(--color-surface-accent-primary-light);
   --Button--lighted-color: var(--color-text-accent-primary);
   --Button--lighted-onActive-backgroundColor: var(
     --color-active-lighted-button
   );
   --Button--lighted-onHover-backgroundColor: var(--color-hover-lighted-button);
-
   --Button--neutral-backgroundColor: var(--color-surface-tertiary);
   --Button--neutral-color: var(--color-text-medium-emphasis);
   --Button--neutral-onActive-backgroundColor: var(
     --color-active-neutral-button
   );
   --Button--neutral-onHover-backgroundColor: var(--color-hover-neutral-button);
-
   --Button--danger-borderColor: var(--color-border-caution);
   --Button--danger-color: var(--color-text-caution);
   --Button--danger-onActive-backgroundColor: var(--color-active-danger-button);

--- a/packages/spindle-ui/src/Dialog/Dialog.css
+++ b/packages/spindle-ui/src/Dialog/Dialog.css
@@ -130,6 +130,7 @@ html.spui-Dialog--open {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -139,6 +140,7 @@ html.spui-Dialog--open {
   from {
     opacity: 1;
   }
+
   to {
     opacity: 0;
   }

--- a/packages/spindle-ui/src/DropdownMenu/DropdownMenu.css
+++ b/packages/spindle-ui/src/DropdownMenu/DropdownMenu.css
@@ -16,7 +16,7 @@
   animation: 0.3s spui-DropdownMenu-fade-in;
   background-color: var(--color-surface-primary);
   border-radius: 12px;
-  box-shadow: 0px 11px 28px rgba(8, 18, 26, 0.12);
+  box-shadow: 0 11px 28px rgba(8, 18, 26, 0.12);
   box-sizing: border-box;
   list-style: none;
   margin: 0;
@@ -153,6 +153,7 @@
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -162,6 +163,7 @@
   from {
     opacity: 1;
   }
+
   to {
     opacity: 0;
   }

--- a/packages/spindle-ui/src/Form/Checkbox.css
+++ b/packages/spindle-ui/src/Form/Checkbox.css
@@ -64,12 +64,9 @@
 /* To add 2px space for outline */
 .spui-Checkbox-outline {
   border-radius: 2px;
-  bottom: -2px;
   height: 22px;
-  left: -2px;
+  inset: -2px;
   position: absolute;
-  right: -2px;
-  top: -2px;
   width: 22px;
 }
 

--- a/packages/spindle-ui/src/Form/DropDown.css
+++ b/packages/spindle-ui/src/Form/DropDown.css
@@ -11,7 +11,7 @@
    * Layout should be set to have appropriate width with longest option text.
    * Browsers automatically get the width from select element
   */
-  -webkit-appearance: none; /* To apply layout (font size, padding etc) to <select> in WebKit */
+  appearance: none; /* To apply layout (font size, padding etc) to <select> in WebKit */
   box-sizing: border-box;
   font-size: 1em;
   margin: 0;

--- a/packages/spindle-ui/src/Form/InlineDropDown.css
+++ b/packages/spindle-ui/src/Form/InlineDropDown.css
@@ -11,8 +11,7 @@
    * Layout should be set to have appropriate width with longest option text.
    * Browsers automatically get the width from select element
   */
-  /* stylelint-disable-next-line declaration-property-value-no-unknown */
-  appearance: listitem; /* To apply layout (font size, padding etc) to <select> in WebKit */
+  appearance: none; /* To apply layout (font size, padding etc) to <select> in WebKit */
   box-sizing: border-box;
   font-size: 1em;
   margin: 0;

--- a/packages/spindle-ui/src/Form/InlineDropDown.css
+++ b/packages/spindle-ui/src/Form/InlineDropDown.css
@@ -11,7 +11,7 @@
    * Layout should be set to have appropriate width with longest option text.
    * Browsers automatically get the width from select element
   */
-  -webkit-appearance: listitem; /* To apply layout (font size, padding etc) to <select> in WebKit */
+  appearance: listitem; /* To apply layout (font size, padding etc) to <select> in WebKit */
   box-sizing: border-box;
   font-size: 1em;
   margin: 0;

--- a/packages/spindle-ui/src/Form/InlineDropDown.css
+++ b/packages/spindle-ui/src/Form/InlineDropDown.css
@@ -11,6 +11,7 @@
    * Layout should be set to have appropriate width with longest option text.
    * Browsers automatically get the width from select element
   */
+  /* stylelint-disable-next-line declaration-property-value-no-unknown */
   appearance: listitem; /* To apply layout (font size, padding etc) to <select> in WebKit */
   box-sizing: border-box;
   font-size: 1em;

--- a/packages/spindle-ui/src/Form/Radio.css
+++ b/packages/spindle-ui/src/Form/Radio.css
@@ -64,12 +64,9 @@
 /* To add 2px space for outline */
 .spui-Radio-outline {
   border-radius: 50%;
-  bottom: -2px;
   height: 24px;
-  left: -2px;
+  inset: -2px;
   position: absolute;
-  right: -2px;
-  top: -2px;
   width: 24px;
 }
 

--- a/packages/spindle-ui/src/Form/ToggleSwitch.css
+++ b/packages/spindle-ui/src/Form/ToggleSwitch.css
@@ -64,11 +64,8 @@
 /* To add 2px space for outline */
 .spui-ToggleSwitch-outline {
   border-radius: 16px;
-  bottom: -2px;
-  left: -2px;
+  inset: -2px;
   position: absolute;
-  right: -2px;
-  top: -2px;
 }
 
 /* box-shadow is used to apply border-radius as outline */

--- a/packages/spindle-ui/src/IconButton/IconButton.css
+++ b/packages/spindle-ui/src/IconButton/IconButton.css
@@ -5,29 +5,24 @@
 :root {
   --IconButton-tapHighlightColor: var(--gray-5-alpha);
   --IconButton-onFocus-outlineColor: var(--color-focus-clarity);
-
   --IconButton--contained-backgroundColor: var(--color-surface-accent-primary);
   --IconButton--contained-color: var(--color-object-high-emphasis-inverse);
   --IconButton--contained-onActive-backgroundColor: var(--primary-green-100);
   --IconButton--contained-onHover-backgroundColor: var(--primary-green-100);
-
   --IconButton--outlined-borderColor: var(--color-border-accent-primary);
   --IconButton--outlined-color: var(--color-object-accent-primary);
   --IconButton--outlined-onActive-backgroundColor: var(--primary-green-5);
   --IconButton--outlined-onHover-backgroundColor: var(--primary-green-5);
-
   --IconButton--lighted-backgroundColor: var(
     --color-surface-accent-primary-light
   );
   --IconButton--lighted-color: var(--color-object-accent-primary);
   --IconButton--lighted-onActive-backgroundColor: var(--primary-green-10);
   --IconButton--lighted-onHover-backgroundColor: var(--primary-green-10);
-
   --IconButton--neutral-backgroundColor: var(--color-surface-tertiary);
   --IconButton--neutral-color: var(--color-object-medium-emphasis);
   --IconButton--neutral-onActive-backgroundColor: var(--gray-20-alpha);
   --IconButton--neutral-onHover-backgroundColor: var(--gray-20-alpha);
-
   --IconButton--danger-borderColor: var(--color-border-caution);
   --IconButton--danger-color: var(--color-object-caution);
   --IconButton--danger-onActive-backgroundColor: var(--caution-red-5-alpha);

--- a/packages/spindle-ui/src/InlineNotification/InlineNotification.css
+++ b/packages/spindle-ui/src/InlineNotification/InlineNotification.css
@@ -14,12 +14,10 @@
   --InlineNotification--neutral-color: var(--color-text-high-emphasis-inverse);
   --InlineNotification--neutral-onHover-backgroundColor: var(--white-30-alpha);
   --InlineNotification--neutral-onActive-backgroundColor: var(--white-30-alpha);
-
   --InlineNotification--outlined-onHover-backgroundColor: var(--white-50-alpha);
   --InlineNotification--outlined-onActive-backgroundColor: var(
     --white-50-alpha
   );
-
   --InlineNotification--contained-backgroundColor: var(--color-surface-primary);
   --InlineNotification--contained-color: var(--color-text-accent-primary);
   --InlineNotification--contained-onHover-backgroundColor: var(
@@ -28,7 +26,6 @@
   --InlineNotification--contained-onActive-backgroundColor: var(
     --white-70-alpha
   );
-
   --InlineNotification--danger-borderColor: var(
     --color-border-high-emphasis-inverse
   );
@@ -41,14 +38,17 @@
   border-radius: 12px;
   width: 100%;
 }
+
 .spui-InlineNotification--full {
-  border-radius: 0px;
+  border-radius: 0;
 }
+
 .spui-InlineNotification-content {
   align-items: center;
   display: flex;
   padding: 8px 12px;
 }
+
 .spui-InlineNotification-icon {
   align-items: center;
   display: flex;
@@ -57,6 +57,7 @@
   margin-right: 8px;
   padding: 5px 0;
 }
+
 .spui-InlineNotification-avatar {
   flex: none;
   height: 36px;
@@ -64,6 +65,7 @@
   position: relative;
   width: 36px;
 }
+
 .spui-InlineNotification-avatar::before {
   border: solid 1px var(--color-border-low-emphasis);
   border-radius: 50%;
@@ -73,12 +75,14 @@
   position: absolute;
   width: 100%;
 }
+
 .spui-InlineNotification-avatarInner {
   border-radius: 50%;
   height: 100%;
   object-fit: cover;
   width: 100%;
 }
+
 .spui-InlineNotification-text {
   flex: 1;
   font-size: 0.875em;
@@ -88,15 +92,18 @@
   min-width: 0;
   overflow-wrap: break-word;
 }
+
 .spui-InlineNotification-iconButton {
   margin-left: 16px;
   padding: 5px 0;
 }
+
 .spui-InlineNotification-textButton {
   flex: none;
   font-size: 0.75em;
   margin-left: 16px;
 }
+
 .spui-InlineNotification-button {
   flex: none;
   margin-left: 16px;
@@ -112,16 +119,20 @@
 .spui-InlineNotification--information {
   background-color: var(--color-surface-tertiary);
 }
+
 .spui-InlineNotification--information .spui-InlineNotification-icon {
   color: var(--color-object-medium-emphasis);
 }
+
 .spui-InlineNotification--information .spui-InlineNotification-text {
   color: var(--color-text-medium-emphasis);
 }
+
 .spui-InlineNotification--information .spui-InlineNotification-iconButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --IconButton--neutral-backgroundColor: transparent;
 }
+
 .spui-InlineNotification--information .spui-InlineNotification-textButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --TextButton-color: var(--color-text-medium-emphasis);
@@ -131,14 +142,17 @@
 .spui-InlineNotification--information.spui-InlineNotification--emphasized {
   background-color: var(--color-surface-accent-neutral-high-emphasis);
 }
+
 .spui-InlineNotification--information.spui-InlineNotification--emphasized
   .spui-InlineNotification-icon {
   color: var(--color-object-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--information.spui-InlineNotification--emphasized
   .spui-InlineNotification-text {
   color: var(--color-text-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--information.spui-InlineNotification--emphasized
   .spui-InlineNotification-iconButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
@@ -152,11 +166,13 @@
     --InlineNotification--neutral-onActive-backgroundColor
   );
 }
+
 .spui-InlineNotification--information.spui-InlineNotification--emphasized
   .spui-InlineNotification-textButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --TextButton-color: var(--color-text-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--information.spui-InlineNotification--emphasized
   .spui-InlineNotification-button {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
@@ -179,12 +195,15 @@
 .spui-InlineNotification--confirmation {
   background-color: var(--color-surface-accent-primary-light);
 }
+
 .spui-InlineNotification--confirmation .spui-InlineNotification-icon {
   color: var(--color-object-accent-primary);
 }
+
 .spui-InlineNotification--confirmation .spui-InlineNotification-text {
   color: var(--color-text-accent-primary);
 }
+
 .spui-InlineNotification--confirmation .spui-InlineNotification-iconButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --IconButton--outlined-borderColor: none;
@@ -197,6 +216,7 @@
     --InlineNotification--outlined-onActive-backgroundColor
   );
 }
+
 .spui-InlineNotification--confirmation .spui-InlineNotification-button {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --Button--outlined-onHover-backgroundColor: var(
@@ -212,19 +232,23 @@
 .spui-InlineNotification--confirmation.spui-InlineNotification--emphasized {
   background-color: var(--color-surface-accent-primary);
 }
+
 .spui-InlineNotification--confirmation.spui-InlineNotification--emphasized
   .spui-InlineNotification-icon {
   color: var(--color-object-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--confirmation.spui-InlineNotification--emphasized
   .spui-InlineNotification-text {
   color: var(--color-text-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--confirmation.spui-InlineNotification--emphasized
   .spui-InlineNotification-textButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --TextButton-color: var(--color-text-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--confirmation.spui-InlineNotification--emphasized
   .spui-InlineNotification-button {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
@@ -247,16 +271,20 @@
 .spui-InlineNotification--error {
   background-color: var(--color-surface-caution-light);
 }
+
 .spui-InlineNotification--error .spui-InlineNotification-icon {
   color: var(--color-object-caution);
 }
+
 .spui-InlineNotification--error .spui-InlineNotification-text {
   color: var(--color-text-caution);
 }
+
 .spui-InlineNotification--error .spui-InlineNotification-iconButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --IconButton--danger-borderColor: none;
 }
+
 .spui-InlineNotification--error .spui-InlineNotification-textButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --TextButton-color: var(--color-text-caution);
@@ -266,14 +294,17 @@
 .spui-InlineNotification--error.spui-InlineNotification--emphasized {
   background-color: var(--color-surface-caution);
 }
+
 .spui-InlineNotification--error.spui-InlineNotification--emphasized
   .spui-InlineNotification-icon {
   color: var(--color-object-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--error.spui-InlineNotification--emphasized
   .spui-InlineNotification-text {
   color: var(--color-text-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--error.spui-InlineNotification--emphasized
   .spui-InlineNotification-iconButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
@@ -287,11 +318,13 @@
     --InlineNotification--danger-onActive-backgroundColor
   );
 }
+
 .spui-InlineNotification--error.spui-InlineNotification--emphasized
   .spui-InlineNotification-textButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --TextButton-color: var(--color-text-high-emphasis-inverse);
 }
+
 .spui-InlineNotification--error.spui-InlineNotification--emphasized
   .spui-InlineNotification-button {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */

--- a/packages/spindle-ui/src/LinkButton/LinkButton.css
+++ b/packages/spindle-ui/src/LinkButton/LinkButton.css
@@ -5,29 +5,24 @@
 :root {
   --LinkButton-tapHighlightColor: var(--gray-5-alpha);
   --LinkButton-onFocus-outlineColor: var(--color-focus-clarity);
-
   --LinkButton--contained-backgroundColor: var(--color-surface-accent-primary);
   --LinkButton--contained-color: var(--color-text-high-emphasis-inverse);
   --LinkButton--contained-onActive-backgroundColor: var(--primary-green-100);
   --LinkButton--contained-onHover-backgroundColor: var(--primary-green-100);
-
   --LinkButton--outlined-borderColor: var(--color-border-accent-primary);
   --LinkButton--outlined-color: var(--color-text-accent-primary);
   --LinkButton--outlined-onActive-backgroundColor: var(--primary-green-5);
   --LinkButton--outlined-onHover-backgroundColor: var(--primary-green-5);
-
   --LinkButton--lighted-backgroundColor: var(
     --color-surface-accent-primary-light
   );
   --LinkButton--lighted-color: var(--color-text-accent-primary);
   --LinkButton--lighted-onActive-backgroundColor: var(--primary-green-10);
   --LinkButton--lighted-onHover-backgroundColor: var(--primary-green-10);
-
   --LinkButton--neutral-backgroundColor: var(--color-surface-tertiary);
   --LinkButton--neutral-color: var(--color-text-medium-emphasis);
   --LinkButton--neutral-onActive-backgroundColor: var(--gray-20-alpha);
   --LinkButton--neutral-onHover-backgroundColor: var(--gray-20-alpha);
-
   --LinkButton--danger-borderColor: var(--color-border-caution);
   --LinkButton--danger-color: var(--color-text-caution);
   --LinkButton--danger-onActive-backgroundColor: var(--caution-red-5-alpha);

--- a/packages/spindle-ui/src/Modal/AppealModal.css
+++ b/packages/spindle-ui/src/Modal/AppealModal.css
@@ -107,7 +107,7 @@ html.spui-AppealModal--open {
 .spui-AppealModal-frame {
   color: var(--color-text-medium-emphasis);
   display: grid;
-  gap: 0px 0px;
+  gap: 0;
   grid-auto-flow: row;
   grid-template-areas:
     'Image'
@@ -242,7 +242,7 @@ html.spui-AppealModal--open {
     /* stylelint-enable plugin/selector-bem-pattern */
 
     display: inline-flex;
-    margin: 36px 0 0 0;
+    margin: 36px 0 0;
   }
 
   .spui-AppealModal-closeTextButton {
@@ -254,6 +254,7 @@ html.spui-AppealModal--open {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -263,6 +264,7 @@ html.spui-AppealModal--open {
   from {
     opacity: 1;
   }
+
   to {
     opacity: 0;
   }

--- a/packages/spindle-ui/src/Modal/AppealModal.css
+++ b/packages/spindle-ui/src/Modal/AppealModal.css
@@ -109,14 +109,12 @@ html.spui-AppealModal--open {
   display: grid;
   gap: 0;
   grid-auto-flow: row;
-  grid-template-areas:
+  grid-template:
     'Image'
     'Title'
     'Body'
     'ButtonGroup'
-    'CloseButton';
-  grid-template-columns: 1fr;
-  grid-template-rows: auto;
+    'CloseButton' / 1fr;
   padding: 0 0 24px;
   width: 100%;
 }
@@ -198,13 +196,11 @@ html.spui-AppealModal--open {
 
   .spui-AppealModal-frame {
     grid-auto-flow: row;
-    grid-template-areas:
+    grid-template:
       'Title CloseButton'
       'Body CloseButton'
       'Image Image'
-      'ButtonGroup ButtonGroup';
-    grid-template-columns: 1fr 72px;
-    grid-template-rows: auto;
+      'ButtonGroup ButtonGroup' / 1fr 72px;
     padding: 0 0 36px;
   }
 

--- a/packages/spindle-ui/src/Modal/SemiModal.css
+++ b/packages/spindle-ui/src/Modal/SemiModal.css
@@ -275,6 +275,7 @@ html.spui-SemiModal--open {
   .spui-SemiModal-closeIconButton {
     height: 24px;
     width: 24px;
+
     --IconButton--neutral-onHover-backgroundColor: transparent;
   }
 
@@ -297,6 +298,7 @@ html.spui-SemiModal--open {
   from {
     transform: translateY(100%);
   }
+
   to {
     transform: translateY(0);
   }
@@ -306,6 +308,7 @@ html.spui-SemiModal--open {
   from {
     transform: translateY(0);
   }
+
   to {
     transform: translateY(100%);
   }
@@ -315,6 +318,7 @@ html.spui-SemiModal--open {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -324,6 +328,7 @@ html.spui-SemiModal--open {
   from {
     opacity: 1;
   }
+
   to {
     opacity: 0;
   }

--- a/packages/spindle-ui/src/SegmentedControl/SegmentedControl.css
+++ b/packages/spindle-ui/src/SegmentedControl/SegmentedControl.css
@@ -57,7 +57,7 @@
 }
 
 .spui-SegmentedControl--divider
-  .spui-SegmentedControl-button:first-of-type:before {
+  .spui-SegmentedControl-button:first-of-type::before {
   content: none;
 }
 
@@ -99,7 +99,7 @@
   background-color: var(--color-surface-primary);
   bottom: 4px;
   /* TODO: replace color with color palette */
-  box-shadow: 0px 3.25px 7.75px rgba(8, 18, 26, 0.06);
+  box-shadow: 0 3.25px 7.75px rgba(8, 18, 26, 0.06);
   content: '';
   height: auto;
   left: 0;

--- a/packages/spindle-ui/src/SnackBar/SnackBar.css
+++ b/packages/spindle-ui/src/SnackBar/SnackBar.css
@@ -22,7 +22,7 @@
 .spui-SnackBar-content {
   align-items: center;
   border-radius: 16px;
-  box-shadow: 0px 11px 28px rgba(8, 18, 26, 0.24);
+  box-shadow: 0 11px 28px rgba(8, 18, 26, 0.24);
   box-sizing: border-box;
   display: inline-grid;
   grid-template: 'Icon Text Button IconButton' auto / auto 1fr auto auto;
@@ -117,6 +117,7 @@
 .spui-SnackBar-iconButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --IconButton--neutral-backgroundColor: transparent;
+
   grid-area: IconButton;
   margin-left: 12px;
 }

--- a/packages/spindle-ui/src/TextButton/TextButton.css
+++ b/packages/spindle-ui/src/TextButton/TextButton.css
@@ -24,10 +24,12 @@
   margin: 0;
   padding: 0;
   -webkit-tap-highlight-color: var(--TextButton-tapHighlightColor);
+  text-decoration: underline;
 }
 
 .spui-TextButton:disabled {
   opacity: 0.3;
+  text-decoration: none;
 }
 
 .spui-TextButton:focus {
@@ -73,16 +75,8 @@
 /*
  * Underline management
 */
-.spui-TextButton {
-  text-decoration: underline;
-}
-
 .spui-TextButton--hasIcon,
 .spui-TextButton--underlinehover {
-  text-decoration: none;
-}
-
-.spui-TextButton:disabled {
   text-decoration: none;
 }
 

--- a/packages/spindle-ui/src/TextButton/TextButton.css
+++ b/packages/spindle-ui/src/TextButton/TextButton.css
@@ -8,7 +8,6 @@
   --TextButton-color: var(--color-text-accent-primary);
   --TextButton-icon-color: var(--color-object-accent-primary);
   --TextButton-fontWeight: bold;
-
   --TextButton--subtle-color: var(--color-text-low-emphasis);
   --TextButton--subtle-icon-color: var(--color-object-low-emphasis);
 }

--- a/packages/spindle-ui/src/TextLink/TextLink.css
+++ b/packages/spindle-ui/src/TextLink/TextLink.css
@@ -19,6 +19,7 @@
   font-weight: var(--TextLink-fontWeight);
   line-height: 1.3;
   -webkit-tap-highlight-color: var(--TextLink-tapHighlightColor);
+  text-decoration: underline;
 }
 
 .spui-TextLink:focus {
@@ -64,10 +65,6 @@
 /*
  * Underline management
 */
-.spui-TextLink {
-  text-decoration: underline;
-}
-
 .spui-TextLink--hasIcon,
 .spui-TextLink--underlinehover {
   text-decoration: none;

--- a/packages/spindle-ui/src/TextLink/TextLink.css
+++ b/packages/spindle-ui/src/TextLink/TextLink.css
@@ -8,7 +8,6 @@
   --TextLink-color: var(--color-text-accent-primary);
   --TextLink-icon-color: var(--color-object-accent-primary);
   --TextLink-fontWeight: bold;
-
   --TextLink--subtle-color: var(--color-text-low-emphasis);
   --TextLink--subtle-icon-color: var(--color-object-low-emphasis);
 }

--- a/packages/spindle-ui/src/Toast/Toast.css
+++ b/packages/spindle-ui/src/Toast/Toast.css
@@ -19,7 +19,7 @@
 .spui-Toast-content {
   align-items: center;
   border-radius: 52px;
-  box-shadow: 0px 11px 28px rgba(8, 18, 26, 0.24);
+  box-shadow: 0 11px 28px rgba(8, 18, 26, 0.24);
   box-sizing: border-box;
   display: inline-flex;
   margin: 0;
@@ -87,6 +87,7 @@
 .spui-Toast-iconButton {
   /* stylelint-disable-next-line plugin/selector-bem-pattern */
   --IconButton--neutral-backgroundColor: transparent;
+
   margin-left: 12px;
 }
 


### PR DESCRIPTION
思いの外変更多くなってしもた (まる)

## 確認コンポーネント

### Checkbox
focus時のアウトラインが表示されている
(前) https://ameba-spindle.web.app/?path=/story/form-checkbox--checkbox
(今) https://ameba-spindle--pr1367-chore-deps-stylelint-62s8imgf.web.app/?path=/story/form-checkbox--checkbox

### Dropdown
動作に変更がない
(前) https://ameba-spindle.web.app/?path=/story/form-dropdown--drop-down
(今) https://ameba-spindle--pr1367-chore-deps-stylelint-62s8imgf.web.app/?path=/story/form-dropdown--drop-down

### InlineDropdown
動作に変更がない
(前) https://ameba-spindle.web.app/?path=/story/form-inlinedropdown--medium
(今) https://ameba-spindle--pr1367-chore-deps-stylelint-62s8imgf.web.app/?path=/story/form-inlinedropdown--medium

### Radio
focus時のアウトラインが表示されている
(前) https://ameba-spindle.web.app/?path=/story/form-radio--radio
(今) https://ameba-spindle--pr1367-chore-deps-stylelint-62s8imgf.web.app/?path=/story/form-radio--radio

### ToggleSwitch
focus時のアウトラインが表示されている
(前) https://ameba-spindle.web.app/?path=/story/form-toggleswitch--toggle-switch
(今) https://ameba-spindle--pr1367-chore-deps-stylelint-62s8imgf.web.app/?path=/story/form-toggleswitch--toggle-switch

### AppealModal
動作に変更がない
(前) https://ameba-spindle.web.app/?path=/story/modal-appealmodal--style-only-small-size
(今) https://ameba-spindle--pr1367-chore-deps-stylelint-62s8imgf.web.app/?path=/story/modal-appealmodal--style-only-small-size

### TextButton
動作に変更がない
(前) https://ameba-spindle.web.app/?path=/docs/textbutton--docs
(今) https://ameba-spindle--pr1367-chore-deps-stylelint-62s8imgf.web.app/?path=/docs/textbutton--docs

### TextLink
動作に変更がない
(前) https://ameba-spindle.web.app/?path=/docs/textlink--docs
(今) https://ameba-spindle--pr1367-chore-deps-stylelint-62s8imgf.web.app/?path=/docs/textlink--docs

---

This pull request updates the stylelint configuration and related dependencies to align with the latest standards, and makes minor improvements to the CSS codebase for consistency and maintainability. The most significant changes are grouped below:

**Stylelint Configuration and Dependency Updates:**

* Changed the base stylelint config from `stylelint-config-prettier` to `stylelint-config-standard` and added/adjusted several linting rules to accommodate new stylelint v16 requirements in `.stylelintrc.json`. [[1]](diffhunk://#diff-1f0648454c9fe881fa959aaa1aaf2332057bb328d0420637cabd5bb3fcd9bbb6L2-R2) [[2]](diffhunk://#diff-1f0648454c9fe881fa959aaa1aaf2332057bb328d0420637cabd5bb3fcd9bbb6L20-R31)
* Upgraded stylelint and related plugins in `package.json` to their latest major versions, ensuring compatibility with the updated configuration.

**CSS Improvements and Consistency:**

* Replaced redundant or verbose positioning properties (`top`, `left`, `right`, `bottom`) with the shorthand `inset` for outline elements in `Checkbox.css`, `Radio.css`, and `ToggleSwitch.css`, simplifying the code. [[1]](diffhunk://#diff-7d2ac9f2586076236020108f2b040d5a7313ede12b9a16fc65ad75d604e03355L50-L55) [[2]](diffhunk://#diff-d3742d29b3645fa1ebfc34773097d5a96203b91aba627c0263d1152aedd09a72L52-L57) [[3]](diffhunk://#diff-cfc7dbb2f274b8cbb093fdcc7cd906102dc7f0945d7c9fd2c9c755e286a5d91eL67-L71)
* Updated the use of the `appearance` property for dropdowns, replacing deprecated vendor-prefixed versions and adding stylelint disables where necessary to pass new lint rules. [[1]](diffhunk://#diff-6c93ef6c6106e7c55ab61dfdab7ea3a0ed9d7a5c42a6762e927a0548254f94ddL14-R14) [[2]](diffhunk://#diff-d7f6345f073edfcd4dd4a8694d0fdbccbb6c5311cb02f26f11f0189e9f829d29L14-R15)

**Minor CSS Cleanups and Fixes:**

* Removed unnecessary blank lines and standardized formatting in several component CSS files for improved readability and maintainability, including `Button.css`, `IconButton.css`, and `InlineNotification.css`. [[1]](diffhunk://#diff-f30ac87ca58792867dc7eec30059575ed3add65fb3e795ccb52f29cef702ec65L8) [[2]](diffhunk://#diff-f30ac87ca58792867dc7eec30059575ed3add65fb3e795ccb52f29cef702ec65L17) [[3]](diffhunk://#diff-f30ac87ca58792867dc7eec30059575ed3add65fb3e795ccb52f29cef702ec65L26-L40) [[4]](diffhunk://#diff-15a84db84c45bc42bc4452f70f0a3a539b1f2d44929a572c9dd833f3122b9414L8-L30) [[5]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033L17-L22) [[6]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033L31)
* Corrected box-shadow syntax for consistency in `DropdownMenu.css`.
* Added missing keyframes and improved animation sections in `DropdownMenu.css` and `Dialog.css`. [[1]](diffhunk://#diff-8bed5839dd22060d47ab9e3fa830c9eb062af8319453b57f8582eb0312df4183R156) [[2]](diffhunk://#diff-8bed5839dd22060d47ab9e3fa830c9eb062af8319453b57f8582eb0312df4183R166) [[3]](diffhunk://#diff-a83d29aeb4b1c1af796f9ee235d59e5587c01655bb6bc31083caf32bcae9c0beR133) [[4]](diffhunk://#diff-a83d29aeb4b1c1af796f9ee235d59e5587c01655bb6bc31083caf32bcae9c0beR143)
* Expanded and reorganized CSS selectors and rules for `InlineNotification.css` to improve maintainability and clarity. [[1]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R41-R51) [[2]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R60-R68) [[3]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R78-R85) [[4]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R95-R106) [[5]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R122-R135) [[6]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R145-R155) [[7]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R169-R175) [[8]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R198-R206) [[9]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R219) [[10]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R235-R251) [[11]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R274-R287) [[12]](diffhunk://#diff-fc1dbfaf5e0beda90716d9fbcb6302652c4322f70606e4e2cf565597e5e74033R297-R307)