### PR TITLE
feat(spindle-ui): add inverse style to Checkbox component

### DIFF
--- a/packages/spindle-ui/src/Form/Checkbox/Checkbox.css
+++ b/packages/spindle-ui/src/Form/Checkbox/Checkbox.css
@@ -51,6 +51,10 @@
   width: 18px;
 }
 
+.spui-Checkbox-label--inverse .spui-Checkbox-icon {
+  border: 1px solid var(--color-border-low-emphasis-inverse);
+}
+
 .spui-Checkbox-input:checked + .spui-Checkbox-icon {
   background-color: var(--color-object-accent-primary);
   border: solid 1px var(--color-object-accent-primary);
@@ -59,6 +63,14 @@
 
 .spui-Checkbox-input:disabled + .spui-Checkbox-icon {
   opacity: 0.3;
+}
+
+.spui-Checkbox-label--inverse
+  .spui-Checkbox-input:checked
+  + .spui-Checkbox-icon {
+  background-color: var(--color-surface-primary);
+  border: solid 1px var(--color-surface-primary);
+  color: var(--color-object-accent-primary);
 }
 
 /* To add 2px space for outline */

--- a/packages/spindle-ui/src/Form/Checkbox/Checkbox.figma.tsx
+++ b/packages/spindle-ui/src/Form/Checkbox/Checkbox.figma.tsx
@@ -12,19 +12,21 @@ figma.connect(
     ],
     props: {
       active: figma.boolean('Active'),
+      inverse: figma.boolean('Inverse'),
       hover: figma.boolean('Focus Ring'),
       label: figma.string('Label'),
       name: figma.string('Name'),
       id: figma.string('id'),
       value: figma.string('value'),
     },
-    example: ({ active, label, name, id, value }) => (
+    example: ({ active, inverse, label, name, id, value }) => (
       <Checkbox
         id={id}
         name={name}
         value={value}
         aria-label={label}
         checked={active}
+        inverse={inverse}
       ></Checkbox>
     ),
   },

--- a/packages/spindle-ui/src/Form/Checkbox/Checkbox.mdx
+++ b/packages/spindle-ui/src/Form/Checkbox/Checkbox.mdx
@@ -87,3 +87,45 @@ import '@openameba/spindle-ui/Form/Checkbox.css';
   `}
 />
 
+## Checkbox Inverse
+
+<Story of={CheckboxStories.CheckboxInverse} />
+
+<Source
+  code={`
+<Checkbox aria-label="Amebaブログ" name="blog" value="amebaBlog" inverse />
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<label class="spui-Checkbox-label spui-Checkbox-label--inverse">
+  <input aria-label="Amebaブログ" class="spui-Checkbox-input" type="checkbox" name="blog" value="amebaBlog">
+  <span class="spui-Checkbox-icon"></span>
+  <span class="spui-Checkbox-outline"></span>
+</label>
+  `}
+/>
+
+## Checkbox Inverse With Text
+
+<Story of={CheckboxStories.CheckboxInverseWithText} />
+
+<Source
+  code={`
+<Checkbox name="blog" value="amebaBlog" inverse>Amebaブログ</Checkbox>
+  `}
+/>
+
+<Source
+  language='html'
+  code={`
+<label class="spui-Checkbox-label spui-Checkbox-label--inverse">
+  <input class="spui-Checkbox-input" type="checkbox" name="blog" value="amebaBlog">
+  <span class="spui-Checkbox-icon"></span>
+  <span class="spui-Checkbox-outline"></span>
+  <span class="spui-Checkbox-text">Amebaブログ</span>
+</label>
+  `}
+/>

--- a/packages/spindle-ui/src/Form/Checkbox/Checkbox.stories.tsx
+++ b/packages/spindle-ui/src/Form/Checkbox/Checkbox.stories.tsx
@@ -41,3 +41,21 @@ export const CheckboxWithText: Story = {
     children: 'Amebaブログ',
   },
 };
+
+export const CheckboxInverse: Story = {
+  args: {
+    'aria-label': 'Amebaブログ',
+    name: 'blog',
+    value: 'amebaBlog',
+    inverse: true,
+  },
+};
+
+export const CheckboxInverseWithText: Story = {
+  args: {
+    name: 'blog',
+    value: 'amebaBlog',
+    children: 'Amebaブログ',
+    inverse: true,
+  },
+};

--- a/packages/spindle-ui/src/Form/Checkbox/Checkbox.tsx
+++ b/packages/spindle-ui/src/Form/Checkbox/Checkbox.tsx
@@ -5,16 +5,24 @@ import CheckBold from '../../Icon/CheckBold';
 interface Props
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'> {
   children?: React.ReactNode;
+  inverse?: boolean;
 }
 
 const BLOCK_NAME = 'spui-Checkbox';
 
 export const Checkbox = forwardRef<HTMLInputElement, Props>(function Checkbox(
-  { children, ...rest }: Props,
+  { children, inverse = false, ...rest }: Props,
   ref,
 ) {
   return (
-    <label className={`${BLOCK_NAME}-label`}>
+    <label
+      className={[
+        `${BLOCK_NAME}-label`,
+        inverse && `${BLOCK_NAME}-label--inverse`,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
       <input
         className={`${BLOCK_NAME}-input`}
         ref={ref}


### PR DESCRIPTION
## Summary
Checkboxコンポーネントに`inverse`プロパティを追加しました。

## Background
Checkboxコンポーネントでinverseスタイル（白背景にアクセントカラーのチェックマーク）が必要となったため、`inverse`プロパティを追加しました。

## Changes
- `Checkbox.tsx`: `inverse?: boolean`プロパティを追加（デフォルト: `false`）
- `Checkbox.css`: inverseスタイルを実装
  - チェック済み時の背景色: `var(--color-surface-primary)`
  - チェックマークの色: `var(--color-object-accent-primary)`
- `Checkbox.stories.tsx`: inverseスタイルのStoryを追加（`CheckboxInverse`, `CheckboxInverseWithText`）
- `Checkbox.mdx`: inverseのドキュメントとサンプルコードを追加
