### PR TITLE
ci: add workflow to sync spindle-mcp-server release

### DIFF
--- a/.github/workflows/sync-mcp-release.yml
+++ b/.github/workflows/sync-mcp-release.yml
@@ -28,10 +28,10 @@ jobs:
         id: check
         run: |
           # spindle-ui/tokensの更新があるか
-          HAS_UI_TOKENS=$(grep -rl "spindle-ui\|spindle-tokens" .changeset/*.md 2>/dev/null && echo "true" || echo "false")
+          HAS_UI_TOKENS=$(grep -rql "spindle-ui\|spindle-tokens" .changeset/*.md 2>/dev/null && echo "true" || echo "false")
 
           # spindle-mcp-serverのchangesetが既にあるか
-          HAS_MCP=$(grep -rl "spindle-mcp-server" .changeset/*.md 2>/dev/null && echo "true" || echo "false")
+          HAS_MCP=$(grep -rql "spindle-mcp-server" .changeset/*.md 2>/dev/null && echo "true" || echo "false")
 
           echo "has_ui_tokens=$HAS_UI_TOKENS" >> $GITHUB_OUTPUT
           echo "has_mcp=$HAS_MCP" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- spindle-ui または spindle-tokens がリリースされる際に、spindle-mcp-server も自動的に patch リリースされるワークフローを追加

## 背景

spindle-mcp-server は、ビルド時に spindle-ui と spindle-tokens のアセットをコピーして配布物に含めています。そのため、これらのパッケージが更新された場合は spindle-mcp-server も再ビルド・リリースする必要があります。

## 動作

1. `changeset-release/` で始まる Version PR で `.changeset/*.md` に変更があると実行
2. spindle-ui または spindle-tokens の changeset があるかチェック
3. spindle-mcp-server の changeset が**ない**場合のみ、自動で patch changeset を生成
4. 生成した changeset をコミット＆プッシュ

| spindle-ui/tokens changeset | spindle-mcp-server changeset | 動作 |
|:--:|:--:|:--|
| あり | なし | 自動生成 |
| あり | あり | 何もしない |
| なし | - | 何もしない |