### PR TITLE
ci: add pull-requests permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
       id-token: write # Needed for npm Trusted Publishing (OIDC)
+      pull-requests: write # Needed for creating pull requests
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
@@ -89,6 +90,7 @@ jobs:
             fi
           done
       - name: Create Pull Request
+        if: steps.check_changes.outputs.CHANGED == 'true'
         run: >
           curl
           -X POST


### PR DESCRIPTION
おかげ様で、OIDCのnpm publish完了しました！が、Pull Requestが作られなかったので修正しました。

:kan: 

---

- Add pull-requests: write permission to fix 'Resource not accessible by integration' error
- Add condition to create PR only when packages are changed