### PR TITLE
ci: update release workflow to use workflow_dispatch with package selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           if [ "$CHANGED_PACKAGES" = "${{ github.event.inputs.package_name }}" ]; then
             echo "Selected package ${{ github.event.inputs.package_name }} has changes. Proceeding with major release."
           else
-            echo "Selected package ${{ github.event.inputs.package_name }} has no changes. Major release requires changes to the selected package."
+            echo "Major releases are only allowed when exactly one package (the selected one) has changes. Changed packages: $CHANGED_PACKAGES. Selected package: ${{ github.event.inputs.package_name }}"
             exit 1
           fi
           echo "Packages changed successfully for major release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,33 @@
 name: releaseing
 
 on:
-  push:
-    branches:
-      - release/major
-      - release/minor
-      - release/patch
-      - release/premajor
-      - release/preminor
-      - release/prepatch
-      - release/prerelease
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Release version type'
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - premajor
+          - preminor
+          - prepatch
+          - prerelease
+      package_name:
+        description: 'Package name to release (leave empty for all packages)'
+        required: false
+        type: choice
+        options:
+          - 'all-changed'
+          - '@openameba/spindle-hooks'
+          - '@openameba/spindle-icons'
+          - '@openameba/spindle-mcp-server'
+          - '@openameba/spindle-syntax-themes'
+          - '@openameba/spindle-theme-switch'
+          - '@openameba/spindle-tokens'
+          - '@openameba/spindle-ui'
 
 jobs:
   releaseing:
@@ -43,21 +61,42 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Extract branch from git ref
+      - name: Check lerna changed for major release
+        if: ${{ github.event.inputs.version_type == 'major' }}
         run: |
-          echo "name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
-          echo "version=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
-        id: extract_branch
-      - name: Releaseing with lerna
-        # also see some options in lerna.json
-        run: yarn lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
+          echo "Checking lerna changed for major release..."
+          CHANGED_PACKAGES=$(npx lerna changed --json | jq -r '.[].name' | tr '\n' ' ')
+          echo "Changed packages: $CHANGED_PACKAGES"
+          if [ -z "$CHANGED_PACKAGES" ]; then
+            echo "No packages have changed. Major release requires changes."
+            exit 1
+          fi
+
+          # Check if the selected package exactly matches the changed packages
+          if [ "$CHANGED_PACKAGES" = "${{ github.event.inputs.package_name }}" ]; then
+            echo "Selected package ${{ github.event.inputs.package_name }} has changes. Proceeding with major release."
+          else
+            echo "Selected package ${{ github.event.inputs.package_name }} has no changes. Major release requires changes to the selected package."
+            exit 1
+          fi
+          echo "Packages changed successfully for major release"
+      - name: Releaseing with lerna (specific package)
+        if: ${{ github.event.inputs.package_name != 'all-changed' }}
+        run: yarn lerna publish ${{ github.event.inputs.version_type }} --conventional-commits --create-release github --yes --no-private --scope ${{ github.event.inputs.package_name }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Releaseing with lerna (all packages)
+        if: ${{ github.event.inputs.package_name == 'all-changed' }}
+        run: yarn lerna publish ${{ github.event.inputs.version_type }} --conventional-commits --create-release github --yes --no-private
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Create Pull Request
-        run: >
-          curl
-          -X POST
-          -H "Accept: application/vnd.github.v3+json"
-          -H "Authorization: token ${{ github.token }}"
-          https://api.github.com/repos/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}/pulls
-          -d '{"head":"${{ steps.extract_branch.outputs.name }}","base":"${{ github.event.repository.default_branch }}","title":"chore: publish"}'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          commit-message: 'chore: publish ${{ github.event.inputs.version_type }} release'
+          branch: release/${{ github.event.inputs.version_type }}
+          delete-branch: true
+          title: 'chore: publish ${{ github.event.inputs.version_type }} release'
+          body: 'Automated ${{ github.event.inputs.version_type }} release via workflow dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: releaseing
+name: releasing
 
 on:
   workflow_dispatch:
@@ -30,8 +30,8 @@ on:
           - '@openameba/spindle-ui'
 
 jobs:
-  releaseing:
-    name: releaseing
+  releasing:
+    name: releasing
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -80,12 +80,12 @@ jobs:
             exit 1
           fi
           echo "Packages changed successfully for major release"
-      - name: Releaseing with lerna (specific package)
+      - name: releasing with lerna (specific package)
         if: ${{ github.event.inputs.package_name != 'all-changed' }}
         run: yarn lerna publish ${{ github.event.inputs.version_type }} --conventional-commits --create-release github --yes --no-private --scope ${{ github.event.inputs.package_name }}
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Releaseing with lerna (all packages)
+      - name: releasing with lerna (all packages)
         if: ${{ github.event.inputs.package_name == 'all-changed' }}
         run: yarn lerna publish ${{ github.event.inputs.version_type }} --conventional-commits --create-release github --yes --no-private
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         if: ${{ github.event.inputs.version_type == 'major' }}
         run: |
           echo "Checking lerna changed for major release..."
-          CHANGED_PACKAGES=$(npx lerna changed --json | jq -r '.[].name' | tr '\n' ' ')
+          CHANGED_PACKAGES=$(npx lerna changed --json | jq -r '.[].name' | tr '\n' ' ' | sed 's/ $//')
           echo "Changed packages: $CHANGED_PACKAGES"
           if [ -z "$CHANGED_PACKAGES" ]; then
             echo "No packages have changed. Major release requires changes."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,11 @@ Amebaとして提供される成果物は、それらに則って開発される
 1. 作業が終わったらコミットをまとめて、該当ブランチを`main`ブランチにマージします
     - コミットはCHANGELOGに反映されるため、適切な単位でまとめてください
     - コミット名については`Pull Requestの作り方`欄を参考にしてください
-2. リリースされるパッケージ名はGitHub Actionsの「Check changed packages」ワークフローで確認できます
-   - 依存モジュールの更新等でソースコードに変更のないパッケージも表示されることがありますが問題ありません
-   - **majorリリースの場合**、GitHub Actionsの「Check changed packages」ワークフローを手動実行し、**対象パッケージ以外の変更が含まれていないか確認してください**。対象外パッケージに変更があると、他のパッケージもメジャーリリースになってしまうためです（されても致命的な問題ではありませんが）
-3. 変更内容に合わせてリリースブランチを作成します。選択できる名前は[release.yml](/.github/workflows/release.yml#L6-L12)を参照してください
-4. ブランチがプッシュされるとCHANGELOG作成・npmパブリッシュ・Pull Request作成が自動的に行われます
-5. 4で作成されたPull Requestの内容を確認し、`main`ブランチにマージします
-6. 開発メンバーに周知します
+2. GitHub Actionsの「releaseing」ワークフローを手動実行します
+   - ワークフロー実行時に以下を選択してください：
+     - **Release version type**: `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`から選択
+     - **Package name to release**: 特定のパッケージ名または`all-changed`（変更された全パッケージ）から選択
+   - **majorリリースの場合**、選択したパッケージのみが変更されていることを確認してください。複数パッケージが変更されている場合は、majorリリースは実行されません。先に他のパッケージをリリースしてから再実行してください。
+3. ワークフロー実行によりCHANGELOG作成・npmパブリッシュ・Pull Request作成が自動的に行われます
+4. 3で作成されたPull Requestの内容を確認し、`main`ブランチにマージします
+5. 開発メンバーに周知します

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Amebaとして提供される成果物は、それらに則って開発される
 1. 作業が終わったらコミットをまとめて、該当ブランチを`main`ブランチにマージします
     - コミットはCHANGELOGに反映されるため、適切な単位でまとめてください
     - コミット名については`Pull Requestの作り方`欄を参考にしてください
-2. GitHub Actionsの「releaseing」ワークフローを手動実行します
+2. GitHub Actionsの「releasing」ワークフローを手動実行します
    - ワークフロー実行時に以下を選択してください：
      - **Release version type**: `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`から選択
      - **Package name to release**: 特定のパッケージ名または`all-changed`（変更された全パッケージ）から選択


### PR DESCRIPTION
パッケージごとのリリースも増えてきそうなのでリリースフローを `workflow_dispatch` にして選択できるようにしました。わかりにくいことがあればレビューコメントお願いします！

---

This pull request updates the release workflow to use a manual (workflow_dispatch) trigger with input options and improves the release process for multi-package repositories. It also updates the contributor documentation to match the new workflow and adds stricter checks for major releases to prevent accidental version bumps of unintended packages.

**Release workflow improvements:**

* Changed `.github/workflows/release.yml` to use `workflow_dispatch` so releases are triggered manually with selectable inputs for version type and package name, rather than automatically on branch pushes.
* Added logic to check that only the selected package has changes when performing a major release, preventing accidental major releases of multiple packages.
* Split the release job to handle either a specific package or all changed packages, based on the selected input.
* Switched to using the `peter-evans/create-pull-request` action for automated PR creation after release, simplifying and standardizing the process.

**Documentation updates:**

* Updated `CONTRIBUTING.md` to describe the new manual release process, including how to select the release type and package, and clarified the requirements for major releases.