### PR TITLE
chore: remove unused workflow inputs

### DIFF
--- a/.github/workflows/build-icon-from-figma.yml
+++ b/.github/workflows/build-icon-from-figma.yml
@@ -3,15 +3,6 @@ name: build icon from Figma
 on:
   workflow_dispatch:
     inputs:
-      fileKey:
-        description: Figma file key
-        type: string
-        required: true
-      page:
-        description: Stringified selected page (id, name)
-        type: string
-        default: '{}'
-        required: true
       selection:
         description: Stringified array of the selected nodes (id, name)
         type: string


### PR DESCRIPTION
### Motivation
- `.github/workflows/build-icon-from-figma.yml` の `workflow_dispatch.inputs` に未使用の `fileKey` と `page` が残っていたため、定義を簡素化して誤操作や混乱を防ぐ。 

### Description
- `workflow_dispatch.inputs` から `fileKey` と `page` を削除しました。 
- `selection` 入力はそのまま残しており、ジョブ内のアイコン更新処理は引き続き `selection` を使用します。 
- 変更は ` .github/workflows/build-icon-from-figma.yml` にのみ適用されています。 

### Testing
- 自動テストは実行していません（CI ワークフロー設定の変更のみのため）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979c678697c832ea787d6cab081a814)