### PR TITLE
docs: improve create-changeset command guidelines

### DIFF
--- a/.claude/commands/create-changeset.md
+++ b/.claude/commands/create-changeset.md
@@ -61,9 +61,12 @@ This command analyzes the current branch changes and creates an appropriate chan
      "@openameba/spindle-tokens": patch
      ---
 
-     Add new color tokens and update Button component
+     - spindle-ui: Add new Button variant for secondary actions
+     - spindle-tokens: Fix color token contrast ratio
      ```
    - The description should be user-friendly as it will appear in CHANGELOG
+   - Split changesets into separate files when the same package has changes with different purposes (e.g., new feature + bug fix, breaking change + internal refactoring). This creates individual top-level items in release notes, making it easier for readers to understand the intent of each change.
+     - Example: Create `.changeset/add-secondary-button.md` for a new feature and `.changeset/fix-button-layout.md` for a bug fix, even if both target the same package
 
 5. **Lint Changeset**
    - Run textlint to check the changeset file: `yarn textlint .changeset/<filename>.md`

--- a/.cursor/commands/create-changeset.md
+++ b/.cursor/commands/create-changeset.md
@@ -56,9 +56,12 @@ This command analyzes the current branch changes and creates an appropriate chan
      "@openameba/spindle-tokens": patch
      ---
 
-     Add new color tokens and update Button component
+     - spindle-ui: Add new Button variant for secondary actions
+     - spindle-tokens: Fix color token contrast ratio
      ```
    - The description should be user-friendly as it will appear in CHANGELOG
+   - Split changesets into separate files when the same package has changes with different purposes (e.g., new feature + bug fix, breaking change + internal refactoring). This creates individual top-level items in release notes, making it easier for readers to understand the intent of each change.
+     - Example: Create `.changeset/add-secondary-button.md` for a new feature and `.changeset/fix-button-layout.md` for a bug fix, even if both target the same package
 
 5. **Lint Changeset**
    - Run textlint to check the changeset file: `yarn textlint .changeset/<filename>.md`


### PR DESCRIPTION
## 概要

`create-changeset` コマンドのガイドラインを改善しました。

## 背景

PR #1527 で、changesetファイルにtextlintのエラー（半角スペースの問題）が見つかりました。
https://github.com/openameba/spindle/pull/1527#issuecomment-3489298609

また、複数パッケージの changeset における記述方法をより明確にする必要がありました。

## 変更内容

### 1. textlint チェックの追加
- changeset生成後、コミット前に `yarn textlint` でチェックを実行
- エラーがある場合は修正して再チェックするフローを明記

### 2. 複数パッケージの changeset 記述方法の改善
- パッケージ名を prefix に含めた形式に変更（例: `spindle-ui: Add new feature`）
- 各パッケージの変更内容を明確に区別

### 3. changeset 分割のガイドライン追加
- 同一パッケージでも目的が異なる変更（新機能追加と不具合修正、API破壊と内部リファクタなど）は別ファイルに分割
- リリースノートでトップレベル項目が個別に表示され、読み手が意図を把握しやすくなる

## 目的

changesetファイルの品質を向上し、リリースノートの可読性を改善します。