### PR TITLE
ci: remove unnecessary script for creating github release

### DIFF
--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -55,13 +55,3 @@ jobs:
           title: 'chore: publish'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create GitHub Releases
-        if: steps.changesets.outputs.published == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # 公開されたパッケージのタグすべてに対してReleaseを作成
-          for package in $(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | "\(.name)@\(.version)"'); do
-            gh release create "${package}" --title "${package}" --generate-notes
-          done


### PR DESCRIPTION
actionでやってくれてたので、カスタムスクリプト必要なさそうでした〜

> createGithubReleases - A boolean value to indicate whether to create Github releases after publish or not. Default to true
https://github.com/changesets/action