### PR TITLE
chore: add changesets for spindle-tokens and spindle-icons

### DIFF
--- a/.changeset/add-spindle-tokens.md
+++ b/.changeset/add-spindle-tokens.md
@@ -1,0 +1,8 @@
+---
+"@openameba/spindle-tokens": minor
+---
+
+feat(spindle-tokens): add Ease Out Soft easing and Slower duration tokens
+
+- Add Easing/Ease Out Soft: cubic-bezier(0.24, 0.27, 0.15, 0.99)
+- Add Duration/Slower: 1000ms

--- a/.changeset/update-filter-icon.md
+++ b/.changeset/update-filter-icon.md
@@ -1,0 +1,6 @@
+---
+"@openameba/spindle-icons": patch
+"@openameba/spindle-ui": patch
+---
+
+feat(spindle-icons): update filter icon


### PR DESCRIPTION
This pull request introduces updates to both the design tokens and icon assets. The most important changes are the addition of new easing and duration tokens, and an update to the filter icon.

**Design tokens:**

* Added a new easing token `Ease Out Soft` with the value `cubic-bezier(0.24, 0.27, 0.15, 0.99)` in `@openameba/spindle-tokens`.
* Added a new duration token `Slower` with the value `1000ms` in `@openameba/spindle-tokens`.

**Icon updates:**

* Updated the filter icon in `@openameba/spindle-icons` and `@openameba/spindle-ui`.