### PR TITLE
ci: fix dependency compatibility error with node.js 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     ]
   },
   "resolutions": {
-    "zod": "3.25.76"
+    "zod": "3.25.76",
+    "superstatic": "10.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16121,10 +16121,10 @@ sudachi-synonyms-dictionary@^5.0.1:
   resolved "https://registry.yarnpkg.com/sudachi-synonyms-dictionary/-/sudachi-synonyms-dictionary-5.0.1.tgz#e51c3bd57c72b1aece0fe8b37558858356bd6b53"
   integrity sha512-MSLBwyztRT4BPstyfM8M8DntQ/sJhRyq43S/vGfRq3/JuBbKFUzrI9rpoiQOc+35el5WrIm4K3fJyLhsSEOIqw==
 
-superstatic@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/superstatic/-/superstatic-9.2.0.tgz#c3d338e87fb1b695670c79db5affb18288441c32"
-  integrity sha512-QrJAJIpAij0jJT1nEwYTB0SzDi4k0wYygu6GxK0ko8twiQgfgaOAZ7Hu99p02MTAsGho753zhzSvsw8We4PBEQ==
+superstatic@10.0.0, superstatic@^9.2.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/superstatic/-/superstatic-10.0.0.tgz#64d07e969b387a2567754205d10305a390dddfa4"
+  integrity sha512-4xIenBdrIIYuqXrIVx/lejyCh4EJwEMPCwfk9VGFfRlhZcdvzTd3oVOUILrAGfC4pFUWixzPgaOVzAEZgeYI3w==
   dependencies:
     basic-auth-connect "^1.1.0"
     commander "^10.0.0"


### PR DESCRIPTION
## 概要

Node.js 24 環境での `yarn install --frozen-lockfile` 実行時に発生する依存関係の互換性エラーを修正しました。

## 変更内容

- `package.json` の `resolutions` に `superstatic@10.0.0` を追加
- `yarn.lock` を更新

## 問題の詳細

`superstatic@9.2.0` が Node.js 18/20/22 のみをサポートしており、Node.js 24 との互換性がなかったため、GitHub Actions の CI で以下のエラーが発生していました：

```
error superstatic@9.2.0: The engine "node" is incompatible with this module. Expected version "18 || 20 || 22". Got "24.10.0"
```

依存関係チェーン:
```
firebase-tools@14.19.1 → superstatic@^9.2.0
```

## 対応方法

`resolutions` フィールドで `superstatic@10.0.0` を指定することで、Node.js 24 に対応したバージョンを使用するようにしました。`superstatic@10.0.0` は Node.js 20/22/24 をサポートしています。

firebase-tools はビルド時に不要な devDependencies のため、resolutions で上書きしても問題ありません。

## 採用しなかった方法

### Node.js バージョンを 22 にダウングレード
- GitHub Actions の `node-version` を 22 に固定する方法
- デメリット: Node.js 24 の最新機能が使えない

### firebase-tools を最新版に更新
- 現在 14.19.1 → 最新 14.20.0 に更新する方法
- デメリット: firebase-tools 自体が `superstatic@^9.2.0` に依存しているため根本的な解決にならない