### PR TITLE
docs: add commit title length guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Use Conventional Commits `BREAKING CHANGE` notation when there are breaking changes
 - Use either Japanese or English for the text
 - Do not include co-author, "Generated with", or other agent-specific information in commits
+- Keep titles under 50 characters; may exceed if scope is long
 
 ## Dependency Updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@
 - Use Conventional Commits `BREAKING CHANGE` notation when there are breaking changes
 - Use either Japanese or English for the text
 - Do not include co-author, "Generated with", or other agent-specific information in commits
+- Keep titles under 50 characters; may exceed if scope is long
 
 ## Dependency Updates
 


### PR DESCRIPTION
This pull request makes a minor update to the documentation for commit message guidelines. It adds a note to both `AGENTS.md` and `CLAUDE.md` specifying that commit titles should be kept under 50 characters, except when the scope is long.