### PR TITLE
Secure npm release workflow with environment protection

### DIFF
--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -11,10 +11,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: github.repository == 'openameba/spindle'
     permissions:
       contents: write
-      id-token: write # Needed for npm Trusted Publishing (OIDC)
       pull-requests: write # Needed for creating pull requests
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,12 +25,57 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
+      # pnpm store cache intentionally omitted so this release workflow does
+      # not restore cache entries that may have been written by PR-triggered
+      # workflows. Release runs are infrequent; install-time increase is
+      # acceptable.
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build spindle-hooks
+        run: pnpm --filter @openameba/spindle-hooks build
+
+      - name: Create Release Pull Request
+        id: changesets
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        with:
+          version: pnpm version-packages
+          commit: 'chore: publish'
+          title: 'chore: publish'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.hasChangesets == 'false'
+    environment: production-npm
+    permissions:
+      contents: read
+      id-token: write # Needed for npm Trusted Publishing (OIDC)
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      # pnpm store cache intentionally omitted so this release workflow does
+      # not restore cache entries that may have been written by PR-triggered
+      # workflows. Release runs are infrequent; install-time increase is
+      # acceptable.
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
           registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
 
       # Update npm (>=11.5.1 required for OIDC/provenance); install latest
       - name: Update npm
@@ -40,16 +87,5 @@ jobs:
       - name: Build spindle-hooks
         run: pnpm --filter @openameba/spindle-hooks build
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
-        with:
-          version: pnpm version-packages
-          commit: 'chore: publish'
-          title: 'chore: publish'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish to npm with prepublishOnly
-        if: steps.changesets.outputs.hasChangesets == 'false'
         run: npm_config_ignore_scripts=false pnpm changeset publish


### PR DESCRIPTION
## 概要
リリースワークフローのセキュリティを強化するため、リポジトリオーナーのチェックと npm 用 production environment 保護を追加し、あわせて不要になった pnpm キャッシュ設定を削除しました。

## 変更点
- `github.repository == 'openameba/spindle'` を追加し、公式リポジトリからのみリリースが走るようにガード
- `environment: production-npm` を追加し、GitHub の environment protection rule(必須レビュアー / wait timer など)を後から差し込めるようにする (現状はそのままリリース)
- `setup-node` の `cache: pnpm` を削除し、PR 系ワークフローと同じキャッシュキーを参照する経路を解消 (実行時間延長は許容)

## 意図
- fork やフォーク先からの意図しない publish を防ぐ
- environment 経由にすることで、将来 GitHub UI 側の設定のみで承認フローや追加バインド(npm trusted publisher の subject claim による絞り込み)を導入できる足場を用意
- リリース側のキャッシュ復元経路を物理的に分離し、PR 系で書かれたキャッシュをリリース時に拾わない構成にする

## マージ前のチェック
- [x] GitHub の Settings > Environments で `production-npm` を作成済み(protection rule は未設定でも可)

https://claude.ai/code/session_01QkmUEebvid6RcCQPJwfZMN