### PR TITLE
chore(spindle-mcp-server): 依存パッケージ更新時に自動リリースされるよう依存関係を追加

### DIFF
--- a/packages/spindle-mcp-server/package.json
+++ b/packages/spindle-mcp-server/package.json
@@ -42,6 +42,8 @@
     "zod": "^4.1.9"
   },
   "devDependencies": {
+    "@openameba/spindle-tokens": "1.8.0",
+    "@openameba/spindle-ui": "3.0.0",
     "@types/node": "20.19.21",
     "cpx2": "8.0.0",
     "vitest": "3.2.4"


### PR DESCRIPTION
## 概要

spindle-mcp-serverが他のパッケージ（spindle-ui、spindle-tokens）の更新時に自動的にリリース対象になるよう、devDependenciesに依存関係を追加しました。

## 変更内容

- `packages/spindle-mcp-server/package.json`のdevDependenciesに以下を追加：
  - `@openameba/spindle-tokens`: 1.8.0（exact version）
  - `@openameba/spindle-ui`: 3.0.0（exact version）

## 背景

spindle-mcp-serverは、copy-assets.jsスクリプトでspindle-uiとspindle-tokensのアセットをコピーして使用していますが、package.jsonにこれらへの依存関係が記載されていませんでした。そのため、lernaはこれらのパッケージが更新されても、spindle-mcp-serverには変更がないと判断し、リリース対象から除外されていました。

## 動作

1. spindle-uiまたはspindle-tokensが更新される（例: 3.0.0 → 3.1.0）
2. `lerna version`実行時、lernaが自動的にspindle-mcp-serverのpackage.jsonを更新（3.0.0 → 3.1.0）
3. この変更によりspindle-mcp-serverのpackage.jsonに差分が生まれる
4. spindle-mcp-serverも同時にリリース対象になる