### PR TITLE
docs(spindle-ui): add design doc for toast component

### DIFF
--- a/packages/spindle-ui/src/Toast/Toast.css
+++ b/packages/spindle-ui/src/Toast/Toast.css
@@ -98,8 +98,7 @@
 }
 
 .spui-Toast-content--information {
-  /* TODO: use --color-surface-accent-neutral-high-emphasis */
-  background-color: var(--gray-80);
+  background-color: var(--color-surface-accent-neutral-high-emphasis);
   color: var(--color-text-high-emphasis-inverse);
 }
 

--- a/packages/spindle-ui/src/Toast/design-doc.md
+++ b/packages/spindle-ui/src/Toast/design-doc.md
@@ -50,7 +50,7 @@ Toastは、見落とされても影響のない「重要ではないお知らせ
 ### Design Tokens
 
 #### Information
-- `--gray-80` (背景色) ※ TODO: `--color-surface-accent-neutral-high-emphasis`に置き換え予定
+- `--color-surface-accent-neutral-high-emphasis` (背景色)
 - `--color-text-high-emphasis-inverse` (テキスト色)
 - `--color-object-high-emphasis-inverse` (アイコン色)
 - `--white-20-alpha` (ホバー時・アクティブ時の背景色)


### PR DESCRIPTION
## 概要

ToastコンポーネントのDesign Docを追加しました。

## 主な内容

- **概要・背景**: Toastの役割と制約（重要ではないお知らせに使用、デフォルト4秒で消える）
- **使用例**: Toast、SnackBar、InlineNotification、Dialogとの使い分け表
- **DO/DO NOT**: 適切な使用例と避けるべき使用例（更新処理の失敗、データ削除失敗など）
- **要素**: 
  - Design Tokens（information、confirmation、errorの3つのvariant）
  - Props定義
  - サイズ制約（max-width: 360px、min-height: 48px）
- **実装例**: ReactとHTMLマークアップのサンプル
- **アクセシビリティ**: 対応項目、注意点、チェックリスト
- **テスト方針**: ユニットテストとヴィジュアルリグレッションテストの方針
- **リンク集**: 関連ドキュメントへのリンク