### PR TITLE
fix(spindle-hooks,spindle-ui): useCarouselのkeyの衝突を解消

### DIFF
--- a/.changeset/fix-hero-carousel-key-collision.md
+++ b/.changeset/fix-hero-carousel-key-collision.md
@@ -1,0 +1,6 @@
+---
+"@openameba/spindle-hooks": minor
+"@openameba/spindle-ui": patch
+---
+
+Add `itemKeys` to `useCarousel` return value so consumers can render `itemsToRender` without React duplicate-key warnings caused by head/tail clones. `HeroCarousel` now uses these stable keys instead of `item.link`.

--- a/packages/spindle-hooks/src/useCarousel/useCarousel.test.ts
+++ b/packages/spindle-hooks/src/useCarousel/useCarousel.test.ts
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+import { useCarousel } from './useCarousel';
+
+type Item = { id: string };
+
+const items: Item[] = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+describe('useCarousel()', () => {
+  it('itemKeys has the same length as itemsToRender', () => {
+    const { result } = renderHook(() =>
+      useCarousel({
+        items,
+        itemLinkClassName: 'link',
+        shouldAutoPlaying: false,
+      }),
+    );
+
+    expect(result.current.itemKeys).toHaveLength(
+      result.current.itemsToRender.length,
+    );
+  });
+
+  it('itemKeys are all unique even when items reference is duplicated by head/tail cloning', () => {
+    const { result } = renderHook(() =>
+      useCarousel({
+        items,
+        itemLinkClassName: 'link',
+        shouldAutoPlaying: false,
+      }),
+    );
+
+    const { itemKeys } = result.current;
+    expect(new Set(itemKeys).size).toBe(itemKeys.length);
+  });
+
+  it('itemKeys use head-/body-/tail- prefixes to indicate cloned vs original items', () => {
+    const { result } = renderHook(() =>
+      useCarousel({
+        items,
+        itemLinkClassName: 'link',
+        shouldAutoPlaying: false,
+        displayCount: 2,
+      }),
+    );
+
+    // displayCount=2 with 3 items → head(2) + body(3) + tail(2)
+    expect(result.current.itemKeys).toEqual([
+      'head-0',
+      'head-1',
+      'body-0',
+      'body-1',
+      'body-2',
+      'tail-0',
+      'tail-1',
+    ]);
+  });
+});

--- a/packages/spindle-hooks/src/useCarousel/useCarousel.ts
+++ b/packages/spindle-hooks/src/useCarousel/useCarousel.ts
@@ -77,6 +77,18 @@ export function useCarousel<Item>({
     [displayCount, items],
   );
 
+  // Stable keys for each entry in `itemsToRender`. Because head/tail are
+  // reference-equal clones of items, consumers cannot derive a unique React
+  // key from the item itself — use these to avoid duplicate-key warnings.
+  const itemKeys = useMemo(
+    () => [
+      ...items.slice(-displayCount).map((_, i) => `head-${i}`),
+      ...items.map((_, i) => `body-${i}`),
+      ...items.slice(0, displayCount).map((_, i) => `tail-${i}`),
+    ],
+    [displayCount, items],
+  );
+
   const slideToNext = (ignoreHover = false) => {
     const shouldSlideToNext =
       ((!isHoveringRef.current && isAutoPlayingRef.current) || ignoreHover) &&
@@ -220,6 +232,7 @@ export function useCarousel<Item>({
     isAutoPlaying,
     isLinkClicked,
     itemsToRender,
+    itemKeys,
     listRef,
     listStyles,
     toggleAutoPlay,

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.keys.test.tsx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.keys.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import { HeroCarousel } from './HeroCarousel';
+
+type CarouselItem = {
+  imageUrl: string;
+  link: string;
+  title: string;
+};
+
+const carouselList: CarouselItem[] = [
+  {
+    title: '1. 生きたコンテンツをつむぐ',
+    imageUrl: 'https://example.com/1.webp',
+    link: 'https://example.com/1',
+  },
+  {
+    title: '2. 長期間続けるためのシステム開発',
+    imageUrl: 'https://example.com/2.webp',
+    link: 'https://example.com/2',
+  },
+  {
+    title: '3.「Spindle」成立の軌跡',
+    imageUrl: 'https://example.com/3.webp',
+    link: 'https://example.com/3',
+  },
+];
+
+// useCarousel clones items at both ends to make the list look like a loop,
+// so the same `link` appears at multiple positions. This test runs against
+// the real hook (no mock) to catch React key collisions.
+describe('<HeroCarousel /> key uniqueness', () => {
+  test('does not warn about duplicated keys when items are cloned by useCarousel', () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    render(<HeroCarousel carouselList={carouselList} autoplay={false} />);
+
+    const duplicatedKeyWarning = consoleErrorSpy.mock.calls.find(([msg]) =>
+      typeof msg === 'string'
+        ? msg.includes('two children with the same key')
+        : false,
+    );
+    expect(duplicatedKeyWarning).toBeUndefined();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.test.tsx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@openameba/spindle-hooks', () => {
         isAutoPlaying,
         isLinkClicked: true,
         itemsToRender: items,
+        itemKeys: items.map((_, i: number) => `body-${i}`),
         listRef: { current: null },
         listStyles: {},
         toggleAutoPlay,

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.tsx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.tsx
@@ -30,6 +30,7 @@ export const HeroCarousel: FC<Props> = React.memo(function HeroCarousel({
     isAutoPlaying,
     isLinkClicked,
     itemsToRender,
+    itemKeys,
     listRef,
     listStyles,
     toggleAutoPlay,
@@ -66,12 +67,12 @@ export const HeroCarousel: FC<Props> = React.memo(function HeroCarousel({
           ref={listRef}
           style={listStyles}
         >
-          {itemsToRender.map((item: CarouselItem) => (
+          {itemsToRender.map((item: CarouselItem, index: number) => (
             <HeroCarouselItem
               carouselItem={item}
               isLinkClicked={isLinkClicked}
               itemLinkClassName={ITEM_LINK_CLASS_NAME}
-              key={item.link}
+              key={itemKeys[index]}
             />
           ))}
         </ul>


### PR DESCRIPTION
## 概要

useCarousel は items の両端に displayCount 件ずつクローンを生成してitemsToRender に並べるが、要素が同じ参照のため利用者が item から一意なReact key を作れず、duplicate-key 警告が必ず発生していたのを修正しました。

useCarousel に head-/body-/tail- プレフィックス付きの itemKeys を追加し、HeroCarousel ではこれを key として使用するように変更しています。