### PR TITLE
ci: resolve E404 error in release workflow with OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,42 @@ jobs:
           echo "name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
           echo "version=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
         id: extract_branch
-      - name: Releaseing with lerna
-        # also see some options in lerna.json
-        run: yarn lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
+      - name: Check for changes
+        run: |
+          echo "Checking for changes..."
+          # Get the list of changed packages
+          CHANGED_PACKAGES=$(yarn lerna changed --json | jq -r '.[].name' || echo "")
+
+          if [ -z "$CHANGED_PACKAGES" ]; then
+            echo "No packages were changed, skipping release"
+            echo "CHANGED=false" >> $GITHUB_OUTPUT
+            echo "CHANGED_PACKAGES=" >> $GITHUB_OUTPUT
+          else
+            echo "Changed packages: $CHANGED_PACKAGES"
+            echo "CHANGED=true" >> $GITHUB_OUTPUT
+            echo "CHANGED_PACKAGES=$CHANGED_PACKAGES" >> $GITHUB_OUTPUT
+          fi
+        id: check_changes
+      - name: Create tags and releases with lerna (skip npm publish)
+        if: steps.check_changes.outputs.CHANGED == 'true'
+        run: yarn lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private --skip-npm
         env:
           GH_TOKEN: ${{ github.token }}
-          # OIDC: do not set NODE_AUTH_TOKEN
-          NPM_CONFIG_PROVENANCE: true
+      - name: Publish updated packages with OIDC
+        if: steps.check_changes.outputs.CHANGED == 'true'
+        run: |
+          # Use the changed packages list from check_changes step
+          CHANGED_PACKAGES="${{ steps.check_changes.outputs.CHANGED_PACKAGES }}"
+          echo "Changed packages: $CHANGED_PACKAGES"
+
+          # Publish each changed package
+          for package_name in $CHANGED_PACKAGES; do
+            echo "Publishing $package_name"
+            package_dir="packages/${package_name#@openameba/}"
+            cd "$package_dir"
+            npm publish --access public
+            cd ../..
+          done
       - name: Create Pull Request
         run: >
           curl


### PR DESCRIPTION
[lernaで未対応](https://github.com/openameba/spindle/pull/1361#issuecomment-3305308333)のため一時的にnpm publishだけスクリプトで実行します。

---

- Replace lerna publish with lerna publish --skip-npm for tag/release creation
- Add individual npm publish with OIDC authentication for changed packages
- Add change detection step to skip release when no packages changed
- Use lerna changed command to get list of modified packages
- Remove --provenance flag as it's automatically enabled with OIDC