### PR TITLE
chore: group stylelint packages in Renovate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,5 +8,13 @@
   ],
   "reviewers": [
     "team:spindle-working-group"
+  ],
+  "packageRules": [
+    {
+      "groupName": "stylelint packages",
+      "matchPackagePatterns": [
+        "^stylelint"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Renovate で stylelint 関連パッケージがまとめて更新されるよう設定を追加

## Background

stylelint のプラグイン（stylelint-config-standard, stylelint-order, stylelint-selector-bem-pattern など）は stylelint 本体への peer dependency が強く、個別にアップデートすると peer dependency エラーが発生しやすいです。

グループ化により、互換性のあるバージョンがまとめて1つのPRで更新されるようになります。