### PR TITLE
chore(spindle-mcp-server): use cpx2 v9 named imports

### DIFF
--- a/packages/spindle-mcp-server/scripts/copy-assets.js
+++ b/packages/spindle-mcp-server/scripts/copy-assets.js
@@ -3,7 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import cpx from 'cpx2';
+import { copy } from 'cpx2';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -52,7 +52,7 @@ async function copyAssets() {
   ];
 
   for (const task of tasks) {
-    await cpx.copy(task.source, task.dest, {
+    await copy(task.source, task.dest, {
       cwd: path.join(__dirname, '..'),
       ignore: task.ignore || [],
     });


### PR DESCRIPTION
## 概要

cpx2 v9 への更新 (#2120) で CI が失敗していた問題を修正します。

## 背景

cpx2 v9.0.0 は ESM へ移行する破壊的変更 (`feat!: migrate to ESM`) を含んでおり、**default export が廃止**されました。そのため `packages/spindle-mcp-server/scripts/copy-assets.js` のデフォルトインポートがビルド時に以下のエラーで失敗していました。

```
import cpx from 'cpx2';
SyntaxError: The requested module 'cpx2' does not provide an export named 'default'
```

## 変更内容

`copy-assets.js` を named import に変更します。cpx2 v9 は `copy` / `copySync` / `watch` を named export として提供しています。

```diff
-import cpx from 'cpx2';
+import { copy } from 'cpx2';
 ...
-    await cpx.copy(task.source, task.dest, {
+    await copy(task.source, task.dest, {
```

このPRは #2120 (`renovate/cpx2-9.x`) に向けており、マージすると #2120 の CI 失敗が解消される想定です。

関連: #2120

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmzWyHkTAECagzpeAwy3d2)_