### PR TITLE
chore: clarify textlint verification in create-design-doc

### DIFF
--- a/.claude/commands/create-design-doc.md
+++ b/.claude/commands/create-design-doc.md
@@ -45,9 +45,9 @@ This command creates a Design Doc for a Spindle UI component. It generates docum
    - Propose additional Stories if needed
    - Review existing tests and suggest missing test cases if needed
 
-6. **Run Auto-fix**
-   - Run `yarn fix` in the project root to automatically fix linting and formatting issues
-   - This will run Biome, lerna format, and textlint auto-fix
+6. **Fix Linting and Formatting Issues**
+   - Run `yarn fix` in the project root to automatically fix code formatting issues (Biome and lerna format will run)
+   - Run `yarn textlint <path-to-design-doc>` and manually fix any errors or warnings until the command passes cleanly
 
 ## Usage
 

--- a/.cursor/commands/create-design-doc.md
+++ b/.cursor/commands/create-design-doc.md
@@ -39,9 +39,9 @@ This command creates a Design Doc for a Spindle UI component. It generates docum
    - Propose additional Stories if needed
    - Review existing tests and suggest missing test cases if needed
 
-6. **Run Auto-fix**
-   - Run `yarn fix` in the project root to automatically fix linting and formatting issues
-   - This will run Biome, lerna format, and textlint auto-fix
+6. **Fix Linting and Formatting Issues**
+   - Run `yarn fix` in the project root to automatically fix code formatting issues (Biome and lerna format will run)
+   - Run `yarn textlint <path-to-design-doc>` and manually fix any errors or warnings until the command passes cleanly
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- `create-design-doc` コマンドのステップ6を更新し、textlint の検証手順を明確化
- textlint の自動修正に関する誤解を招く記述を削除し、手動修正が必要であることを明記

## Test plan
- [x] `.claude/commands/create-design-doc.md` の変更内容を確認
- [x] `.cursor/commands/create-design-doc.md` の変更内容を確認