### PR TITLE
ci: prepublishOnly を publish ワークフローからトポロジカル順で実行する

### DIFF
--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -84,8 +84,12 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build spindle-hooks
-        run: pnpm --filter @openameba/spindle-hooks build
+      # Stage publish artifacts here in topological order; letting
+      # `changeset publish` fire prepublishOnly in parallel races a
+      # producer's `rm -rf dist` (via prebuild) against a consumer
+      # reading the same dist through the workspace symlink.
+      - name: Prepare publishable packages
+        run: pnpm -r --if-present run prepublishOnly
 
-      - name: Publish to npm with prepublishOnly
-        run: pnpm_config_ignore_scripts=false pnpm changeset publish
+      - name: Publish to npm
+        run: pnpm changeset publish


### PR DESCRIPTION
## 背景

Publish ワークフローが `@openameba/spindle-ui` の publish 時に `TS2307: Cannot find module '@openameba/spindle-hooks'` で失敗していました。

直前の変更 (aed9fb4) で `spindle-ui` の `@openameba/spindle-hooks` 依存を `^1.10.0` から `workspace:^` に切り替えたところ、`node_modules/@openameba/spindle-hooks` が **npm tarball 由来の独立コピー** から **ワークスペースへのシンボリックリンク** に変わったことで、これまで偶然顕在化していなかった race condition が露呈したものです。

## 原因

`changeset publish` は `@changesets/cli` の内部で `Promise.all` を使い、各パッケージの publish を **並列実行** します。その際に各パッケージの `prepublishOnly` も並列で発火するため、次のような衝突が起きていました。

- `spindle-hooks` の `prepublishOnly` (= `pnpm build`) が `prebuild: pnpm clean` (`rm -rf dist`) で **自身の `dist/` を一度全削除**
- ちょうどその瞬間に `spindle-ui` の `prepublishOnly` 内の `tsc -p tsconfig.esm.json` が、シンボリックリンク経由で `spindle-hooks/dist/index.d.ts` を読みに行く
- → 型解決失敗 → `TS2307` → `ELIFECYCLE`

## 修正方針

ローカル publish は OIDC Trusted Publishing 採用により行えないため、`prepublishOnly` はワークフローからのみ起動されます。これを **`changeset publish` に任せず、事前にワークフローでトポロジカル順に実行する** ことで race を解消しました。

```yaml
- name: Prepare publishable packages
  run: pnpm -r --if-present run prepublishOnly

- name: Publish to npm
  run: pnpm changeset publish
```

- `pnpm -r` はワークスペース依存グラフ順で実行するため、依存先 (例: `spindle-hooks`) が完全に build 完了してから依存元 (例: `spindle-ui`) が走る → race なし
- `--if-present` で `prepublishOnly` が定義されているパッケージだけが対象になり、明示的な `--filter` リストを保守する必要がない
- `pnpm-workspace.yaml` の `ignoreScripts: true` により `pnpm changeset publish` 自体は `prepublishOnly` を再発火させない (以前は `pnpm_config_ignore_scripts=false` で強制発火させていたものをやめた)
- 各パッケージの publish 前準備レシピ (`pnpm build && pnpm cp` / `pnpm minify` / `npm run build` 等) は package.json に温存

## 検証

ローカルで全パッケージの `dist/` を削除した状態から `pnpm -r --if-present run prepublishOnly` を実行し、6 パッケージ全てが 0 errors で完了し、publish artifact (spindle-ui の `index.{js,mjs,d.ts}` 等) が揃うことを確認済みです。

## 影響範囲

- `.github/workflows/release-changesets.yml` の publish ジョブのみ
- 各パッケージの `package.json` には変更なし

---
_Generated by [Claude Code](https://claude.ai/code/session_011ogmNDfPXWY4NTCjpKkCAa)_