### PR TITLE
デザインドキュメントワークフローにFigma Code Connect対応を追加

### DIFF
--- a/.claude/commands/create-design-doc.md
+++ b/.claude/commands/create-design-doc.md
@@ -1,32 +1,49 @@
 ---
 description: Create a design document for a Spindle UI component
-argument-hint: [component-name]
-allowed-tools: Read, Write, Glob, Grep, Bash
+argument-hint: [component-name] [figma-url]
+allowed-tools: Read, Write, Glob, Grep, Bash, mcp__figma-desktop__get_design_context, mcp__figma__get_design_context
 ---
 
 # Create Design Doc Command
 
 ## Overview
 
-This command creates a Design Doc for a Spindle UI component. It generates documentation following the template format, referencing existing Design Docs and component implementations.
+This command creates a Design Doc for a Spindle UI component. It generates documentation following the template format, referencing existing Design Docs and component implementations. It can work with both existing and new components, and optionally includes Figma Code Connect information if a Figma URL is provided.
 
 ## Steps
 
-1. **Retrieve Design Doc Template**
+1. **Determine Component Status**
+   - Check if the component already exists in @packages/spindle-ui/src/
+   - If the component doesn't exist, this is a new component
+   - Skip steps marked with (existing components only) for new components
+
+2. **Retrieve Design Doc Template**
    - Read the template from @packages/spindle-ui/.scaffdog/design-doc.md
 
-2. **Reference Existing Design Docs**
+3. **Reference Existing Design Docs**
    - Read multiple Design Docs from similar components
    - Understand the structure and style
    - Examples: @packages/spindle-ui/src/Form/ButtonSwitch/design-doc.md, @packages/spindle-ui/src/Rating/design-doc.md
 
-3. **Analyze Component Implementation**
+4. **Process Figma URL** (if provided)
+   - Check if Figma MCP is available (look for `mcp__figma-desktop__get_design_context` or `mcp__figma__get_design_context`)
+   - Extract the node-id from the Figma URL and convert format
+     - Example: `https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=1-2` → extract `1-2` → convert to `1:2`
+   - If Figma MCP is available:
+     - Use `get_design_context` with the converted nodeId (e.g., `1:2`) to fetch component information
+     - This retrieves properties, variants, design tokens, and component structure
+     - Use this information to populate the Figma Code Connect section with accurate property mappings
+   - If Figma MCP is not available:
+     - Inform the user that Figma MCP is not configured
+     - Store the Figma URL and node-id for manual Code Connect documentation
+
+5. **Analyze Component Implementation** (existing components only)
    - TypeScript files (Props definitions)
    - CSS files (Design Tokens)
    - Stories files (variations)
    - MDX files (usage examples)
 
-4. **Create Design Doc**
+6. **Create Design Doc**
    - Place the file in the appropriate path based on the component name
    - Include the following sections:
      - **Overview & Background** (Required): Component purpose and use cases
@@ -36,24 +53,37 @@ This command creates a Design Doc for a Spindle UI component. It generates docum
        - Design Tokens: Colors and tokens used
        - Properties: TypeScript type definitions
      - **Implementation Examples** (Optional): React and HTML markup samples
+     - **Figma Code Connect** (Optional): If Figma URL was provided, populate this section with:
+       - The extracted node-id formatted as `node-id=X:Y`
+       - Mapping design showing how Figma variants/properties map to React props
+       - Implementation example using `figma.connect()` with the proper URL and mappings
      - **Accessibility** (Required): Checklist based on Ameba Accessibility Guidelines
      - **Testing Strategy** (Optional): Testing Library and Storybook test approach
      - **Links** (Optional): Reference documentation URLs
 
-5. **Suggest Missing Stories and Tests**
+7. **Suggest Missing Stories and Tests** (existing components only)
    - Review existing Stories and identify missing variations (e.g., checked state)
    - Propose additional Stories if needed
    - Review existing tests and suggest missing test cases if needed
 
-6. **Fix Linting and Formatting Issues**
+8. **Fix Linting and Formatting Issues**
    - Run `yarn fix` in the project root to automatically fix code formatting issues (Biome and lerna format will run)
    - Run `yarn textlint <path-to-design-doc>` and manually fix any errors or warnings until the command passes cleanly
 
 ## Usage
 
 ```bash
+# Existing component
 /create-design-doc Button
+
+# Existing component with nested path
 /create-design-doc Form/TextField
+
+# New component with Figma URL
+/create-design-doc NewComponent https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=1-2
+
+# Existing component with Figma URL to add Code Connect section
+/create-design-doc Button https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=123-456
 ```
 
 ## Notes

--- a/.cursor/commands/create-design-doc.md
+++ b/.cursor/commands/create-design-doc.md
@@ -2,25 +2,42 @@
 
 ## Overview
 
-This command creates a Design Doc for a Spindle UI component. It generates documentation following the template format, referencing existing Design Docs and component implementations.
+This command creates a Design Doc for a Spindle UI component. It generates documentation following the template format, referencing existing Design Docs and component implementations. It can work with both existing and new components, and optionally includes Figma Code Connect information if a Figma URL is provided.
 
 ## Steps
 
-1. **Retrieve Design Doc Template**
+1. **Determine Component Status**
+   - Check if the component already exists in `packages/spindle-ui/src/`
+   - If the component doesn't exist, this is a new component
+   - Skip steps marked with (existing components only) for new components
+
+2. **Retrieve Design Doc Template**
    - Read the template from `packages/spindle-ui/.scaffdog/design-doc.md`
 
-2. **Reference Existing Design Docs**
+3. **Reference Existing Design Docs**
    - Read multiple Design Docs from similar components
    - Understand the structure and style
    - Examples: `packages/spindle-ui/src/Form/ButtonSwitch/design-doc.md`, `packages/spindle-ui/src/Rating/design-doc.md`
 
-3. **Analyze Component Implementation**
+4. **Process Figma URL** (if provided)
+   - Check if Figma MCP is available (look for `mcp__figma-desktop__get_design_context` or `mcp__figma__get_design_context`)
+   - Extract the node-id from the Figma URL and convert format
+     - Example: `https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=1-2` → extract `1-2` → convert to `1:2`
+   - If Figma MCP is available:
+     - Use `get_design_context` with the converted nodeId (e.g., `1:2`) to fetch component information
+     - This retrieves properties, variants, design tokens, and component structure
+     - Use this information to populate the Figma Code Connect section with accurate property mappings
+   - If Figma MCP is not available:
+     - Inform the user that Figma MCP is not configured
+     - Store the Figma URL and node-id for manual Code Connect documentation
+
+5. **Analyze Component Implementation** (existing components only)
    - TypeScript files (Props definitions)
    - CSS files (Design Tokens)
    - Stories files (variations)
    - MDX files (usage examples)
 
-4. **Create Design Doc**
+6. **Create Design Doc**
    - Place the file in the appropriate path based on the component name
    - Include the following sections:
      - **Overview & Background** (Required): Component purpose and use cases
@@ -30,24 +47,37 @@ This command creates a Design Doc for a Spindle UI component. It generates docum
        - Design Tokens: Colors and tokens used
        - Properties: TypeScript type definitions
      - **Implementation Examples** (Optional): React and HTML markup samples
+     - **Figma Code Connect** (Optional): If Figma URL was provided, populate this section with:
+       - The extracted node-id formatted as `node-id=X:Y`
+       - Mapping design showing how Figma variants/properties map to React props
+       - Implementation example using `figma.connect()` with the proper URL and mappings
      - **Accessibility** (Required): Checklist based on Ameba Accessibility Guidelines
      - **Testing Strategy** (Optional): Testing Library and Storybook test approach
      - **Links** (Optional): Reference documentation URLs
 
-5. **Suggest Missing Stories and Tests**
+7. **Suggest Missing Stories and Tests** (existing components only)
    - Review existing Stories and identify missing variations (e.g., checked state)
    - Propose additional Stories if needed
    - Review existing tests and suggest missing test cases if needed
 
-6. **Fix Linting and Formatting Issues**
+8. **Fix Linting and Formatting Issues**
    - Run `yarn fix` in the project root to automatically fix code formatting issues (Biome and lerna format will run)
    - Run `yarn textlint <path-to-design-doc>` and manually fix any errors or warnings until the command passes cleanly
 
 ## Usage
 
 ```bash
+# Existing component
 /create-design-doc Button
+
+# Existing component with nested path
 /create-design-doc Form/TextField
+
+# New component with Figma URL
+/create-design-doc NewComponent https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=1-2
+
+# Existing component with Figma URL to add Code Connect section
+/create-design-doc Button https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=123-456
 ```
 
 ## Notes

--- a/packages/spindle-ui/.scaffdog/design-doc.md
+++ b/packages/spindle-ui/.scaffdog/design-doc.md
@@ -59,6 +59,39 @@ type Props = {
 ## 実装例
 <!-- オプション項目です。大まかなコードを書いたり、複数の実装を比較する際に利用します -->
 
+## Figma Code Connect
+<!-- オプション項目です。Figmaのデザインコンポーネントと実装コードを連携させる設計を記述します。
+
+Figma Code Connectを使うと、Figma上でコンポーネントを選択した際に、実装コードが自動的に表示されるようになります。
+
+Figmaのデザインデータと実装方針を踏まえ以下の項目を記載してください。
+
+(例)
+### マッピング
+- Figmaバリアント "Size" (Large/Medium/Small) → React prop `size` (large/medium/small)
+- Figmaバリアント "Active" (True/False) → React prop `active` (boolean)
+
+### 実装例
+```tsx
+figma.connect(
+  'https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=NODE_ID',
+  {
+    props: {
+      size: figma.enum('Size', {
+        'Large': 'large',
+        'Medium': 'medium',
+        'Small': 'small',
+      }),
+      active: figma.boolean('Active'),
+    },
+    example: ({ size, active }) => (
+      <Component size={size} active={active} />
+    ),
+  }
+)
+```
+-->
+
 ## アクセシビリティ
 <!-- 必須項目です。「Ameba Accessibility Checklist」を使って対応する項目をリストアップします。対応する項目を以下の形式で記述します。
 - [項目](ガイドラインURL) [重要度]


### PR DESCRIPTION
## 概要

デザインドキュメントのテンプレートとワークフローにFigma Code Connect機能を追加しました。

## 主な変更点

- デザインドキュメントテンプレートに「Figma Code Connect」セクションを追加
- `create-design-doc`コマンドを拡張し、新規コンポーネントとFigma URLに対応
- Figma MCP統合により、コンポーネントのプロパティやバリアントを自動取得
- FigmaバリアントからReact propsへのマッピング例を追加

## 変更ファイル

- `.claude/commands/create-design-doc.md` - Claude用コマンド定義
- `.cursor/commands/create-design-doc.md` - Cursor用コマンド定義
- `packages/spindle-ui/.scaffdog/design-doc.md` - デザインドキュメントテンプレート

## 使用方法

### 既存コンポーネント
```bash
/create-design-doc Button
```

### 新規コンポーネント（Figma URL付き）
```bash
/create-design-doc NewComponent https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=1-2
```

### 既存コンポーネント（Figma Code Connect追加）
```bash
/create-design-doc Button https://www.figma.com/design/FILE_KEY/FILE_NAME?node-id=123-456
```

## 動作

- 新規コンポーネントの場合、実装分析とテスト提案のステップをスキップ
- Figma URLが提供された場合、Figma MCPを使用してコンポーネント情報を取得
- 取得した情報を元に、Figma Code Connectセクションにプロパティマッピングを自動生成