### PR TITLE
ci: change allow branch to main

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
   "command": {
     "version": {
       "message": "chore: publish",
-      "allowBranch": ["version/*", "release/*"]
+      "allowBranch": ["main"]
     }
   },
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"


### PR DESCRIPTION
This pull request makes a small configuration change to the `lerna.json` file, restricting the allowed branches for versioning and publishing to only the `main` branch.