### PR TITLE
chore: add .stylelintignore to exclude build artifacts

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+**/dist/
+packages/spindle-mcp-server/assets/


### PR DESCRIPTION
## 概要

ローカルでbuild後にstylelintを実行すると、build成果物（`dist/`ディレクトリ内のファイル）が対象になってしまう問題を解決するため、`.stylelintignore`ファイルを追加しました。

## 変更内容

- `.stylelintignore`を追加
  - `**/dist/`：各パッケージのbuild成果物を除外
  - `packages/spindle-mcp-server/assets/`：コピーされたアセットを除外

## 備考

CI上では元々build成果物が存在しないため問題ありませんでしたが、ローカル環境でbuild後にlintを実行する際にこの設定が有効になります。