### PR TITLE
chore(spindle-mcp-server): use workspace:* for internal dependencies

### DIFF
--- a/packages/spindle-mcp-server/package.json
+++ b/packages/spindle-mcp-server/package.json
@@ -43,8 +43,8 @@
   },
   "devDependencies": {
     "@cfworker/json-schema": "4.1.1",
-    "@openameba/spindle-tokens": "1.9.0",
-    "@openameba/spindle-ui": "3.1.4",
+    "@openameba/spindle-tokens": "workspace:*",
+    "@openameba/spindle-ui": "workspace:*",
     "@types/node": "24.10.9",
     "cpx2": "8.0.0",
     "vitest": "4.0.17"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,11 +183,11 @@ importers:
         specifier: 4.1.1
         version: 4.1.1
       '@openameba/spindle-tokens':
-        specifier: 1.9.0
-        version: 1.9.0
+        specifier: workspace:*
+        version: link:../spindle-tokens
       '@openameba/spindle-ui':
-        specifier: 3.1.4
-        version: 3.1.4(@types/react@19.2.8)(react@19.2.3)
+        specifier: workspace:*
+        version: link:../spindle-ui
       '@types/node':
         specifier: 24.10.9
         version: 24.10.9
@@ -1481,18 +1481,6 @@ packages:
     peerDependencies:
       '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0|| ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0|| ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@openameba/spindle-tokens@1.9.0':
-    resolution: {integrity: sha512-rRLRE7wvtfabWXt8z5Z6qDGlRxOPkRl3AkVFKFe2CO/0PznR/Vjf8uP/ermAJdB9H9G7yYikyi7rUIAzat/j2g==}
-
-  '@openameba/spindle-ui@3.1.4':
-    resolution: {integrity: sha512-4mUnrXPhPv/kphiGwAYOY5RhP5TREgg39014ksyn3ywC+ilc5HKn6dH5Qk8SED6WFyvDJs1YwYyRyOcGiWr9Ew==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -10447,17 +10435,6 @@ snapshots:
   '@openameba/spindle-hooks@1.10.1(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.8
-
-  '@openameba/spindle-tokens@1.9.0': {}
-
-  '@openameba/spindle-ui@3.1.4(@types/react@19.2.8)(react@19.2.3)':
-    dependencies:
-      '@openameba/spindle-hooks': 1.10.1(@types/react@19.2.8)(react@19.2.3)
-      ameba-color-palette.css: 4.17.0
-      react: 19.2.3
-      use-callback-ref: 1.3.3(@types/react@19.2.8)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.8
 


### PR DESCRIPTION
This ensures spindle-mcp-server always references the latest local versions of spindle-tokens and spindle-ui during development, and pnpm automatically resolves to the correct version numbers at publish.

#1783 でリリース対応したので deps の指定も変えました。

