### PR TITLE
ci: add module Node16 to match moduleResolution node16 in spindle-the…

### DIFF
--- a/packages/spindle-theme-switch/tsconfig.json
+++ b/packages/spindle-theme-switch/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "outDir": "dist",
+    "module": "Node16",
     "moduleResolution": "node16"
   },
   "include": [


### PR DESCRIPTION
…me-switch

- Fixes TypeScript error TS5110 in release workflow
- moduleResolution: node16 requires module: Node16

ref: https://github.com/openameba/spindle/actions/runs/17815612035/job/50648124084#step:10:126
