### PR TITLE
fix(spindle-ui): spindle-hooks の依存指定を workspace 化

### DIFF
--- a/packages/spindle-ui/package.json
+++ b/packages/spindle-ui/package.json
@@ -60,7 +60,7 @@
     }
   },
   "dependencies": {
-    "@openameba/spindle-hooks": "^1.10.0",
+    "@openameba/spindle-hooks": "workspace:^",
     "ameba-color-palette.css": "^4.17.0",
     "use-callback-ref": "^1.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,8 +270,8 @@ importers:
   packages/spindle-ui:
     dependencies:
       '@openameba/spindle-hooks':
-        specifier: ^1.10.0
-        version: 1.10.1(@types/react@19.2.14)(react@19.2.6)
+        specifier: workspace:^
+        version: link:../spindle-hooks
       ameba-color-palette.css:
         specifier: ^4.17.0
         version: 4.17.0
@@ -1646,15 +1646,6 @@ packages:
   '@oozcitak/util@10.0.0':
     resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
     engines: {node: '>=20.0'}
-
-  '@openameba/spindle-hooks@1.10.1':
-    resolution: {integrity: sha512-CEas3+PT8Al37xyDS2STtdgg3KTOEMsk7Lo2TUoWm+8//VKXcynoNOMvQt+MmhYG0opwP1IC5M+Kzu8LXxltBA==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0|| ^19.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0|| ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@openameba/textlint-rule-preset-ameba@https://codeload.github.com/openameba/textlint-rule-preset-ameba/tar.gz/e22b25089b6ab737ca03cedb8a089f2377d3386e':
     resolution: {gitHosted: true, integrity: sha512-tfgcQNIQnLzetlCPk0YV3192sSj0IQp1jgGo6IKxNCfECfBoAh3DvTarAD7gXWaOoYmgn4rTWN1i+uLn+hohhA==, tarball: https://codeload.github.com/openameba/textlint-rule-preset-ameba/tar.gz/e22b25089b6ab737ca03cedb8a089f2377d3386e}
@@ -10851,12 +10842,6 @@ snapshots:
       '@oozcitak/util': 10.0.0
 
   '@oozcitak/util@10.0.0': {}
-
-  '@openameba/spindle-hooks@1.10.1(@types/react@19.2.14)(react@19.2.6)':
-    dependencies:
-      react: 19.2.6
-    optionalDependencies:
-      '@types/react': 19.2.14
 
   '@openameba/textlint-rule-preset-ameba@https://codeload.github.com/openameba/textlint-rule-preset-ameba/tar.gz/e22b25089b6ab737ca03cedb8a089f2377d3386e(textlint@15.6.0(@cfworker/json-schema@4.1.1))':
     dependencies:


### PR DESCRIPTION
## 概要

Release ワークフロー (`release-changesets.yml`) の `Create Release Pull Request` ステップが、TypeScript v6 アップデート (#1980) のマージ後に失敗していた問題を修正します。

失敗ジョブ: https://github.com/openameba/spindle/actions/runs/25780277301/job/75721176256

## エラー内容

```
[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for @openameba/spindle-hooks@^1.10.2
while fetching it from https://registry.npmjs.org/
The latest release of @openameba/spindle-hooks is "1.10.1"
```

## 原因

`packages/spindle-ui/package.json` の `@openameba/spindle-hooks` の依存指定が `workspace:` プロトコルではなく `^1.10.0` になっていました。

pnpm 9 以降は `link-workspace-packages` のデフォルトが `false` のため、`workspace:` プレフィックスのない依存は **常に npm registry から解決** されます。リリースフロー内では次の順で破綻していました:

1. `changeset version` が `spindle-hooks` を 1.10.1 → 1.10.2 に patch bump
2. 同一 changeset に `spindle-ui` も含まれていたため、changesets が `spindle-ui` の依存範囲を `^1.10.0` → `^1.10.2` に書き換え
3. 続く `pnpm install --lockfile-only --no-frozen-lockfile` が `^1.10.2` を registry から解決しようとし、未公開のため失敗

これまでのリリースで顕在化しなかったのは、changesets 移行後の唯一の `spindle-hooks` リリース (1.10.1) では changeset に `spindle-ui` が含まれておらず、依存範囲の書き換えが発生しなかったためです。今回が初めて `spindle-hooks` と `spindle-ui` を同一 changeset に並べたリリースでした。

## 変更内容

`packages/spindle-ui/package.json` の `@openameba/spindle-hooks` 依存を `workspace:^` に変更しました。

- ローカルでは workspace から解決され、未公開バージョンの registry 解決が発生しません
- 公開時は `^<実バージョン>` に展開されるため、利用者側の semver 範囲セマンティクス (dedupe 互換) を維持します
- `spindle-mcp-server` の `workspace:*` は CLI/MCP サーバ実行体で利用形態が異なる (npx 経由・dedupe 不要) ため、本 PR では変更しません

## 動作確認

- ローカルで `pnpm install --frozen-lockfile` が成功することを確認
- 修正前にローカルで `pnpm version-packages` を実行してエラーが再現することを確認済み


---
_Generated by [Claude Code](https://claude.ai/code/session_01LTAU5DfJPmcmfSB55kmQZz)_