### PR TITLE
docs(spindle-ui): add InputLabel design doc and tests

### DIFF
--- a/packages/spindle-ui/src/Form/InputLabel/InputLabel.mdx
+++ b/packages/spindle-ui/src/Form/InputLabel/InputLabel.mdx
@@ -40,3 +40,25 @@ import '@openameba/spindle-ui/Form/InputLabel.css';
   `}
 />
 
+## Long Text
+
+<Story of={InputLabelStories.LongText} />
+
+<Source
+  code={`
+<InputLabel id="long-comment">
+  これはとても長いラベルテキストです。画面幅が狭い場合や、テキストサイズを200%に拡大した場合でも、このテキストは適切に折り返されて表示されることを確認するためのストーリーです。アクセシビリティガイドラインに準拠し、情報が欠落しないことを確認します。
+</InputLabel>
+  `}
+/>
+
+## Empty Children
+
+<Story of={InputLabelStories.EmptyChildren} />
+
+<Source
+  code={`
+<InputLabel id="empty" />
+  `}
+/>
+

--- a/packages/spindle-ui/src/Form/InputLabel/InputLabel.stories.tsx
+++ b/packages/spindle-ui/src/Form/InputLabel/InputLabel.stories.tsx
@@ -15,3 +15,18 @@ export const InputLabel: Story = {
     children: 'コメントを入力',
   },
 };
+
+export const LongText: Story = {
+  args: {
+    id: 'long-comment',
+    children:
+      'これはとても長いラベルテキストです。画面幅が狭い場合や、テキストサイズを200%に拡大した場合でも、このテキストは適切に折り返されて表示されることを確認するためのストーリーです。アクセシビリティガイドラインに準拠し、情報が欠落しないことを確認します。',
+  },
+};
+
+export const EmptyChildren: Story = {
+  args: {
+    id: 'empty',
+    children: '',
+  },
+};

--- a/packages/spindle-ui/src/Form/InputLabel/InputLabel.test.tsx
+++ b/packages/spindle-ui/src/Form/InputLabel/InputLabel.test.tsx
@@ -5,6 +5,16 @@ import React from 'react';
 import { InputLabel } from './InputLabel';
 
 describe('<InputLabel />', () => {
+  test('renders correctly with children', () => {
+    render(<InputLabel id="test">Label Text</InputLabel>);
+
+    const label = screen.getByText('Label Text');
+    expect(label).toBeInTheDocument();
+    expect(label.tagName).toBe('LABEL');
+    expect(label).toHaveAttribute('for', 'test');
+    expect(label).toHaveClass('spui-InputLabel');
+  });
+
   test('click', async () => {
     const user = userEvent.setup();
 
@@ -17,5 +27,24 @@ describe('<InputLabel />', () => {
 
     await user.click(screen.getByLabelText('test'));
     expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  test('renders with empty children', () => {
+    const { container } = render(<InputLabel id="test" />);
+
+    const label = container.querySelector('.spui-InputLabel');
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveAttribute('for', 'test');
+  });
+
+  test('passes through additional HTML attributes', () => {
+    render(
+      <InputLabel id="test" title="Custom Title">
+        Label
+      </InputLabel>,
+    );
+
+    const label = screen.getByText('Label');
+    expect(label).toHaveAttribute('title', 'Custom Title');
   });
 });

--- a/packages/spindle-ui/src/Form/InputLabel/design-doc.md
+++ b/packages/spindle-ui/src/Form/InputLabel/design-doc.md
@@ -1,0 +1,91 @@
+# InputLabel
+
+## 概要・背景
+
+InputLabelは、フォーム入力要素に対してラベルを提供するためのコンポーネントです。標準のHTML label要素をラップし、Spindleのデザインシステムに沿ったスタイルを提供します。このコンポーネントは、テキストフィールド、テキストエリア、セレクトボックスなど、さまざまなフォーム要素と組み合わせて使用されることを想定しています。
+
+## 使用例
+
+### DO
+
+InputLabelは、`id`プロパティで関連付けるフォーム要素のIDを指定して使用します。
+
+```tsx
+<InputLabel id="comment">コメントを入力</InputLabel>
+<input type="text" id="comment" />
+```
+
+#### 子要素が空の場合
+
+子要素が空の場合、ラベルは自動的に非表示になります（`display: none`が適用されます）。これにより、空のラベルが不要な余白を作ることを防ぎます。
+
+```tsx
+<InputLabel id="comment" />
+```
+
+### DO NOT
+
+このコンポーネントは`className`プロパティを受け取らないため、ラベル自体の見た目を変更できません。レイアウトやスタイルを調整する必要がある場合は、このコンポーネントを別のコンポーネントでラップするなど、コンポーネントを組み合わせて実装してください。
+
+## 要素
+
+### Design Tokens
+
+- Text Medium Emphasis (ラベルテキストの色)
+
+### プロパティ
+
+```ts
+type Props = {
+  // ラベルのテキスト内容
+  children?: React.ReactNode;
+  // 関連付けるフォーム要素のID (必須)
+  id: string;
+  // 標準のlabel要素の属性 (htmlFor以外)
+} & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'className'>;
+```
+
+## 実装例
+
+### React実装の例
+
+```tsx
+<InputLabel id="comment">コメントを入力</InputLabel>
+<input type="text" id="comment" />
+```
+
+### 書き出されるマークアップ
+
+```html
+<label class="spui-InputLabel" for="comment">コメントを入力</label>
+```
+
+## アクセシビリティ
+
+- [情報や関係性を明確にする](https://a11y-guidelines.ameba.design/1/3/1/)[基本必須]
+  - [ ] label要素のfor属性でフォーム要素と関連付けている
+  - [ ] idプロパティが適切に設定され、対応するフォーム要素と一致している
+- [テキストや文字画像のコントラストを確保する](https://a11y-guidelines.ameba.design/1/4/3/)[基本必須]
+  - [ ] SpindleカラーパレットのTheme Colorsを適切に使い分けている
+- [テキストサイズを拡大縮小できる](https://a11y-guidelines.ameba.design/1/4/4/)[基本必須]
+  - [ ] 画面を200%拡大・文字サイズを2倍に変更しても、適切に文字が折り返される
+- [HTMLを正しく記述する](https://a11y-guidelines.ameba.design/4/1/1/)[基本必須]
+  - [ ] HTML仕様に準拠した実装をしている
+  - [ ] セマンティックなlabel要素を使用している
+
+## テスト方針
+
+### ユニットテスト (Testing Library)
+
+- ラベルがレンダリングされること
+- ラベルをクリックすると、関連付けられたフォーム要素がフォーカスされること
+- 子要素が空の場合、ラベルが非表示になること
+
+### ヴィジュアルリグレッションテスト (Storybook)
+
+- 通常状態
+- 長いテキストを含む状態
+
+## リンク集
+
+- [HTMLのlabel要素 (MDN)](https://developer.mozilla.org/ja/docs/Web/HTML/Element/label)


### PR DESCRIPTION
## 概要

InputLabelコンポーネントのDesign Docとテスト、Storiesを追加しました。

## 変更内容

### Design Doc
- コンポーネントの概要・背景を記載
- 使用例（DO/DO NOT）を追加
- Design Tokensとプロパティを定義
- アクセシビリティチェックリストを追加
- テスト方針を記載

### Stories
- **LongText**: 長いテキストが適切に折り返されることを確認するストーリー
- **EmptyChildren**: 子要素が空の場合に`display: none`が適用されることを確認するストーリー

### テストケース
- 基本的なレンダリングテスト
- クリック時のフォーカステスト（既存）
- 空の子要素のレンダリングテスト
- 追加のHTML属性が正しく渡されることを確認するテスト

### ドキュメント
- Storybook MDXに新しいストーリーのセクションを追加

## 備考

- パッケージのAPIや機能には変更がないため、changesetは作成していません
- 全てのlintとフォーマットチェックが通過しています