### PR TITLE
docs: add initial Spindle Agents Guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Spindle Agents Guide
+
+## Code Quality Guidelines
+- Write clean, readable, and maintainable code
+- Follow existing code patterns and conventions in the project
+- Write self-documenting code that explains itself
+- Add comments only when necessary to explain implementation intent or reasoning
+- Avoid comments that simply restate what the code does
+- Focus comments on "why" rather than "what" or "how"
+
+## Commit Convention
+- Follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+- Specify package name in scope
+  - For multiple packages: use comma-separated list without spaces (e.g., `feat(spindle-ui,spindle-tokens): add new component`)
+  - For root-level changes: omit scope (e.g., `chore: update CI configuration`)
+- `feat` and `fix` will be reflected in CHANGELOG, so write titles that work as release notes
+- Use Conventional Commits `BREAKING CHANGE` notation when there are breaking changes
+- Use either Japanese or English for the text
+- Do not include co-author, "Generated with", or other agent-specific information in commits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Spindle Agents Guide
+
+## Code Quality Guidelines
+- Write clean, readable, and maintainable code
+- Follow existing code patterns and conventions in the project
+- Write self-documenting code that explains itself
+- Add comments only when necessary to explain implementation intent or reasoning
+- Avoid comments that simply restate what the code does
+- Focus comments on "why" rather than "what" or "how"
+
+## Commit Convention
+- Follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+- Specify package name in scope
+  - For multiple packages: use comma-separated list without spaces (e.g., `feat(spindle-ui,spindle-tokens): add new component`)
+  - For root-level changes: omit scope (e.g., `chore: update CI configuration`)
+- `feat` and `fix` will be reflected in CHANGELOG, so write titles that work as release notes
+- Use Conventional Commits `BREAKING CHANGE` notation when there are breaking changes
+- Use either Japanese or English for the text
+- Do not include co-author, "Generated with", or other agent-specific information in commits


### PR DESCRIPTION
直近困った点のみを追加しました。他の観点やより良い方法があれば教えてください〜。

最小限気味で入れてますが、今後フローの変更により変わる可能性が高めです。

---

- Add commit convention guidelines following Conventional Commits 1.0.0
- Specify package name in scope for multiple packages without spaces
- Add code quality guidelines focusing on self-documenting code
- Emphasize comments on 'why' rather than 'what' or 'how'
- Prohibit agent-specific information in commits