### PR TITLE
fix(spindle-mcp-server): migrate to ES module format and update TypeScript config

### DIFF
--- a/packages/spindle-mcp-server/src/server.ts
+++ b/packages/spindle-mcp-server/src/server.ts
@@ -7,7 +7,6 @@ import { getIconInfo, getIcons } from './icon.js';
 import { getComponentDesignDocTemplate } from './design-doc.js';
 import pkg from '../package.json' with { type: 'json' };
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const VERSION = pkg.version;
 
 export function createServer(): McpServer {

--- a/packages/spindle-mcp-server/src/server.ts
+++ b/packages/spindle-mcp-server/src/server.ts
@@ -5,9 +5,10 @@ import { getComponents, getComponentInfo } from './components.js';
 import { getAllCssDesignTokens, getCssDesignToken } from './design-token.js';
 import { getIconInfo, getIcons } from './icon.js';
 import { getComponentDesignDocTemplate } from './design-doc.js';
+import pkg from '../package.json' with { type: 'json' };
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const VERSION = require('../package.json').version;
+const VERSION = pkg.version;
 
 export function createServer(): McpServer {
   const server = new McpServer({

--- a/packages/spindle-mcp-server/tsconfig.json
+++ b/packages/spindle-mcp-server/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "module": "CommonJS",
-    "target": "ES2020",
-    "lib": ["ES2020"],
+    "module": "nodenext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
     "declaration": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
esmでビルドできておらず実行できなかったので修正しました。

確認方法

```
yarn
cd packages/spindle-mcp-server
yarn build
node dist/index.js
```