### PR TITLE
feat(spindle-ui): migrate SemiModal, AppealModal to allow-discrete transitions

### DIFF
--- a/packages/spindle-ui/src/Modal/AppealModal.css
+++ b/packages/spindle-ui/src/Modal/AppealModal.css
@@ -25,16 +25,12 @@
   width: 400px;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
-.spui-AppealModal[open] {
+.spui-AppealModal[open],
+.spui-AppealModal--styleOnly,
+.spui-AppealModal[open]::backdrop {
   opacity: 1;
 }
 
-.spui-AppealModal--styleOnly {
-  opacity: 1;
-}
-
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-AppealModal::backdrop {
   /* TODO: replace color with color palette, backdrop does not accept variable */
   background: rgba(0, 0, 0, 0.6);
@@ -45,19 +41,12 @@
     overlay 500ms allow-discrete;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
-.spui-AppealModal[open]::backdrop {
-  opacity: 1;
-}
-
 /* Starting style for smooth transitions */
 @starting-style {
-  /* stylelint-disable-next-line plugin/selector-bem-pattern */
   .spui-AppealModal[open] {
     opacity: 0;
   }
 
-  /* stylelint-disable-next-line plugin/selector-bem-pattern */
   .spui-AppealModal[open]::backdrop {
     opacity: 0;
   }
@@ -179,7 +168,6 @@ html:has(.spui-AppealModal[open]) {
   text-align: center;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-AppealModal-buttonGroup :is(.spui-Button, .spui-LinkButton) {
   max-width: 240px;
 }

--- a/packages/spindle-ui/src/Modal/AppealModal.css
+++ b/packages/spindle-ui/src/Modal/AppealModal.css
@@ -16,45 +16,64 @@
   border-radius: 20px;
   /* TODO: replace color with color palette */
   box-shadow: 0 11px 28px rgba(8, 18, 26, 0.12);
+  opacity: 0;
   padding: 0;
+  transition:
+    opacity 500ms cubic-bezier(0, 0, 0, 1),
+    display 500ms allow-discrete,
+    overlay 500ms allow-discrete;
   width: 400px;
 }
 
-/* stylelint-disable plugin/selector-bem-pattern */
-/* NOTE: set no animations to the dialog-polyfill browsers for stability */
-.spui-AppealModal[open]:not(.spui-AppealModal--closing),
-.spui-AppealModal[open]:not(
-    .spui-AppealModal--closing
-  ).spui-AppealModal::backdrop {
-  animation: 0.5s cubic-bezier(0, 0, 0, 1) spui-AppealModal-fade-in;
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
+.spui-AppealModal[open] {
+  opacity: 1;
 }
 
-.spui-AppealModal--closing,
-.spui-AppealModal--closing.spui-AppealModal::backdrop {
-  animation: 0.3s cubic-bezier(0, 0, 0, 1) spui-AppealModal-fade-out;
+.spui-AppealModal--styleOnly {
+  opacity: 1;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .spui-AppealModal[open]:not(.spui-AppealModal--closing),
-  .spui-AppealModal[open]:not(
-      .spui-AppealModal--closing
-    ).spui-AppealModal::backdrop,
-  .spui-AppealModal--closing,
-  .spui-AppealModal--closing.spui-AppealModal::backdrop {
-    /* Do not remove this animation to detect animationend in JavaScript */
-    animation-duration: 0.01s;
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
+.spui-AppealModal::backdrop {
+  /* TODO: replace color with color palette, backdrop does not accept variable */
+  background: rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition:
+    opacity 500ms cubic-bezier(0, 0, 0, 1),
+    display 500ms allow-discrete,
+    overlay 500ms allow-discrete;
+}
+
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
+.spui-AppealModal[open]::backdrop {
+  opacity: 1;
+}
+
+/* Starting style for smooth transitions */
+@starting-style {
+  /* stylelint-disable-next-line plugin/selector-bem-pattern */
+  .spui-AppealModal[open] {
+    opacity: 0;
+  }
+
+  /* stylelint-disable-next-line plugin/selector-bem-pattern */
+  .spui-AppealModal[open]::backdrop {
+    opacity: 0;
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .spui-AppealModal,
+  .spui-AppealModal::backdrop {
+    transition-duration: 0.01s;
+  }
+}
+
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
 html:has(.spui-AppealModal[open]) {
   overflow: hidden;
 }
-
-/* Fallback for :has() */
-html.spui-AppealModal--open {
-  overflow: hidden;
-}
-/* stylelint-enable plugin/selector-bem-pattern */
 
 /* The minimum margin for the small devices */
 /* 440px is calculated from dialog width (400px) + minimum margin (20px * 2) */
@@ -63,17 +82,6 @@ html.spui-AppealModal--open {
   .spui-AppealModal {
     width: calc(100% - (24px * 2));
   }
-}
-
-.spui-AppealModal::backdrop {
-  /* TODO: replace color with color palette, backdrop does not accept variable */
-  background: rgba(0, 0, 0, 0.6);
-}
-
-/* Dialog polyfill adds ".backdrop" instead of "::backdrop" */
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
-.spui-AppealModal + .backdrop {
-  background: rgba(0, 0, 0, 0.6);
 }
 
 /*
@@ -243,25 +251,5 @@ html.spui-AppealModal--open {
 
   .spui-AppealModal-closeTextButton {
     display: none;
-  }
-}
-
-@keyframes spui-AppealModal-fade-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes spui-AppealModal-fade-out {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
   }
 }

--- a/packages/spindle-ui/src/Modal/AppealModal.tsx
+++ b/packages/spindle-ui/src/Modal/AppealModal.tsx
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import { useMergeRefs } from 'use-callback-ref';
 import { ButtonGroup as Group } from '../ButtonGroup';
 import CrossBold from '../Icon/CrossBold';
@@ -21,14 +15,12 @@ interface AppealModalProps extends React.DialogHTMLAttributes<HTMLElement> {
 }
 
 const BLOCK_NAME = 'spui-AppealModal';
-const FADE_OUT_ANIMATION = 'spui-AppealModal-fade-out';
 
 const Frame = forwardRef<HTMLDialogElement, AppealModalProps>(
   function AppealModal(
     { children, className, open, size = 'large', onClose, ...rest },
     ref,
   ) {
-    const [closing, setClosing] = useState(false);
     const dialogEl = useRef<HTMLDialogElement>(null);
 
     const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -49,30 +41,8 @@ const Frame = forwardRef<HTMLDialogElement, AppealModalProps>(
       // Detect escape key type
       if (event.target === dialogEl.current) {
         onClose && onClose(event);
-        setClosing(false);
       }
     };
-
-    const handleAnimationEnd = useCallback(
-      (event: AnimationEvent) => {
-        if (
-          dialogEl.current &&
-          event.animationName === FADE_OUT_ANIMATION &&
-          !event.pseudoElement // To exclude ::backdrop
-        ) {
-          dialogEl.current.close && dialogEl.current.close();
-        }
-      },
-      [dialogEl],
-    );
-
-    useEffect(() => {
-      const dialog = dialogEl.current;
-      dialog?.addEventListener('animationend', handleAnimationEnd, false);
-
-      return () =>
-        dialog?.removeEventListener('animationend', handleAnimationEnd, false);
-    }, [dialogEl, handleAnimationEnd]);
 
     useEffect(() => {
       const dialog = dialogEl.current;
@@ -80,31 +50,16 @@ const Frame = forwardRef<HTMLDialogElement, AppealModalProps>(
         return;
       }
 
-      // Remove this when browsers support :has() pseudo-class
-      const classNameToStopScrollBehindDialog = `${BLOCK_NAME}--open`;
-
       if (open) {
         !dialog.open && dialog.showModal?.();
-        document.documentElement.classList.add(
-          classNameToStopScrollBehindDialog,
-        );
       } else {
-        dialog?.open && setClosing(true);
-        // Always remove this class to avoid unexpected scroll stopping
-        document.documentElement.classList.remove(
-          classNameToStopScrollBehindDialog,
-        );
+        dialog?.close?.();
       }
     }, [open, dialogEl]);
 
     return (
       <dialog
-        className={[
-          BLOCK_NAME,
-          `${BLOCK_NAME}--${size}`,
-          closing && `${BLOCK_NAME}--closing`,
-          className,
-        ]
+        className={[BLOCK_NAME, `${BLOCK_NAME}--${size}`, className]
           .filter(Boolean)
           .join(' ')
           .trim()}
@@ -141,7 +96,12 @@ const StyleOnly = ({
 }: React.ComponentProps<'div'> & { size?: Size }) => {
   return (
     <div
-      className={[BLOCK_NAME, `${BLOCK_NAME}--${size}`, className]
+      className={[
+        BLOCK_NAME,
+        `${BLOCK_NAME}--styleOnly`,
+        `${BLOCK_NAME}--${size}`,
+        className,
+      ]
         .filter(Boolean)
         .join(' ')
         .trim()}

--- a/packages/spindle-ui/src/Modal/SemiModal.css
+++ b/packages/spindle-ui/src/Modal/SemiModal.css
@@ -16,72 +16,89 @@
   /* TODO: replace color with color palette */
   box-shadow: 0 11px 28px rgba(8, 18, 26, 0.12);
   height: fit-content;
+  opacity: 0;
   padding: 0;
   position: fixed;
+  transition:
+    opacity 350ms cubic-bezier(0, 0, 0, 1),
+    display 350ms allow-discrete,
+    overlay 350ms allow-discrete;
   width: fit-content;
 }
 
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal[data-type='sheet'] {
   border-radius: 20px 20px 0 0;
   bottom: 0;
   margin: auto auto 0;
   transform: translateY(100%);
+  transition:
+    opacity 350ms cubic-bezier(0, 0, 0, 1),
+    transform 350ms cubic-bezier(0, 0, 0, 1),
+    display 350ms allow-discrete,
+    overlay 350ms allow-discrete;
   will-change: translate;
 }
 
-/* stylelint-disable plugin/selector-bem-pattern */
-/* NOTE: set no animations to the dialog-polyfill browsers for stability */
-.spui-SemiModal[data-type='popup'][open]:not(.spui-SemiModal--closing),
-.spui-SemiModal[data-type='popup'][open]:not(
-    .spui-SemiModal--closing
-  ).spui-SemiModal::backdrop,
-.spui-SemiModal[data-type='sheet'][open]:not(
-    .spui-SemiModal--closing
-  ).spui-SemiModal::backdrop {
-  animation: 350ms cubic-bezier(0, 0, 0, 1) spui-SemiModal-fade-in;
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
+.spui-SemiModal[open] {
+  opacity: 1;
 }
 
-.spui-SemiModal--closing.spui-SemiModal[data-type='popup'],
-.spui-SemiModal--closing[data-type='popup'].spui-SemiModal::backdrop,
-.spui-SemiModal--closing[data-type='sheet'].spui-SemiModal::backdrop {
-  animation: 350ms cubic-bezier(0, 0, 0, 1) spui-SemiModal-fade-out;
+.spui-SemiModal--styleOnly {
+  opacity: 1;
 }
 
-.spui-SemiModal[data-type='sheet'][open]:not(.spui-SemiModal--closing, button) {
-  animation: both 350ms cubic-bezier(0, 0, 0, 1) spui-SemiModal-slide-in;
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
+.spui-SemiModal::backdrop {
+  /* TODO: replace color with color palette, backdrop does not accept variable */
+  background: rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition:
+    opacity 350ms cubic-bezier(0, 0, 0, 1),
+    display 350ms allow-discrete,
+    overlay 350ms allow-discrete;
 }
 
-.spui-SemiModal--closing.spui-SemiModal[data-type='sheet'] {
-  animation: both 350ms cubic-bezier(0, 0, 0, 1) spui-SemiModal-slide-out;
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
+.spui-SemiModal[open]::backdrop {
+  opacity: 1;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .spui-SemiModal[data-type='popup'][open]:not(.spui-SemiModal--closing),
-  .spui-SemiModal[data-type='popup'][open]:not(
-      .spui-SemiModal--closing
-    ).spui-SemiModal::backdrop,
-  .spui-SemiModal[data-type='popup'].spui-SemiModal--closing,
-  .spui-SemiModal--closing.spui-SemiModal[data-type='popup']::backdrop,
-  .spui-SemiModal[data-type='sheet'][open]:not(.spui-SemiModal--closing),
-  .spui-SemiModal[data-type='sheet'][open]:not(
-      .spui-SemiModal--closing
-    ).spui-SemiModal::backdrop,
-  .spui-SemiModal[data-type='sheet'].spui-SemiModal--closing,
-  .spui-SemiModal--closing.spui-SemiModal[data-type='sheet']::backdrop {
-    /* Do not remove this animation to detect animationend in JavaScript */
-    animation-duration: 0.01s;
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
+.spui-SemiModal[data-type='sheet'][open] {
+  transform: translateY(0);
+}
+
+/* Starting style for smooth transitions */
+@starting-style {
+  /* stylelint-disable-next-line plugin/selector-bem-pattern */
+  .spui-SemiModal[open] {
+    opacity: 0;
+  }
+
+  /* stylelint-disable-next-line plugin/selector-bem-pattern */
+  .spui-SemiModal[open]::backdrop {
+    opacity: 0;
+  }
+
+  /* stylelint-disable-next-line plugin/selector-bem-pattern */
+  .spui-SemiModal[data-type='sheet'][open] {
+    transform: translateY(100%);
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .spui-SemiModal,
+  .spui-SemiModal::backdrop {
+    transition-duration: 0.01s;
+  }
+}
+
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
 html:has(.spui-SemiModal[open]) {
   overflow: hidden;
 }
-
-/* Fallback for :has() */
-html.spui-SemiModal--open {
-  overflow: hidden;
-}
-/* stylelint-enable plugin/selector-bem-pattern */
 
 /* The minimum margin for the small devices */
 /* 440px is calculated from dialog width (400px) + minimum margin (20px * 2) */
@@ -90,17 +107,6 @@ html.spui-SemiModal--open {
   .spui-SemiModal {
     width: calc(100% - (20px * 2));
   }
-}
-
-.spui-SemiModal::backdrop {
-  /* TODO: replace color with color palette, backdrop does not accept variable */
-  background: rgba(0, 0, 0, 0.6);
-}
-
-/* Dialog polyfill adds ".backdrop" instead of "::backdrop" */
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
-.spui-SemiModal + .backdrop {
-  background: rgba(0, 0, 0, 0.6);
 }
 
 /*
@@ -155,6 +161,7 @@ html.spui-SemiModal--open {
   /* stylelint-disable plugin/selector-bem-pattern */
   --IconButton--neutral-backgroundColor: transparent;
   --IconButton--neutral-onHover-backgroundColor: var(--color-surface-tertiary);
+  /* stylelint-enable plugin/selector-bem-pattern */
 }
 
 .spui-SemiModal-headerTitle {
@@ -176,16 +183,19 @@ html.spui-SemiModal--open {
   overflow: hidden scroll;
 }
 
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal-contents::-webkit-scrollbar {
   border-radius: 4px;
   width: 8px;
 }
 
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal-contents::-webkit-scrollbar-thumb {
   background: var(--color-object-low-emphasis);
   border-radius: 4px;
 }
 
+/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal-contents::-webkit-scrollbar-track:enabled {
   background-color: var(--color-surface-secondary);
   border-radius: 4px;
@@ -275,8 +285,9 @@ html.spui-SemiModal--open {
   .spui-SemiModal-closeIconButton {
     height: 24px;
     width: 24px;
-
+    /* stylelint-disable plugin/selector-bem-pattern */
     --IconButton--neutral-onHover-backgroundColor: transparent;
+    /* stylelint-enable plugin/selector-bem-pattern */
   }
 
   .spui-SemiModal-frame {
@@ -291,45 +302,5 @@ html.spui-SemiModal--open {
   .spui-SemiModal-footer :is(.spui-Button, .spui-LinkButton) {
     max-width: 360px;
     width: 100%;
-  }
-}
-
-@keyframes spui-SemiModal-slide-in {
-  from {
-    transform: translateY(100%);
-  }
-
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes spui-SemiModal-slide-out {
-  from {
-    transform: translateY(0);
-  }
-
-  to {
-    transform: translateY(100%);
-  }
-}
-
-@keyframes spui-SemiModal-fade-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes spui-SemiModal-fade-out {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
   }
 }

--- a/packages/spindle-ui/src/Modal/SemiModal.css
+++ b/packages/spindle-ui/src/Modal/SemiModal.css
@@ -26,7 +26,6 @@
   width: fit-content;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal[data-type='sheet'] {
   border-radius: 20px 20px 0 0;
   bottom: 0;
@@ -40,16 +39,12 @@
   will-change: translate;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
-.spui-SemiModal[open] {
+.spui-SemiModal[open],
+.spui-SemiModal--styleOnly,
+.spui-SemiModal[open]::backdrop {
   opacity: 1;
 }
 
-.spui-SemiModal--styleOnly {
-  opacity: 1;
-}
-
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal::backdrop {
   /* TODO: replace color with color palette, backdrop does not accept variable */
   background: rgba(0, 0, 0, 0.6);
@@ -60,29 +55,20 @@
     overlay 350ms allow-discrete;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
-.spui-SemiModal[open]::backdrop {
-  opacity: 1;
-}
-
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal[data-type='sheet'][open] {
   transform: translateY(0);
 }
 
 /* Starting style for smooth transitions */
 @starting-style {
-  /* stylelint-disable-next-line plugin/selector-bem-pattern */
   .spui-SemiModal[open] {
     opacity: 0;
   }
 
-  /* stylelint-disable-next-line plugin/selector-bem-pattern */
   .spui-SemiModal[open]::backdrop {
     opacity: 0;
   }
 
-  /* stylelint-disable-next-line plugin/selector-bem-pattern */
   .spui-SemiModal[data-type='sheet'][open] {
     transform: translateY(100%);
   }
@@ -183,19 +169,16 @@ html:has(.spui-SemiModal[open]) {
   overflow: hidden scroll;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal-contents::-webkit-scrollbar {
   border-radius: 4px;
   width: 8px;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal-contents::-webkit-scrollbar-thumb {
   background: var(--color-object-low-emphasis);
   border-radius: 4px;
 }
 
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
 .spui-SemiModal-contents::-webkit-scrollbar-track:enabled {
   background-color: var(--color-surface-secondary);
   border-radius: 4px;

--- a/packages/spindle-ui/src/Modal/SemiModal.tsx
+++ b/packages/spindle-ui/src/Modal/SemiModal.tsx
@@ -1,11 +1,4 @@
-import React, {
-  forwardRef,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { forwardRef, ReactNode, useEffect, useRef } from 'react';
 import { useMergeRefs } from 'use-callback-ref';
 import CrossBold from '../Icon/CrossBold';
 import { IconButton } from '../IconButton';
@@ -23,16 +16,11 @@ interface SemiModalProps
 }
 
 const BLOCK_NAME = 'spui-SemiModal';
-const ANIMATION_NAME_LIST = [
-  `${BLOCK_NAME}-fade-out`,
-  `${BLOCK_NAME}-slide-out`,
-];
 
 const Frame = forwardRef<HTMLDialogElement, SemiModalProps>(function SemiModal(
   { children, open, size = 'medium', type = 'popup', onClose, ...rest },
   ref,
 ) {
-  const [closing, setClosing] = useState(false);
   const dialogEl = useRef<HTMLDialogElement>(null);
 
   // 閉じるアイコンを押した時
@@ -56,59 +44,25 @@ const Frame = forwardRef<HTMLDialogElement, SemiModalProps>(function SemiModal(
     // Detect escape key type
     if (event.target === dialogEl.current) {
       onClose?.(event);
-      setClosing(false);
     }
   };
-
-  // modalアニメーション終了時
-  const handleAnimationEnd = useCallback(
-    (event: AnimationEvent) => {
-      if (
-        dialogEl.current &&
-        ANIMATION_NAME_LIST.includes(event.animationName) &&
-        !event.pseudoElement // To exclude ::backdrop
-      ) {
-        dialogEl.current?.close?.();
-      }
-    },
-    [dialogEl],
-  );
-
-  useEffect(() => {
-    dialogEl.current?.addEventListener(
-      'animationend',
-      handleAnimationEnd,
-      false,
-    );
-  }, [handleAnimationEnd]);
 
   useEffect(() => {
     if (!dialogEl.current) {
       return;
     }
 
-    // Remove this when browsers support :has() pseudo-class
-    const classNameToStopScrollBehindDialog = `${BLOCK_NAME}--open`;
-
     if (open) {
       dialogEl.current?.showModal?.();
-      document.documentElement.classList.add(classNameToStopScrollBehindDialog);
     } else {
-      dialogEl.current?.open && setClosing(true);
-      // Always remove this class to avoid unexpected scroll stopping
-      document.documentElement.classList.remove(
-        classNameToStopScrollBehindDialog,
-      );
+      dialogEl.current?.close?.();
     }
   }, [open, dialogEl]);
 
   return (
     <dialog
       role="dialog"
-      className={[BLOCK_NAME, closing && `${BLOCK_NAME}--closing`]
-        .filter(Boolean)
-        .join(' ')
-        .trim()}
+      className={BLOCK_NAME}
       ref={useMergeRefs([dialogEl, ref])}
       onClick={handleDialogClick}
       onClose={handleDialogClose}
@@ -183,7 +137,12 @@ const StyleOnly = ({
 }: React.ComponentProps<'div'> & { size?: Size; type?: Type }) => {
   return (
     <div
-      className={[BLOCK_NAME, `${BLOCK_NAME}--${size}`, className]
+      className={[
+        BLOCK_NAME,
+        `${BLOCK_NAME}--styleOnly`,
+        `${BLOCK_NAME}--${size}`,
+        className,
+      ]
         .filter(Boolean)
         .join(' ')
         .trim()}


### PR DESCRIPTION
[Dialogと同様](https://github.com/openameba/spindle/pull/1360)にModal系コンポーネントも開閉トランジッションを変更しました。
Storybookをポチポチして確認いただければと思います。

---

This pull request refactors the modal animation and transition logic for both `AppealModal` and `SemiModal` components to use modern CSS transitions instead of JavaScript-driven animation state and keyframes. The changes simplify the React component logic, improve accessibility, and provide smoother open/close transitions using CSS features like `@starting-style` and `:has()`. Legacy polyfill and animation code is removed, and the CSS is updated to use transitions for opacity and transforms.

**Modal Animation and Transition Refactor:**

* Replaced JavaScript-based animation state and keyframe-driven open/close logic in `AppealModal.tsx` and `SemiModal.tsx` with pure CSS transitions for opacity (and transform for sheets), removing the need for `useState` and animation event handlers. [[1]](diffhunk://#diff-38884c4646d84ff35cd0ef647770410b3a1c4f61d667676757ef179a9c30af59L1-R1) [[2]](diffhunk://#diff-38884c4646d84ff35cd0ef647770410b3a1c4f61d667676757ef179a9c30af59L24-L31) [[3]](diffhunk://#diff-38884c4646d84ff35cd0ef647770410b3a1c4f61d667676757ef179a9c30af59L52-R62) [[4]](diffhunk://#diff-8d2763a255de25eb936690b07990a85dea20428701390fe24e9defe1db8f9d77L1-R1) [[5]](diffhunk://#diff-8d2763a255de25eb936690b07990a85dea20428701390fe24e9defe1db8f9d77L26-L35) [[6]](diffhunk://#diff-8d2763a255de25eb936690b07990a85dea20428701390fe24e9defe1db8f9d77L59-R65)
* Updated CSS in `AppealModal.css` and `SemiModal.css` to use `opacity` and `transform` transitions, including `@starting-style` for smooth entry/exit, and removed all keyframe animations and related BEM class toggling. [[1]](diffhunk://#diff-32271bba7948394e4cfaa72e0e8bf6eec2c4f1aad3d4e4bc9147dfb2729226a7R19-L57) [[2]](diffhunk://#diff-32271bba7948394e4cfaa72e0e8bf6eec2c4f1aad3d4e4bc9147dfb2729226a7L68-L78) [[3]](diffhunk://#diff-32271bba7948394e4cfaa72e0e8bf6eec2c4f1aad3d4e4bc9147dfb2729226a7L248-L267) [[4]](diffhunk://#diff-d35b5cb728f4ddc91b44948164bc650af67f03596ce85c573cd9ff38b0e80dd1R19-L84) [[5]](diffhunk://#diff-d35b5cb728f4ddc91b44948164bc650af67f03596ce85c573cd9ff38b0e80dd1L95-L105) [[6]](diffhunk://#diff-d35b5cb728f4ddc91b44948164bc650af67f03596ce85c573cd9ff38b0e80dd1L296-L335)
* Added and updated CSS for modal and backdrop transitions, ensuring accessibility and compatibility with reduced motion settings (`prefers-reduced-motion`). [[1]](diffhunk://#diff-32271bba7948394e4cfaa72e0e8bf6eec2c4f1aad3d4e4bc9147dfb2729226a7R19-L57) [[2]](diffhunk://#diff-d35b5cb728f4ddc91b44948164bc650af67f03596ce85c573cd9ff38b0e80dd1R19-L84)
* Updated fallback and scroll lock logic to rely on the `:has()` selector instead of toggling extra classes from JavaScript, simplifying the scroll prevention approach. [[1]](diffhunk://#diff-32271bba7948394e4cfaa72e0e8bf6eec2c4f1aad3d4e4bc9147dfb2729226a7R19-L57) [[2]](diffhunk://#diff-d35b5cb728f4ddc91b44948164bc650af67f03596ce85c573cd9ff38b0e80dd1R19-L84)

**Component and Style Consistency Improvements:**

* Updated the `StyleOnly` variants of both modals to include the new `--styleOnly` class for consistent styling. [[1]](diffhunk://#diff-38884c4646d84ff35cd0ef647770410b3a1c4f61d667676757ef179a9c30af59L144-R104) [[2]](diffhunk://#diff-8d2763a255de25eb936690b07990a85dea20428701390fe24e9defe1db8f9d77L186-R145)
* Cleaned up and streamlined CSS, removing polyfill-specific selectors and redundant style blocks, and ensuring consistent scrollbar styling. [[1]](diffhunk://#diff-d35b5cb728f4ddc91b44948164bc650af67f03596ce85c573cd9ff38b0e80dd1R164) [[2]](diffhunk://#diff-d35b5cb728f4ddc91b44948164bc650af67f03596ce85c573cd9ff38b0e80dd1R186-R198) [[3]](diffhunk://#diff-d35b5cb728f4ddc91b44948164bc650af67f03596ce85c573cd9ff38b0e80dd1L278-R290)

These changes modernize the modal components, reduce code complexity, and provide a more robust and maintainable animation system.