### PR TITLE
Update TypeScript configurations for improved module resolution

### DIFF
--- a/.changeset/typescript-v6-compatibility.md
+++ b/.changeset/typescript-v6-compatibility.md
@@ -1,0 +1,8 @@
+---
+"@openameba/spindle-hooks": patch
+"@openameba/spindle-mcp-server": patch
+"@openameba/spindle-theme-switch": patch
+"@openameba/spindle-ui": patch
+---
+
+TypeScript v6でビルド可能にするため、各パッケージのtsconfigを更新。spindle-hooksとspindle-uiのCJSビルドのtargetを `es5` から `es2018` に引き上げ (IE11等のES2018非対応環境は元々サポート対象外)。

--- a/packages/spindle-hooks/tsconfig.cjs.json
+++ b/packages/spindle-hooks/tsconfig.cjs.json
@@ -1,8 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2018",
     "outDir": "dist",
+    "rootDir": "./src",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true

--- a/packages/spindle-hooks/tsconfig.esm.json
+++ b/packages/spindle-hooks/tsconfig.esm.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2018",
     "outDir": "dist",
-    "moduleResolution": "node"
+    "rootDir": "./src",
+    "module": "ESNext",
+    "moduleResolution": "bundler"
   },
   "exclude": [
     "src/**/*.test.*",

--- a/packages/spindle-mcp-server/tsconfig.json
+++ b/packages/spindle-mcp-server/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "nodenext",
     "target": "ES2022",
     "lib": ["ES2022", "DOM"],
+    "types": ["node"],
     "declaration": true
   },
   "include": ["src/**/*"],

--- a/packages/spindle-theme-switch/src/types/spindle-theme-switch.d.ts
+++ b/packages/spindle-theme-switch/src/types/spindle-theme-switch.d.ts
@@ -1,6 +1,6 @@
 import { DarkModeToggle } from 'dark-mode-toggle';
 
-import './jsx';
+import './jsx.js';
 
 export class SpindleThemeSwitch extends DarkModeToggle {
   constructor();

--- a/packages/spindle-theme-switch/tsconfig.json
+++ b/packages/spindle-theme-switch/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "outDir": "dist",
+    "rootDir": "./src",
     "module": "Node16",
     "moduleResolution": "node16"
   },

--- a/packages/spindle-ui/tsconfig.cjs.json
+++ b/packages/spindle-ui/tsconfig.cjs.json
@@ -1,8 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2018",
     "outDir": "dist",
+    "rootDir": "./src",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/spindle-ui/tsconfig.esm.json
+++ b/packages/spindle-ui/tsconfig.esm.json
@@ -1,9 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2018",
     "outDir": "dist",
-    "moduleResolution": "node",
+    "rootDir": "./src",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   }
 }

--- a/packages/spindle-ui/tsconfig.json
+++ b/packages/spindle-ui/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "paths": {
+      "src/*": ["./src/*"]
+    },
     "lib": ["ESNext", "DOM"],
     "types": ["vitest/globals", "@testing-library/jest-dom"],
     "jsx": "react",


### PR DESCRIPTION
## 概要
TypeScript v6 へのアップグレード (`renovate/typescript-6.x` PR) で発生する build エラーと deprecation 警告を解消するため、対象パッケージの tsconfig を修正します。

## 変更内容

### `spindle-mcp-server/tsconfig.json`
- `"types": ["node"]` を追加 — TS v6 で Node 組み込み型 (`node:fs`, `Buffer`, `process` 等) の暗黙取り込みが効かなくなったため明示

### `spindle-theme-switch/`
- `tsconfig.json`: `"rootDir": "./src"` を追加 — TS v6 で `rootDir` 未指定がエラー化
- `src/types/spindle-theme-switch.d.ts`: `import './jsx'` → `import './jsx.js'` — `moduleResolution: node16` で拡張子必須

### `spindle-hooks/`, `spindle-ui/` の ESM / CJS build tsconfig
TS v6 で deprecated になった `target: es5` / `moduleResolution: node`(=`node10`) を非 deprecated な設定に置換し、`ignoreDeprecations` を使わない構成に統一。

| 設定 | 修正前 | 修正後 |
|---|---|---|
| `target` (ESM/CJS) | `ESNext` / `es5` | `ES2018` |
| `module` (ESM) | (未指定) | `ESNext` |
| `moduleResolution` (ESM) | `node` (deprecated) | `bundler` |
| `module` (CJS) | (未指定 = commonjs) | `Node16` |
| `moduleResolution` (CJS) | (未指定 = node10) | `Node16` |
| `rootDir` | (未指定) | `./src` |

### `spindle-ui/tsconfig.json`
- `baseUrl: "."` (TS v6 で deprecated) → `paths: { "src/*": ["./src/*"] }` に置換 — `.figma.tsx` 内の `src/...` 形式の import を維持

## 対象外
- `spindle-theme-switch/tsconfig.json` および `spindle-mcp-server/tsconfig.json` の `target` (それぞれ `ESNext` / `ES2022`) はパッケージ特性上の理由で意図的に維持しています (ES2018 への統一は本 PR の目的外)

## 検証
- `pnpm --filter './packages/*' --filter '!@openameba/spindle-icons' -r build` → 全パッケージ build 成功、deprecation 警告 0
- `TZ=Asia/Tokyo pnpm test` → 312 tests / 42 files 全 pass

https://claude.ai/code/session_01VLfLgDaTdtCVq6j7AVN7hd