### PR TITLE
fix(spindle-ui): pagination component aria

### DIFF
--- a/packages/spindle-ui/src/Pagination/PaginationItem.css
+++ b/packages/spindle-ui/src/Pagination/PaginationItem.css
@@ -22,18 +22,18 @@
   text-decoration: none;
 }
 
-.spui-PaginationItem-link--prev[aria-disabled],
-.spui-PaginationItem-link--next[aria-disabled],
-.spui-PaginationItem-link--first[aria-disabled],
-.spui-PaginationItem-link--last[aria-disabled] {
+.spui-PaginationItem-link--prev[aria-hidden],
+.spui-PaginationItem-link--next[aria-hidden],
+.spui-PaginationItem-link--first[aria-hidden],
+.spui-PaginationItem-link--last[aria-hidden] {
   opacity: 0.3;
 }
 
-.spui-PaginationItem-link[aria-disabled]:focus-visible {
+.spui-PaginationItem-link[aria-hidden]:focus-visible {
   outline: none;
 }
 
-.spui-PaginationItem-link:not([aria-disabled]):focus-visible {
+.spui-PaginationItem-link:not([aria-hidden]):focus-visible {
   outline: 2px solid var(--color-focus-clarity);
   outline-offset: 1px;
 }
@@ -58,7 +58,7 @@
 }
 
 @media (hover: hover) {
-  .spui-PaginationItem-link:not([aria-disabled]):hover {
+  .spui-PaginationItem-link:not([aria-hidden]):hover {
     background: var(--color-surface-tertiary);
   }
 }

--- a/packages/spindle-ui/src/Pagination/PaginationItem.tsx
+++ b/packages/spindle-ui/src/Pagination/PaginationItem.tsx
@@ -94,7 +94,8 @@ export const PaginationItem: FC<Props> = React.memo(
         rel={getLinkRelAttribute({ linkFollowType, pageNumber })}
         aria-label={itemPropMap[type].label}
         href={isDisabled ? undefined : createUrl(pageNumber)}
-        aria-disabled={isDisabled ? true : undefined}
+        aria-hidden={isDisabled ? true : undefined}
+        tabIndex={isDisabled ? -1 : undefined}
         onClick={
           isDisabled
             ? undefined


### PR DESCRIPTION
### 概要
Paginationコンポーネントの利用者よりaタグにaria-disabledをつけている影響でアクセシビリティのエラーが出ている。
という報告を受けて修正しました。

aria-hiddenとtabindexにしています。

### 期間
急ぎではないのでお手隙で。