### PR TITLE
fix(spindle-hooks): useAutoSlideの無限再レンダリングを修正

### DIFF
--- a/.changeset/fix-useautoslide-infinite-loop.md
+++ b/.changeset/fix-useautoslide-infinite-loop.md
@@ -1,0 +1,6 @@
+---
+"@openameba/spindle-hooks": patch
+"@openameba/spindle-ui": patch
+---
+
+Fix infinite re-render ("Maximum update depth exceeded") in `useAutoSlide` / `HeroCarousel` when `autoplay` is enabled. The timeout id is now held in a ref instead of state so the auto-slide callbacks stay stable and the mount effect no longer re-runs on every commit. Surfaced under React 19.

--- a/packages/spindle-hooks/src/useCarousel/useAutoSlide.test.ts
+++ b/packages/spindle-hooks/src/useCarousel/useAutoSlide.test.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAutoSlide } from './useAutoSlide';
+
+const AUTO_SLIDE_SPEED = 4000;
+
+describe('useAutoSlide()', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('does not throw "Maximum update depth exceeded" when mounted with autoplay enabled', () => {
+    expect(() =>
+      renderHook(() =>
+        useAutoSlide({ onTimeOut: () => {}, shouldAutoPlaying: true }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('calls onTimeOut after AUTO_SLIDE_SPEED when autoplay is enabled', () => {
+    const onTimeOut = vi.fn();
+    renderHook(() => useAutoSlide({ onTimeOut, shouldAutoPlaying: true }));
+
+    expect(onTimeOut).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(AUTO_SLIDE_SPEED);
+    });
+
+    expect(onTimeOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start the timer when autoplay is disabled', () => {
+    const onTimeOut = vi.fn();
+    renderHook(() => useAutoSlide({ onTimeOut, shouldAutoPlaying: false }));
+
+    act(() => {
+      vi.advanceTimersByTime(AUTO_SLIDE_SPEED);
+    });
+
+    expect(onTimeOut).not.toHaveBeenCalled();
+  });
+
+  it('always invokes the latest onTimeOut closure', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ onTimeOut }) => useAutoSlide({ onTimeOut, shouldAutoPlaying: true }),
+      { initialProps: { onTimeOut: first } },
+    );
+
+    rerender({ onTimeOut: second });
+
+    act(() => {
+      vi.advanceTimersByTime(AUTO_SLIDE_SPEED);
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles isAutoPlaying and stops advancing while paused', () => {
+    const onTimeOut = vi.fn();
+    const { result } = renderHook(() =>
+      useAutoSlide({ onTimeOut, shouldAutoPlaying: true }),
+    );
+
+    expect(result.current.isAutoPlaying).toBe(true);
+
+    act(() => {
+      result.current.toggleAutoPlay();
+    });
+
+    expect(result.current.isAutoPlaying).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(AUTO_SLIDE_SPEED * 2);
+    });
+
+    expect(onTimeOut).not.toHaveBeenCalled();
+  });
+
+  it('clears the pending timer on unmount', () => {
+    const onTimeOut = vi.fn();
+    const { unmount } = renderHook(() =>
+      useAutoSlide({ onTimeOut, shouldAutoPlaying: true }),
+    );
+
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/spindle-hooks/src/useCarousel/useAutoSlide.ts
+++ b/packages/spindle-hooks/src/useCarousel/useAutoSlide.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const AUTO_SLIDE_SPEED = 4000; // ms
 
@@ -9,44 +9,55 @@ type Payload = {
 
 export function useAutoSlide({ onTimeOut, shouldAutoPlaying = true }: Payload) {
   const [isAutoPlaying, setIsAutoPlaying] = useState(shouldAutoPlaying);
-  const [timeoutId, setTimeoutId] = useState<number | null>(null);
+
+  // Hold the timer id in a ref so setting it neither triggers a re-render nor
+  // invalidates the callbacks below, which would otherwise re-run the mount
+  // effect on every commit and cause an infinite update loop.
+  const timeoutIdRef = useRef<number | null>(null);
+
+  // `onTimeOut` is a fresh closure on every render; read it through a ref so
+  // callbacks can call the latest one while keeping a stable identity.
+  const onTimeOutRef = useRef(onTimeOut);
+  useEffect(() => {
+    onTimeOutRef.current = onTimeOut;
+  }, [onTimeOut]);
 
   const resetTimeOut = useCallback(() => {
-    if (timeoutId) {
-      window.clearTimeout(timeoutId);
+    if (timeoutIdRef.current != null) {
+      window.clearTimeout(timeoutIdRef.current);
+      timeoutIdRef.current = null;
     }
-  }, [timeoutId]);
+  }, []);
 
   const activateAutoSlide = useCallback(() => {
     resetTimeOut();
 
-    const newTimeoutId = window.setTimeout(() => {
-      onTimeOut();
+    timeoutIdRef.current = window.setTimeout(() => {
+      onTimeOutRef.current();
     }, AUTO_SLIDE_SPEED);
+  }, [resetTimeOut]);
 
-    setTimeoutId(newTimeoutId);
-  }, [resetTimeOut, onTimeOut]);
-
-  const resetAutoSlide = () => {
+  const resetAutoSlide = useCallback(() => {
     if (isAutoPlaying) {
       activateAutoSlide();
     }
-  };
+  }, [isAutoPlaying, activateAutoSlide]);
 
-  const toggleAutoPlay = () => {
+  const toggleAutoPlay = useCallback(() => {
     resetTimeOut();
 
     if (!isAutoPlaying) {
       activateAutoSlide();
     }
     setIsAutoPlaying((prev) => !prev);
-  };
+  }, [isAutoPlaying, resetTimeOut, activateAutoSlide]);
 
   useEffect(() => {
     if (shouldAutoPlaying) {
       activateAutoSlide();
     }
-  }, [activateAutoSlide, shouldAutoPlaying]); // eslint-disable-line react-hooks/exhaustive-deps
+    return () => resetTimeOut();
+  }, [shouldAutoPlaying, activateAutoSlide, resetTimeOut]);
 
   return {
     isAutoPlaying,

--- a/packages/spindle-ui/src/HeroCarousel/HeroCarousel.stories.tsx
+++ b/packages/spindle-ui/src/HeroCarousel/HeroCarousel.stories.tsx
@@ -47,6 +47,10 @@ export const Normal: Story = {
   render: () => <HeroCarousel carouselList={carouselList} autoplay={false} />,
 };
 
+export const Autoplay: Story = {
+  render: () => <HeroCarousel carouselList={carouselList} autoplay />,
+};
+
 const longTitleCarouselList: CarouselItem[] = [
   {
     title:


### PR DESCRIPTION
## 概要

autoplay有効時にHeroCarousel/useAutoSlideが "Maximum update depth exceeded" を投げる無限ループを修正。

タイマーIDをuseStateからuseRefに変更し、onTimeOutもrefで最新クロージャを参照するようにして、resetTimeOut/activateAutoSlideを不変化。これによりmount effectが毎コミットで再実行されなくなる。アンマウント時にclearTimeoutしてタイマーリークも防止。

合わせてautoplay有効のStory(HeroCarousel/Autoplay)を追加し、Storybook上でこの不具合を検知できるようにした(既存Storyはいずれもautoplay=falseで顕在化しなかった)。