### PR TITLE
fix: workaround pnpm v10.28.1 filter bug in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       # Build all packages except spindle-icons to check if the system works or not
       # spindle-icons is excluded because it requires FIGMA_TOKEN and fetches data from Figma API on every build
+      # Note: pnpm v10.28.1+ has a bug that includes root package when using negation filter (pnpm/pnpm#10485)
+      # Workaround: use positive filter to select packages from ./packages/* then exclude spindle-icons
       - name: build all packages
         run: |
-          pnpm --filter '!@openameba/spindle-icons' -r build
+          pnpm --filter './packages/*' --filter '!@openameba/spindle-icons' -r build
           pnpm build:extensionReplace

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spindle",
   "private": true,
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.28.1",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "test": "run-p codecheck test:packages",
@@ -38,7 +38,7 @@
     "jscodeshift": "17.3.0",
     "lint-staged": "16.2.7",
     "npm-run-all2": "8.0.4",
-    "pnpm": "10.28.0",
+    "pnpm": "10.28.1",
     "prettier": "3.8.0",
     "stylelint": "16.26.1",
     "stylelint-config-standard": "39.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: 8.0.4
         version: 8.0.4
       pnpm:
-        specifier: 10.28.0
-        version: 10.28.0
+        specifier: 10.28.1
+        version: 10.28.1
       prettier:
         specifier: 3.8.0
         version: 3.8.0
@@ -6672,8 +6672,8 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
-  pnpm@10.28.0:
-    resolution: {integrity: sha512-Bd9x0UIfITmeBT/eVnzqNNRG+gLHZXFEG/wceVbpjjYwiJgtlARl/TRIDU2QoGaLwSNi+KqIAApk6D0LDke+SA==}
+  pnpm@10.28.1:
+    resolution: {integrity: sha512-fX27yp6ZRHt8O/enMoavqva+mSUeuUmLrvp9QGiS9nuHmts6HX5of8TMwaOIxxdfuq5WeiarRNEGe1T8sNajFg==}
     engines: {node: '>=18.12'}
     hasBin: true
 
@@ -16561,7 +16561,7 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  pnpm@10.28.0: {}
+  pnpm@10.28.1: {}
 
   portfinder@1.0.38:
     dependencies:


### PR DESCRIPTION
pnpm v10.28.1 has a regression (pnpm/pnpm#10485) where negation filters cause the root package to be included. Added positive filter './packages/*' to explicitly scope to workspace packages before applying the spindle-icons exclusion.