### PR TITLE
Remove unused pnpm format script from fix:packages task

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "fix": "run-p fix:*",
     "fix:code": "biome check --write",
     "fix:css": "stylelint '**/*.css' --fix",
-    "fix:packages": "pnpm -r --parallel format",
     "fix:text": "textlint --fix .",
     "bootstrap": "pnpm install",
     "build": "run-s build:*",


### PR DESCRIPTION
## Summary
Removed the `fix:packages` npm script that was running `pnpm -r --parallel format` across all workspace packages.

## Changes
- Deleted the `fix:packages` script from the `fix` task chain in package.json

## Details
This script appears to be unused or redundant in the current workflow. The `fix` task uses `run-p` to execute all `fix:*` scripts in parallel, but removing this entry suggests that:
- Package formatting is now handled elsewhere in the build/lint pipeline
- The parallel format command is no longer needed for workspace management
- Code formatting is likely consolidated under the existing `fix:code` (biome) and `fix:css` (stylelint) tasks

https://claude.ai/code/session_017wRDxA3syk3BVKnjjvp4fA