### PR TITLE
ci: add GH_TOKEN environment variable for lerna github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
           echo "version=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
         id: extract_branch
       - name: Releaseing with lerna
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: yarn lerna publish ${{ steps.extract_branch.outputs.version }} --conventional-commits --create-release github --yes --no-private
       - name: Create Pull Request
         run: >


### PR DESCRIPTION
fix https://github.com/openameba/spindle/actions/runs/18370403069/job/52332008799#step:10:15

This pull request makes a small change to the release workflow configuration, ensuring that the `GH_TOKEN` environment variable is set for the release step. This will allow Lerna to authenticate with GitHub when creating releases.