### PR TITLE
fix: format スクリプト未定義のパッケージをスキップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fix": "run-p fix:*",
     "fix:code": "biome check --write",
     "fix:css": "stylelint '**/*.css' --fix",
-    "fix:packages": "pnpm -r --parallel format",
+    "fix:packages": "pnpm -r --parallel --if-present format",
     "fix:text": "textlint --fix .",
     "bootstrap": "pnpm install",
     "build": "run-s build:*",


### PR DESCRIPTION
### Motivation
- CI の `fix:packages` 実行時に一部パッケージで `format` スクリプトが未定義なため `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` で失敗する問題を回避するため。 

### Description
- `package.json` の `fix:packages` スクリプトを `"pnpm -r --parallel format"` から `"pnpm -r --parallel --if-present format"` に変更して、`format` スクリプトがないパッケージをスキップするようにしました。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979ccc2a894832e92d900dc1a03e13f)