### PR TITLE
docs(spindle-ui): add Tooltip component design doc

### DIFF
--- a/packages/spindle-ui/src/Tooltip/design-doc.md
+++ b/packages/spindle-ui/src/Tooltip/design-doc.md
@@ -203,6 +203,7 @@ Tooltipは、表示状態に応じて適切なARIA属性を自動的に付与し
 - `Tooltip.Trigger`のchildrenとして渡された関数に、トリガー要素に必要なprops（`ref`、`aria-describedby`、`aria-expanded`、`onMouseEnter`、`onFocus`、`onBlur`、`onPointerDown`、`onPointerUp`）を渡します
 - Tooltipの`id`を自動生成し、`aria-describedby`で関連付けます
 - トリガー要素のサイズを取得し、ポインターがトリガーに対して相対的に適切な位置に配置されるように計算します
+- デバイスタイプの判定には`onPointerDown`/`onPointerUp`の`e.pointerType`を使用します。`'ontouchstart' in window`や`navigator.maxTouchPoints`等の環境全体の判定も可能ですが、タッチとポインティングデバイスが共存する環境（タッチ対応PC等）では実際にどちらで操作されたかを判定できません。なお、`onClick`は`MouseEvent`のため`pointerType`が取得できません
 
 #### トリガー要素の要件
 


### PR DESCRIPTION
新規で作成するTooltipコンポーネントのDesign Docと実装を追加しました。

## 意思決定ポイント

### コンポーネントの命名

現状ではホバーした際に表示するいわゆる一般的なツールチップは提供せず、クリックした際に表示する形式（トグルチップ形式）のみを提供しますが、将来的にツールチップも提供する可能性があるため、`Toggletip`ではなく`Tooltip`としてコンポーネントを設計しています。

### コンポーネント設計

最終的にパターン3を採用しました。

#### パターン1: 利用者が手動で管理

```tsx
<>
  <IconButton ref={triggerRef} aria-describedby="tooltip-1">
    <Information aria-hidden="true" />
  </IconButton>
  <Tooltip.Frame id="tooltip-1" triggerRef={triggerRef} open={open}>
    <Tooltip.Content>テキスト</Tooltip.Content>
  </Tooltip.Frame>
</>
```

**Pros:**
- シンプルで明示的
- 完全な制御が可能

**Cons:**
- `id`、`triggerRef`、`aria-describedby`、`aria-expanded`を手動管理
- アクセシビリティ対応の負荷が高く実装漏れのリスク
- ボイラープレートコードが多い

#### パターン2: text propで完全自動化

```tsx
<Tooltip text="テキスト">
  <IconButton>
    <Information aria-hidden="true" />
  </IconButton>
</Tooltip>
```

**Pros:**
- ボイラープレートなし
- `id`、`aria-*`属性などを自動付与

**Cons:**
- 他コンポーネントと異なる設計（Frame/Trigger/Content構造ではない）

#### パターン3: Frame/Trigger/Content

```tsx
<Tooltip.Frame open={open} onClose={handleClose}>
  <Tooltip.Trigger>
    <IconButton aria-label="詳細情報" onClick={handleClick}>
      <Information aria-hidden="true" />
    </IconButton>
  </Tooltip.Trigger>
  <Tooltip.Content>
    補足情報
  </Tooltip.Content>
</Tooltip.Frame>
```

**Pros:**
- リッチなコンテンツ対応
- `id`、`aria-*`属性などを自動付与
- 他コンポーネントと同じ設計
- 拡張性・柔軟性が高い

**Cons:**
- パターン2より若干冗長
