### PR TITLE
fix: allowedVersionsにstylelint-selector-bem-patternの設定を追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,8 @@ packages:
 peerDependencyRules:
   ignoreMissing:
     - hono
+  allowedVersions:
+    stylelint-selector-bem-pattern>stylelint: '17'
 
 overrides:
   superstatic: 10.0.0


### PR DESCRIPTION
stylelint-selector-bem-patternがstylelintの17系に対応しておらず、peer dependencyの警告が発生していたのでこちらに対応しました。