### PR TITLE
ci: build all packages except spindle-icons in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,9 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-v2
       - run: yarn install --frozen-lockfile
-      # Build application to check if the system works or not
-      # TODO: Build script for spindle-icon should be added
-      - name: build application
+      # Build all packages except spindle-icons to check if the system works or not
+      # spindle-icons is excluded because it requires FIGMA_TOKEN and fetches data from Figma API on every build
+      - name: build all packages
         run: |
-          yarn lerna run --scope @openameba/spindle-hooks build
-          yarn lerna run --scope @openameba/spindle-ui storybook:build
-          yarn lerna run --scope @openameba/spindle-ui build
+          yarn lerna run --ignore @openameba/spindle-icons build
           yarn build:extensionReplace


### PR DESCRIPTION
This pull request updates the build workflow to exclude the `spindle-icons` package from the build step, as it requires a `FIGMA_TOKEN` and fetches data from the Figma API on every build. This change ensures the build process is more reliable and does not fail due to missing external dependencies.

Build workflow improvements:

* Modified the build step in `.github/workflows/build.yml` to use `yarn lerna run --ignore @openameba/spindle-icons build`, which skips building the `spindle-icons` package during CI to avoid dependency on the Figma API and token.
* Updated comments in the workflow file to clarify the reason for excluding `spindle-icons` from the build process.