### PR TITLE
feat(spindle-ui): navigation tabにCapsule StyleとInline Styleを追加

### DIFF
--- a/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.css
+++ b/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.css
@@ -1,0 +1,167 @@
+.spui-CapsuleTab {
+  background-color: var(--color-surface-primary);
+}
+
+.spui-CapsuleTab--border {
+  border-bottom: 1px solid var(--color-border-low-emphasis);
+}
+
+.spui-CapsuleTab--scrollable {
+  position: relative;
+}
+
+.spui-CapsuleTab-container {
+  align-items: center;
+  column-gap: 8px;
+  display: flex;
+  padding: 12px 16px;
+}
+
+.spui-CapsuleTab--fixed .spui-CapsuleTab-container {
+  justify-content: center;
+}
+
+.spui-CapsuleTab--scrollable .spui-CapsuleTab-container {
+  overflow-x: auto;
+  scroll-behavior: smooth;
+}
+
+.spui-CapsuleTab-button {
+  background-color: transparent;
+  border: none;
+  border-radius: 40px;
+  box-sizing: border-box;
+  min-width: 56px;
+  padding: 6px 14px;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.spui-CapsuleTab--scrollable .spui-CapsuleTab-button {
+  flex-shrink: 0;
+}
+
+.spui-CapsuleTab-button:hover {
+  background-color: var(--color-surface-secondary);
+}
+
+.spui-CapsuleTab-button[aria-selected="true"] {
+  background-color: var(--color-surface-accent-primary);
+}
+
+/* stylelint-disable-next-line  */
+.spui-CapsuleTab-button[aria-selected="true"]:hover {
+  background-color: var(--color-hover-contained-button);
+}
+
+.spui-CapsuleTab-button:focus {
+  outline: 2px solid var(--color-focus-clarity);
+  outline-offset: 1px;
+}
+
+.spui-CapsuleTab-button:not(:focus-visible) {
+  outline: none;
+}
+
+.spui-CapsuleTab-label {
+  color: var(--color-text-low-emphasis);
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: bold;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* stylelint-disable-next-line  */
+.spui-CapsuleTab-button[aria-selected="true"] .spui-CapsuleTab-label {
+  color: var(--color-text-high-emphasis-inverse);
+}
+
+.spui-CapsuleTab-arrow {
+  background-color: var(--color-surface-primary);
+  bottom: 0;
+  height: fit-content;
+  margin: auto;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  transition:
+    opacity 0.35s ease-in-out,
+    visibility 0.35s ease-in-out;
+  visibility: hidden;
+  z-index: 1;
+}
+
+.spui-CapsuleTab-arrow.is-showed {
+  opacity: 1;
+  visibility: visible;
+}
+
+.spui-CapsuleTab-arrow::before {
+  content: "";
+  height: 100%;
+  position: absolute;
+  width: 10px;
+  z-index: -1;
+}
+
+.spui-CapsuleTab-arrow--left {
+  left: 0;
+}
+
+.spui-CapsuleTab-arrow--left::before {
+  background: linear-gradient(
+    270deg,
+    rgba(255, 255, 255, 0) 0,
+    var(--color-surface-primary) 100%
+  );
+  left: 44px; /* ボタンの横幅分 */
+}
+
+.spui-CapsuleTab-arrow--right {
+  right: 0;
+}
+
+.spui-CapsuleTab-arrow--right::before {
+  background: linear-gradient(
+    270deg,
+    var(--color-surface-primary) 0,
+    rgba(255, 255, 255, 0) 100%
+  );
+  right: 44px; /* ボタンの横幅分 */
+}
+
+.spui-CapsuleTab-arrowButton {
+  background-color: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--color-object-low-emphasis);
+  display: flex;
+  padding: 14px;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.spui-CapsuleTab-arrowButton:hover {
+  background-color: var(--color-surface-tertiary);
+}
+
+.spui-CapsuleTab-arrowButton:focus {
+  outline: 2px solid var(--color-focus-clarity);
+}
+
+.spui-CapsuleTab-arrowButton:not(:focus-visible) {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spui-CapsuleTab-button,
+  .spui-CapsuleTab-arrow,
+  .spui-CapsuleTab-arrowButton {
+    transition: 0.1ms;
+  }
+
+  .spui-CapsuleTab--scrollable .spui-CapsuleTab-container {
+    scroll-behavior: auto;
+  }
+}

--- a/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.figma.tsx
+++ b/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.figma.tsx
@@ -1,0 +1,43 @@
+import figma from '@figma/code-connect';
+import React from 'react';
+import { CapsuleTab } from './CapsuleTab';
+
+figma.connect(
+  CapsuleTab,
+  'https://www.figma.com/design/FSgvRthUiMMXWgrSE4RUgr/Spindle-UI?node-id=4053-27265&t=YLIDc1qkFqK1kafo-4',
+  {
+    imports: [
+      "import { CapsuleTab } from '@openameba/spindle-ui/NavigationTab';",
+      "import '@openameba/spindle-ui/NavigationTab/index.css';",
+    ],
+    variant: { Type: 'Capsule' },
+    props: {
+      scroll: figma.enum('Scroll', {
+        Fixed: 'fixed',
+        Scrollable: 'scrollable',
+      }),
+      number: figma.enum('数', {
+        '2': '2',
+        '3': '3',
+        '4': '4',
+        '5': '5',
+      }),
+      selected: figma.enum('選択アイテム', {
+        '1': '1',
+        '2': '2',
+        '3': '3',
+        '4': '4',
+        '5': '5',
+      }),
+      border: figma.boolean('Border'),
+    },
+    example: ({ scroll, selected, border }) => (
+      <CapsuleTab
+        variant={scroll}
+        options={[{ id: selected, label: '' }]}
+        defaultSelectedId={selected}
+        hasBorder={border}
+      />
+    ),
+  },
+);

--- a/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.mdx
+++ b/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.mdx
@@ -1,0 +1,86 @@
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import * as CapsuleTabStories from './CapsuleTab.stories';
+
+<Meta of={CapsuleTabStories} />
+
+# NavigationTab/CapsuleTab
+
+NavigationTabは表示内容を伝え、切り替える事を目的としたコンポーネントです。CapsuleTabはUnderlineTabより象徴的に使ったり、目立たせたい時に利用してください。UnderlineTabと併用してサブナビゲーション的に利用することも可能です。
+
+<Source
+  language="javascript"
+  code={`
+import { CapsuleTab } from '@openameba/spindle-ui/NavigationTab';
+import '@openameba/spindle-ui/NavigationTab/index.css';
+  `}
+/>
+
+<Source
+  language="css"
+  code={`@import './node_modules/@openameba/spindle-ui/NavigationTab/CapsuleTab/CapsuleTab.css'`}
+/>
+
+<Source
+  language="html"
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/NavigationTab/CapsuleTab/CapsuleTab.css">`}
+/>
+
+## 指定できるプロパティ
+- `defaultSelectedId`(必須): 初期の選択状態にしたい項目の`id`を指定します。この`id`は`options`内のいずれかの`id`と一致している必要があります。
+- `options`(必須): 各項目の情報を指定します。`id`（必須）は各項目を識別するためのもので、配列内で一意である必要があります。`label`（必須）はCapsuleTabに表示されるラベルです。
+- `hasBorder`(任意): コンポーネント下に区切り線を表示するかどうかを指定します。デフォルトは`false`です。
+- `variant`(任意): CapsuleTabの種類を指定します。デフォルトは`fixed`で、その他に`scrollable`を指定することもできます。
+- `onClick`(任意): 各項目をクリックした際に追加で行いたい処理がある場合は指定します。第2引数の`id`には、選択された項目の`id`が渡されます。
+
+## アクセシビリティ
+CapsuleTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が設定されます。また、`aria-controls`には`options`の`id`に`-tabpanel`を付与したものが設定されます。（例：`id`が`all`の場合、`id`には`all`、`aria-controls`には`all-tabpanel`が設定されます）
+
+上記を用いて、各項目と表示内容を関連付けてください。
+
+<Source
+  code={`<CapsuleTab
+  defaultSelectedId={'all'}
+  options={[
+    { id: 'all', label: 'すべて' },
+    { id: 'follow', label: 'フォロー' },
+    { id: 'follower', label: 'フォロワー' },
+  ]}
+/>
+<div id="all-tabpanel" role="tabpanel" aria-labelledby="all">
+  <p>「すべて」選択時の表示内容</p>
+</div>
+<div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow">
+  <p>「フォロー」選択時の表示内容</p>
+</div>
+<div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower">
+  <p>「フォロワー」選択時の表示内容</p>
+</div>`}
+/>
+
+## Variant（fixed）
+
+`variant: fixed`を指定した場合、各項目はラベルの長さに応じた幅になり、全体が中央揃えで配置されます。`fixed`を指定している場合、長い項目名（`label`）や多数の項目が設定されることは期待していません。長い項目名や多数の項目を設定したい場合は`variant: scrollable`の利用を検討してください。
+
+<Story of={CapsuleTabStories.VariantFixed} />
+
+## Variant（scrollable）
+
+`variant: scrollable`を指定した場合、CapsuleTabの全体が表示領域内に収まらなくなった瞬間から、横スクロール可能になります。左右に見切れた項目がある場合には、スクロール操作用のボタンが表示されます。また、項目を選択すると、選択した項目が中央に来るようにスクロールされます。
+
+<Story of={CapsuleTabStories.VariantScrollable} />
+
+## Variant（scrollable with short label）
+
+CapsuleTabの全体が表示領域内に収まっている場合は、特にスクロールはしません。
+
+<Story of={CapsuleTabStories.VariantScrollableWithShortLabel} />
+
+## HasBorder（true）
+
+コンポーネント下に区切り線を表示するかどうかを指定します。デフォルトは`false`ですが、`true`を指定すれば表示できます。
+
+<Story of={CapsuleTabStories.HasBorderTrue} />
+
+## Baseline
+
+Widely available

--- a/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.stories.tsx
+++ b/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.stories.tsx
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { action } from 'storybook/actions';
+import { CapsuleTab } from './CapsuleTab';
+
+const meta: Meta<typeof CapsuleTab> = {
+  title: 'NavigationTab/CapsuleTab',
+  args: {
+    onClick: action('clicked'),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const VariantFixed: Story = {
+  render: (args) => (
+    <>
+      <CapsuleTab
+        defaultSelectedId={'fixed-all'}
+        options={[
+          { id: 'fixed-all', label: 'すべて' },
+          { id: 'fixed-follow', label: 'フォロー' },
+          { id: 'fixed-follower', label: 'フォロワー' },
+        ]}
+        {...args}
+      />
+      <div
+        id="fixed-all-tabpanel"
+        role="tabpanel"
+        aria-labelledby="fixed-all"
+      />
+      <div
+        id="fixed-follow-tabpanel"
+        role="tabpanel"
+        aria-labelledby="fixed-follow"
+      />
+      <div
+        id="fixed-follower-tabpanel"
+        role="tabpanel"
+        aria-labelledby="fixed-follower"
+      />
+    </>
+  ),
+};
+
+export const VariantScrollable: Story = {
+  render: (args) => (
+    <>
+      <CapsuleTab
+        defaultSelectedId={'scrollable-follow'}
+        options={[
+          { id: 'scrollable-all', label: 'すべて' },
+          { id: 'scrollable-follow', label: 'フォロー' },
+          { id: 'scrollable-follower', label: 'フォロワー' },
+          { id: 'scrollable-recommend', label: 'おすすめ' },
+          { id: 'scrollable-ranking', label: 'ランキング' },
+          { id: 'scrollable-official', label: '公式ジャンル' },
+          { id: 'scrollable-topics', label: 'トピックス' },
+        ]}
+        variant="scrollable"
+        {...args}
+      />
+      <div
+        id="scrollable-all-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-all"
+      />
+      <div
+        id="scrollable-follow-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-follow"
+      />
+      <div
+        id="scrollable-follower-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-follower"
+      />
+      <div
+        id="scrollable-recommend-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-recommend"
+      />
+      <div
+        id="scrollable-ranking-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-ranking"
+      />
+      <div
+        id="scrollable-official-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-official"
+      />
+      <div
+        id="scrollable-topics-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-topics"
+      />
+    </>
+  ),
+};
+
+export const VariantScrollableWithShortLabel: Story = {
+  render: (args) => (
+    <>
+      <CapsuleTab
+        defaultSelectedId={'scrollable-short-follower'}
+        options={[
+          { id: 'scrollable-short-all', label: 'すべて' },
+          { id: 'scrollable-short-follow', label: 'フォロー' },
+          { id: 'scrollable-short-follower', label: 'フォロワー' },
+        ]}
+        variant="scrollable"
+        {...args}
+      />
+      <div
+        id="scrollable-short-all-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-short-all"
+      />
+      <div
+        id="scrollable-short-follow-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-short-follow"
+      />
+      <div
+        id="scrollable-short-follower-tabpanel"
+        role="tabpanel"
+        aria-labelledby="scrollable-short-follower"
+      />
+    </>
+  ),
+};
+
+export const HasBorderTrue: Story = {
+  render: (args) => (
+    <>
+      <CapsuleTab
+        defaultSelectedId={'hasBorder-all'}
+        hasBorder={true}
+        options={[
+          { id: 'hasBorder-all', label: 'すべて' },
+          { id: 'hasBorder-follow', label: 'フォロー' },
+          { id: 'hasBorder-follower', label: 'フォロワー' },
+        ]}
+        {...args}
+      />
+      <div
+        id="hasBorder-all-tabpanel"
+        role="tabpanel"
+        aria-labelledby="hasBorder-all"
+      />
+      <div
+        id="hasBorder-follow-tabpanel"
+        role="tabpanel"
+        aria-labelledby="hasBorder-follow"
+      />
+      <div
+        id="hasBorder-follower-tabpanel"
+        role="tabpanel"
+        aria-labelledby="hasBorder-follower"
+      />
+    </>
+  ),
+};

--- a/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.test.tsx
+++ b/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { CapsuleTab } from './CapsuleTab';
+
+const options = [
+  { id: 'all', label: 'すべて' },
+  { id: 'follow', label: 'フォロー' },
+  { id: 'follower', label: 'フォロワー' },
+];
+
+describe('<CapsuleTab />', () => {
+  describe('defaultSelectedId Props', () => {
+    test('If defaultSelectedId is not included in options, nothing is selected.', () => {
+      render(
+        <CapsuleTab defaultSelectedId={'notIncludedId'} options={options} />,
+      );
+
+      const notSelectedButtons = screen.getAllByRole('tab', {
+        selected: false,
+      });
+      expect(notSelectedButtons.length).toEqual(options.length);
+    });
+
+    test('If defaultSelectedId is included in options, it must be selected.', () => {
+      const defaultSelectedId = options[0].id;
+      render(
+        <CapsuleTab defaultSelectedId={defaultSelectedId} options={options} />,
+      );
+
+      const notSelectedButtons = screen.getAllByRole('tab', {
+        selected: false,
+      });
+      expect(notSelectedButtons.length).toEqual(options.length - 1);
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(defaultSelectedId);
+    });
+  });
+
+  describe('options Props', () => {
+    test('Nothing is displayed when options is empty array.', () => {
+      const { container } = render(
+        <CapsuleTab defaultSelectedId={options[0].id} options={[]} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    test('If options are specified, they should be properly reflected.', () => {
+      const defaultSelectedId = options[1].id;
+      render(
+        <CapsuleTab defaultSelectedId={defaultSelectedId} options={options} />,
+      );
+
+      const buttons = screen.getAllByRole('tab');
+      buttons.forEach((button, i) => {
+        expect(button.getAttribute('aria-controls')).toEqual(
+          `${options[i].id}-tabpanel`,
+        );
+        expect(button.getAttribute('aria-selected')).toEqual(
+          defaultSelectedId === button.id ? 'true' : 'false',
+        );
+        expect(button.getAttribute('id')).toEqual(options[i].id);
+        expect(button.getAttribute('tabIndex')).toEqual(
+          defaultSelectedId === button.id ? '0' : '-1',
+        );
+      });
+    });
+  });
+
+  describe('hasBorder Props', () => {
+    test('Border must be displayed when hasBorder is true.', () => {
+      const { container } = render(
+        <CapsuleTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          hasBorder={true}
+        />,
+      );
+
+      expect(container.firstChild).toHaveClass('spui-CapsuleTab--border');
+    });
+
+    test('Border is not initially displayed.', () => {
+      const { container } = render(
+        <CapsuleTab defaultSelectedId={options[0].id} options={options} />,
+      );
+
+      expect(container.firstChild).not.toHaveClass('spui-CapsuleTab--border');
+    });
+  });
+
+  describe('variant Props', () => {
+    test('The fixed class must be applied by default.', () => {
+      const { container } = render(
+        <CapsuleTab defaultSelectedId={options[0].id} options={options} />,
+      );
+
+      expect(container.firstChild).toHaveClass('spui-CapsuleTab--fixed');
+    });
+
+    test('The scrollable class must be applied when variant is scrollable.', () => {
+      const { container } = render(
+        <CapsuleTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          variant={'scrollable'}
+        />,
+      );
+
+      expect(container.firstChild).toHaveClass('spui-CapsuleTab--scrollable');
+    });
+  });
+
+  describe('onClick Props', () => {
+    test('The selected item should change when onClick is called.', async () => {
+      const defaultSelectedId = options[0].id;
+      const selectedId = options[1].id;
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <CapsuleTab
+          defaultSelectedId={defaultSelectedId}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      const defaultSelectedButton = screen.getByRole('tab', { selected: true });
+      expect(defaultSelectedButton.getAttribute('id')).toEqual(
+        defaultSelectedId,
+      );
+
+      if (defaultSelectedButton.nextElementSibling) {
+        await user.click(defaultSelectedButton.nextElementSibling);
+      }
+      expect(onClick).toHaveBeenCalled();
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(selectedId);
+    });
+
+    test('onClick must not be called when the selected item is clicked.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <CapsuleTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      await user.click(screen.getByRole('tab', { selected: true }));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.test.tsx
+++ b/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.test.tsx
@@ -158,4 +158,150 @@ describe('<CapsuleTab />', () => {
       expect(onClick).not.toHaveBeenCalled();
     });
   });
+
+  describe('Keyboard interaction', () => {
+    test('Pressing ArrowRight moves focus to the next tab and selects it.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <CapsuleTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowRight}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(options[1].id);
+      expect(selectedButton).toHaveFocus();
+      expect(onClick).toHaveBeenCalled();
+    });
+
+    test('Pressing ArrowRight on the last tab moves to the first tab.', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CapsuleTab
+          defaultSelectedId={options[options.length - 1].id}
+          options={options}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowRight}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(options[0].id);
+      expect(selectedButton).toHaveFocus();
+    });
+
+    test('Pressing ArrowLeft on the first tab moves to the last tab.', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CapsuleTab defaultSelectedId={options[0].id} options={options} />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowLeft}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(
+        options[options.length - 1].id,
+      );
+      expect(selectedButton).toHaveFocus();
+    });
+
+    test('Pressing Enter on the selected tab does not fire onClick.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <CapsuleTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{Enter}');
+
+      expect(onClick).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('tab', { selected: true }).getAttribute('id'),
+      ).toEqual(options[0].id);
+    });
+  });
+
+  describe('Scroll behavior', () => {
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+    const scrollIntoViewMock = vi.fn();
+
+    beforeEach(() => {
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    });
+
+    afterEach(() => {
+      scrollIntoViewMock.mockClear();
+      window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    });
+
+    test('Arrow buttons must be displayed when variant is scrollable.', () => {
+      render(
+        <CapsuleTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          variant={'scrollable'}
+        />,
+      );
+
+      expect(screen.getByLabelText('左に移動')).toBeInTheDocument();
+      expect(screen.getByLabelText('右に移動')).toBeInTheDocument();
+    });
+
+    test('Arrow buttons must not be displayed when variant is fixed.', () => {
+      render(
+        <CapsuleTab defaultSelectedId={options[0].id} options={options} />,
+      );
+
+      expect(screen.queryByLabelText('左に移動')).toBeNull();
+      expect(screen.queryByLabelText('右に移動')).toBeNull();
+    });
+
+    test('The selected item must be scrolled to the center when variant is scrollable.', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CapsuleTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          variant={'scrollable'}
+        />,
+      );
+
+      await user.click(screen.getAllByRole('tab')[1]);
+
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({
+        block: 'nearest',
+        inline: 'center',
+      });
+    });
+
+    test('Scroll centering must not happen when variant is fixed.', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CapsuleTab defaultSelectedId={options[0].id} options={options} />,
+      );
+
+      await user.click(screen.getAllByRole('tab')[1]);
+
+      expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.tsx
+++ b/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.tsx
@@ -1,0 +1,244 @@
+import React, {
+  createRef,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import ChevronLeftBold from '../../Icon/ChevronLeftBold';
+import ChevronRightBold from '../../Icon/ChevronRightBold';
+
+type Option = {
+  label: string;
+  id: string;
+};
+
+type Variant = 'fixed' | 'scrollable';
+
+type Props = {
+  defaultSelectedId: string;
+  options: Option[];
+  hasBorder?: boolean;
+  variant?: Variant;
+  onClick?: (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLButtonElement>,
+    id: string,
+  ) => void;
+};
+
+const BLOCK_NAME = 'spui-CapsuleTab';
+const SCROLL_DISTANCE = 150;
+
+export const CapsuleTab: React.FC<Props> = ({
+  defaultSelectedId,
+  options,
+  hasBorder = false,
+  variant = 'fixed',
+  onClick,
+}) => {
+  const [selectedId, setSelectedId] = useState(defaultSelectedId);
+  const [showPrevButton, setShowPrevButton] = useState(false);
+  const [showNextButton, setShowNextButton] = useState(false);
+
+  const buttonsRef = useRef<RefObject<HTMLButtonElement | null>[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useCallback((direction: 'prev' | 'next') => {
+    const containerElement = containerRef.current;
+    if (!containerElement) {
+      return;
+    }
+
+    const scrollDistance =
+      direction === 'next' ? SCROLL_DISTANCE : -SCROLL_DISTANCE;
+    containerElement.scrollLeft = containerElement.scrollLeft + scrollDistance;
+  }, []);
+
+  const handleClick = useCallback(
+    (
+      e:
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+      id: string,
+      index: number,
+    ) => {
+      // 既に選択中の項目に対してクリックした場合は何もしない
+      if (id === selectedId) {
+        return;
+      }
+
+      setSelectedId(id);
+
+      // 選択した項目が中央に来るようにスクロールする
+      if (variant === 'scrollable') {
+        buttonsRef.current[index]?.current?.scrollIntoView?.({
+          block: 'nearest',
+          inline: 'center',
+        });
+      }
+
+      if (typeof onClick === 'function') {
+        onClick(e, id);
+      }
+    },
+    [onClick, selectedId, variant],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const totalLength = options.length;
+
+      switch (e.key) {
+        case 'ArrowLeft': {
+          // 基本的には1つ前の要素に移動。ただし、既に先頭の要素にいる場合はリストの最後尾に移動
+          const prevButtonIndex = index - 1 < 0 ? totalLength - 1 : index - 1;
+          const prevButtonRef = buttonsRef.current[prevButtonIndex];
+          prevButtonRef.current?.focus();
+          handleClick(e, options[prevButtonIndex].id, prevButtonIndex);
+          break;
+        }
+        case 'ArrowRight': {
+          // 基本的には1つ後の要素に移動。ただし、既に最後尾の要素にいる場合はリストの先頭に移動
+          const nextButtonIndex = index + 1 >= totalLength ? 0 : index + 1;
+          const nextButtonRef = buttonsRef.current[nextButtonIndex];
+          nextButtonRef.current?.focus();
+          handleClick(e, options[nextButtonIndex].id, nextButtonIndex);
+          break;
+        }
+        case 'Enter': {
+          const targetButton = buttonsRef.current[index].current;
+          // 既に選択中の項目に対してEnterを押下した場合は無効にする
+          if (targetButton?.getAttribute('aria-selected') === 'true') {
+            e.preventDefault();
+          }
+          break;
+        }
+      }
+    },
+    [options, handleClick],
+  );
+
+  useEffect(() => {
+    buttonsRef.current = options.map(
+      (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
+    );
+  }, [options]);
+
+  useEffect(() => {
+    if (variant !== 'scrollable') {
+      return;
+    }
+    const containerElement = containerRef.current;
+    if (!containerElement) {
+      return;
+    }
+
+    const updateDisplayedButton = () => {
+      setShowPrevButton(containerElement.scrollLeft > 0);
+      setShowNextButton(
+        containerElement.scrollWidth >
+          Math.ceil(containerElement.clientWidth + containerElement.scrollLeft),
+      );
+    };
+
+    updateDisplayedButton();
+    window.addEventListener('resize', updateDisplayedButton);
+    containerElement.addEventListener('scroll', updateDisplayedButton);
+
+    return () => {
+      window.removeEventListener('resize', updateDisplayedButton);
+      containerElement.removeEventListener('scroll', updateDisplayedButton);
+    };
+  }, [variant]);
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={[
+        BLOCK_NAME,
+        `${BLOCK_NAME}--${variant}`,
+        hasBorder && `${BLOCK_NAME}--border`,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .trim()}
+    >
+      {variant === 'scrollable' && (
+        <div
+          className={[
+            `${BLOCK_NAME}-arrow`,
+            `${BLOCK_NAME}-arrow--left`,
+            showPrevButton && 'is-showed',
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .trim()}
+        >
+          <button
+            className={`${BLOCK_NAME}-arrowButton`}
+            type="button"
+            onClick={() => handleScroll('prev')}
+          >
+            <ChevronLeftBold aria-label="左に移動" height={16} width={16} />
+          </button>
+        </div>
+      )}
+
+      <div
+        className={`${BLOCK_NAME}-container`}
+        role="tablist"
+        ref={containerRef}
+      >
+        {options.map((option, index) => {
+          const { label, id } = option;
+          const isSelected = id === selectedId;
+
+          return (
+            <button
+              aria-controls={`${id}-tabpanel`}
+              aria-selected={isSelected}
+              className={`${BLOCK_NAME}-button`}
+              key={id}
+              id={id}
+              tabIndex={isSelected ? 0 : -1}
+              type="button"
+              ref={buttonsRef.current[index]}
+              role="tab"
+              onClick={(e) => handleClick(e, id, index)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+            >
+              <span className={`${BLOCK_NAME}-label`}>{label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {variant === 'scrollable' && (
+        <div
+          className={[
+            `${BLOCK_NAME}-arrow`,
+            `${BLOCK_NAME}-arrow--right`,
+            showNextButton && 'is-showed',
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .trim()}
+        >
+          <button
+            className={`${BLOCK_NAME}-arrowButton`}
+            type="button"
+            onClick={() => handleScroll('next')}
+          >
+            <ChevronRightBold aria-label="右に移動" height={16} width={16} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.tsx
+++ b/packages/spindle-ui/src/NavigationTab/CapsuleTab/CapsuleTab.tsx
@@ -1,13 +1,7 @@
-import React, {
-  createRef,
-  type RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback } from 'react';
 import ChevronLeftBold from '../../Icon/ChevronLeftBold';
 import ChevronRightBold from '../../Icon/ChevronRightBold';
+import { useScrollArrows, useTabList } from '../hooks';
 
 type Option = {
   label: string;
@@ -30,7 +24,6 @@ type Props = {
 };
 
 const BLOCK_NAME = 'spui-CapsuleTab';
-const SCROLL_DISTANCE = 150;
 
 export const CapsuleTab: React.FC<Props> = ({
   defaultSelectedId,
@@ -39,120 +32,28 @@ export const CapsuleTab: React.FC<Props> = ({
   variant = 'fixed',
   onClick,
 }) => {
-  const [selectedId, setSelectedId] = useState(defaultSelectedId);
-  const [showPrevButton, setShowPrevButton] = useState(false);
-  const [showNextButton, setShowNextButton] = useState(false);
-
-  const buttonsRef = useRef<RefObject<HTMLButtonElement | null>[]>([]);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const handleScroll = useCallback((direction: 'prev' | 'next') => {
-    const containerElement = containerRef.current;
-    if (!containerElement) {
-      return;
-    }
-
-    const scrollDistance =
-      direction === 'next' ? SCROLL_DISTANCE : -SCROLL_DISTANCE;
-    containerElement.scrollLeft = containerElement.scrollLeft + scrollDistance;
-  }, []);
-
-  const handleClick = useCallback(
-    (
-      e:
-        | React.MouseEvent<HTMLButtonElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-      id: string,
-      index: number,
-    ) => {
-      // 既に選択中の項目に対してクリックした場合は何もしない
-      if (id === selectedId) {
+  const handleSelect = useCallback(
+    (selectedButton: HTMLButtonElement | null) => {
+      if (variant !== 'scrollable') {
         return;
       }
-
-      setSelectedId(id);
-
       // 選択した項目が中央に来るようにスクロールする
-      if (variant === 'scrollable') {
-        buttonsRef.current[index]?.current?.scrollIntoView?.({
-          block: 'nearest',
-          inline: 'center',
-        });
-      }
-
-      if (typeof onClick === 'function') {
-        onClick(e, id);
-      }
+      selectedButton?.scrollIntoView?.({
+        block: 'nearest',
+        inline: 'center',
+      });
     },
-    [onClick, selectedId, variant],
+    [variant],
   );
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
-      const totalLength = options.length;
-
-      switch (e.key) {
-        case 'ArrowLeft': {
-          // 基本的には1つ前の要素に移動。ただし、既に先頭の要素にいる場合はリストの最後尾に移動
-          const prevButtonIndex = index - 1 < 0 ? totalLength - 1 : index - 1;
-          const prevButtonRef = buttonsRef.current[prevButtonIndex];
-          prevButtonRef.current?.focus();
-          handleClick(e, options[prevButtonIndex].id, prevButtonIndex);
-          break;
-        }
-        case 'ArrowRight': {
-          // 基本的には1つ後の要素に移動。ただし、既に最後尾の要素にいる場合はリストの先頭に移動
-          const nextButtonIndex = index + 1 >= totalLength ? 0 : index + 1;
-          const nextButtonRef = buttonsRef.current[nextButtonIndex];
-          nextButtonRef.current?.focus();
-          handleClick(e, options[nextButtonIndex].id, nextButtonIndex);
-          break;
-        }
-        case 'Enter': {
-          const targetButton = buttonsRef.current[index].current;
-          // 既に選択中の項目に対してEnterを押下した場合は無効にする
-          if (targetButton?.getAttribute('aria-selected') === 'true') {
-            e.preventDefault();
-          }
-          break;
-        }
-      }
-    },
-    [options, handleClick],
-  );
-
-  useEffect(() => {
-    buttonsRef.current = options.map(
-      (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
-    );
-  }, [options]);
-
-  useEffect(() => {
-    if (variant !== 'scrollable') {
-      return;
-    }
-    const containerElement = containerRef.current;
-    if (!containerElement) {
-      return;
-    }
-
-    const updateDisplayedButton = () => {
-      setShowPrevButton(containerElement.scrollLeft > 0);
-      setShowNextButton(
-        containerElement.scrollWidth >
-          Math.ceil(containerElement.clientWidth + containerElement.scrollLeft),
-      );
-    };
-
-    updateDisplayedButton();
-    window.addEventListener('resize', updateDisplayedButton);
-    containerElement.addEventListener('scroll', updateDisplayedButton);
-
-    return () => {
-      window.removeEventListener('resize', updateDisplayedButton);
-      containerElement.removeEventListener('scroll', updateDisplayedButton);
-    };
-  }, [variant]);
+  const { selectedId, buttonsRef, handleClick, handleKeyDown } = useTabList({
+    defaultSelectedId,
+    options,
+    onClick,
+    onSelect: handleSelect,
+  });
+  const { containerRef, showPrevButton, showNextButton, handleScroll } =
+    useScrollArrows(variant === 'scrollable');
 
   if (options.length === 0) {
     return null;

--- a/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.css
+++ b/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.css
@@ -1,0 +1,64 @@
+.spui-InlineTab {
+  background-color: var(--color-surface-secondary);
+  border-radius: 70px;
+  box-sizing: border-box;
+  display: grid;
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
+  padding: 4px;
+  width: fit-content;
+}
+
+.spui-InlineTab-button {
+  background-color: transparent;
+  border: none;
+  border-radius: 40px;
+  box-sizing: border-box;
+  min-width: 80px;
+  padding: 8px 16px;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.spui-InlineTab-button:hover {
+  background-color: var(--color-surface-secondary);
+}
+
+.spui-InlineTab-button[aria-selected="true"] {
+  background-color: var(--color-surface-accent-primary);
+}
+
+/* stylelint-disable-next-line  */
+.spui-InlineTab-button[aria-selected="true"]:hover {
+  background-color: var(--color-hover-contained-button);
+}
+
+.spui-InlineTab-button:focus {
+  outline: 2px solid var(--color-focus-clarity);
+  outline-offset: 1px;
+}
+
+.spui-InlineTab-button:not(:focus-visible) {
+  outline: none;
+}
+
+.spui-InlineTab-label {
+  color: var(--color-text-low-emphasis);
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: bold;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* stylelint-disable-next-line  */
+.spui-InlineTab-button[aria-selected="true"] .spui-InlineTab-label {
+  color: var(--color-text-high-emphasis-inverse);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spui-InlineTab-button {
+    transition: 0.1ms;
+  }
+}

--- a/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.figma.tsx
+++ b/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.figma.tsx
@@ -1,0 +1,36 @@
+import figma from '@figma/code-connect';
+import React from 'react';
+import { InlineTab } from './InlineTab';
+
+figma.connect(
+  InlineTab,
+  'https://www.figma.com/design/FSgvRthUiMMXWgrSE4RUgr/Spindle-UI?node-id=4053-27265&t=YLIDc1qkFqK1kafo-4',
+  {
+    imports: [
+      "import { InlineTab } from '@openameba/spindle-ui/NavigationTab';",
+      "import '@openameba/spindle-ui/NavigationTab/index.css';",
+    ],
+    variant: { Type: 'Inline Capsule' },
+    props: {
+      number: figma.enum('数', {
+        '2': '2',
+        '3': '3',
+        '4': '4',
+        '5': '5',
+      }),
+      selected: figma.enum('選択アイテム', {
+        '1': '1',
+        '2': '2',
+        '3': '3',
+        '4': '4',
+        '5': '5',
+      }),
+    },
+    example: ({ selected }) => (
+      <InlineTab
+        options={[{ id: selected, label: '' }]}
+        defaultSelectedId={selected}
+      />
+    ),
+  },
+);

--- a/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.mdx
+++ b/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.mdx
@@ -1,0 +1,76 @@
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks';
+import * as InlineTabStories from './InlineTab.stories';
+
+<Meta of={InlineTabStories} />
+
+# NavigationTab/InlineTab
+
+NavigationTabは表示内容を伝え、切り替える事を目的としたコンポーネントです。InlineTabはNavigationTabのいずれかと並列に何らかの要素を配置したい時に利用してください。ただし、横スクロールできないため項目数が少ない時のみ利用してください。
+
+<Source
+  language="javascript"
+  code={`
+import { InlineTab } from '@openameba/spindle-ui/NavigationTab';
+import '@openameba/spindle-ui/NavigationTab/index.css';
+  `}
+/>
+
+<Source
+  language="css"
+  code={`@import './node_modules/@openameba/spindle-ui/NavigationTab/InlineTab/InlineTab.css'`}
+/>
+
+<Source
+  language="html"
+  code={`<link rel="stylesheet" href="https://unpkg.com/@openameba/spindle-ui/NavigationTab/InlineTab/InlineTab.css">`}
+/>
+
+## 指定できるプロパティ
+- `defaultSelectedId`(必須): 初期の選択状態にしたい項目の`id`を指定します。この`id`は`options`内のいずれかの`id`と一致している必要があります。
+- `options`(必須): 各項目の情報を指定します。`id`（必須）は各項目を識別するためのもので、配列内で一意である必要があります。`label`（必須）はInlineTabに表示されるラベルです。
+- `onClick`(任意): 各項目をクリックした際に追加で行いたい処理がある場合は指定します。第2引数の`id`には、選択された項目の`id`が渡されます。
+
+## アクセシビリティ
+InlineTab内の各項目は`tab`roleを持ち、`id`には`options`の`id`が設定されます。また、`aria-controls`には`options`の`id`に`-tabpanel`を付与したものが設定されます。（例：`id`が`all`の場合、`id`には`all`、`aria-controls`には`all-tabpanel`が設定されます）
+
+上記を用いて、各項目と表示内容を関連付けてください。
+
+<Source
+  code={`<InlineTab
+  defaultSelectedId={'all'}
+  options={[
+    { id: 'all', label: 'すべて' },
+    { id: 'follow', label: 'フォロー' },
+    { id: 'follower', label: 'フォロワー' },
+  ]}
+/>
+<div id="all-tabpanel" role="tabpanel" aria-labelledby="all">
+  <p>「すべて」選択時の表示内容</p>
+</div>
+<div id="follow-tabpanel" role="tabpanel" aria-labelledby="follow">
+  <p>「フォロー」選択時の表示内容</p>
+</div>
+<div id="follower-tabpanel" role="tabpanel" aria-labelledby="follower">
+  <p>「フォロワー」選択時の表示内容</p>
+</div>`}
+/>
+
+## Normal
+
+コンポーネントの幅は項目数に応じた内容幅になります（各項目の最小幅は80pxです）。NavigationTabのいずれかと並列に要素を配置する用途を想定しているため、親要素いっぱいには広がりません。親要素いっぱいに広げたい場合は、利用側でコンポーネントに`width: 100%`を指定してください。その場合、各項目は等分された幅で配置されます。
+
+<Story of={InlineTabStories.Normal} />
+
+## TwoItems
+
+<Story of={InlineTabStories.TwoItems} />
+
+## LongLabel
+
+各項目は最も長い項目名（`label`）に合わせた等幅になります。表示領域内に収まらない場合、項目名は1行内で省略されます。横スクロールはできないため、項目数が少なく項目名が短い場合のみ利用してください。
+
+<Story of={InlineTabStories.LongLabel} />
+
+## Baseline
+
+Widely available

--- a/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.stories.tsx
+++ b/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { action } from 'storybook/actions';
+import { InlineTab } from './InlineTab';
+
+const meta: Meta<typeof InlineTab> = {
+  title: 'NavigationTab/InlineTab',
+  args: {
+    onClick: action('clicked'),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Normal: Story = {
+  render: (args) => (
+    <>
+      <InlineTab
+        defaultSelectedId={'normal-all'}
+        options={[
+          { id: 'normal-all', label: 'すべて' },
+          { id: 'normal-follow', label: 'フォロー' },
+          { id: 'normal-follower', label: 'フォロワー' },
+        ]}
+        {...args}
+      />
+      <div
+        id="normal-all-tabpanel"
+        role="tabpanel"
+        aria-labelledby="normal-all"
+      />
+      <div
+        id="normal-follow-tabpanel"
+        role="tabpanel"
+        aria-labelledby="normal-follow"
+      />
+      <div
+        id="normal-follower-tabpanel"
+        role="tabpanel"
+        aria-labelledby="normal-follower"
+      />
+    </>
+  ),
+};
+
+export const TwoItems: Story = {
+  render: (args) => (
+    <>
+      <InlineTab
+        defaultSelectedId={'two-recommend'}
+        options={[
+          { id: 'two-recommend', label: 'おすすめ' },
+          { id: 'two-following', label: 'フォロー中' },
+        ]}
+        {...args}
+      />
+      <div
+        id="two-recommend-tabpanel"
+        role="tabpanel"
+        aria-labelledby="two-recommend"
+      />
+      <div
+        id="two-following-tabpanel"
+        role="tabpanel"
+        aria-labelledby="two-following"
+      />
+    </>
+  ),
+};
+
+export const LongLabel: Story = {
+  render: (args) => (
+    <>
+      <InlineTab
+        defaultSelectedId={'long-all'}
+        options={[
+          { id: 'long-all', label: 'すべて' },
+          {
+            id: 'long-others',
+            label: 'とても長い項目名は1行内で省略されます',
+          },
+        ]}
+        {...args}
+      />
+      <div id="long-all-tabpanel" role="tabpanel" aria-labelledby="long-all" />
+      <div
+        id="long-others-tabpanel"
+        role="tabpanel"
+        aria-labelledby="long-others"
+      />
+    </>
+  ),
+};

--- a/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.test.tsx
+++ b/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { InlineTab } from './InlineTab';
+
+const options = [
+  { id: 'all', label: 'すべて' },
+  { id: 'follow', label: 'フォロー' },
+  { id: 'follower', label: 'フォロワー' },
+];
+
+describe('<InlineTab />', () => {
+  describe('defaultSelectedId Props', () => {
+    test('If defaultSelectedId is not included in options, nothing is selected.', () => {
+      render(
+        <InlineTab defaultSelectedId={'notIncludedId'} options={options} />,
+      );
+
+      const notSelectedButtons = screen.getAllByRole('tab', {
+        selected: false,
+      });
+      expect(notSelectedButtons.length).toEqual(options.length);
+    });
+
+    test('If defaultSelectedId is included in options, it must be selected.', () => {
+      const defaultSelectedId = options[0].id;
+      render(
+        <InlineTab defaultSelectedId={defaultSelectedId} options={options} />,
+      );
+
+      const notSelectedButtons = screen.getAllByRole('tab', {
+        selected: false,
+      });
+      expect(notSelectedButtons.length).toEqual(options.length - 1);
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(defaultSelectedId);
+    });
+  });
+
+  describe('options Props', () => {
+    test('Nothing is displayed when options is empty array.', () => {
+      const { container } = render(
+        <InlineTab defaultSelectedId={options[0].id} options={[]} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    test('If options are specified, they should be properly reflected.', () => {
+      const defaultSelectedId = options[1].id;
+      render(
+        <InlineTab defaultSelectedId={defaultSelectedId} options={options} />,
+      );
+
+      const buttons = screen.getAllByRole('tab');
+      buttons.forEach((button, i) => {
+        expect(button.getAttribute('aria-controls')).toEqual(
+          `${options[i].id}-tabpanel`,
+        );
+        expect(button.getAttribute('aria-selected')).toEqual(
+          defaultSelectedId === button.id ? 'true' : 'false',
+        );
+        expect(button.getAttribute('id')).toEqual(options[i].id);
+        expect(button.getAttribute('tabIndex')).toEqual(
+          defaultSelectedId === button.id ? '0' : '-1',
+        );
+      });
+    });
+  });
+
+  describe('onClick Props', () => {
+    test('The selected item should change when onClick is called.', async () => {
+      const defaultSelectedId = options[0].id;
+      const selectedId = options[1].id;
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <InlineTab
+          defaultSelectedId={defaultSelectedId}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      const defaultSelectedButton = screen.getByRole('tab', { selected: true });
+      expect(defaultSelectedButton.getAttribute('id')).toEqual(
+        defaultSelectedId,
+      );
+
+      if (defaultSelectedButton.nextElementSibling) {
+        await user.click(defaultSelectedButton.nextElementSibling);
+      }
+      expect(onClick).toHaveBeenCalled();
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(selectedId);
+    });
+
+    test('onClick must not be called when the selected item is clicked.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <InlineTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      await user.click(screen.getByRole('tab', { selected: true }));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.test.tsx
+++ b/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.test.tsx
@@ -114,4 +114,81 @@ describe('<InlineTab />', () => {
       expect(onClick).not.toHaveBeenCalled();
     });
   });
+
+  describe('Keyboard interaction', () => {
+    test('Pressing ArrowRight moves focus to the next tab and selects it.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <InlineTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowRight}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(options[1].id);
+      expect(selectedButton).toHaveFocus();
+      expect(onClick).toHaveBeenCalled();
+    });
+
+    test('Pressing ArrowRight on the last tab moves to the first tab.', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <InlineTab
+          defaultSelectedId={options[options.length - 1].id}
+          options={options}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowRight}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(options[0].id);
+      expect(selectedButton).toHaveFocus();
+    });
+
+    test('Pressing ArrowLeft on the first tab moves to the last tab.', async () => {
+      const user = userEvent.setup();
+
+      render(<InlineTab defaultSelectedId={options[0].id} options={options} />);
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowLeft}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(
+        options[options.length - 1].id,
+      );
+      expect(selectedButton).toHaveFocus();
+    });
+
+    test('Pressing Enter on the selected tab does not fire onClick.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <InlineTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{Enter}');
+
+      expect(onClick).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('tab', { selected: true }).getAttribute('id'),
+      ).toEqual(options[0].id);
+    });
+  });
 });

--- a/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.tsx
+++ b/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.tsx
@@ -1,11 +1,5 @@
-import React, {
-  createRef,
-  type RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React from 'react';
+import { useTabList } from '../hooks';
 
 type Option = {
   label: string;
@@ -30,70 +24,11 @@ export const InlineTab: React.FC<Props> = ({
   options,
   onClick,
 }) => {
-  const [selectedId, setSelectedId] = useState(defaultSelectedId);
-
-  const buttonsRef = useRef<RefObject<HTMLButtonElement | null>[]>([]);
-
-  const handleClick = useCallback(
-    (
-      e:
-        | React.MouseEvent<HTMLButtonElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-      id: string,
-    ) => {
-      // 既に選択中の項目に対してクリックした場合は何もしない
-      if (id === selectedId) {
-        return;
-      }
-
-      setSelectedId(id);
-
-      if (typeof onClick === 'function') {
-        onClick(e, id);
-      }
-    },
-    [onClick, selectedId],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
-      const totalLength = options.length;
-
-      switch (e.key) {
-        case 'ArrowLeft': {
-          // 基本的には1つ前の要素に移動。ただし、既に先頭の要素にいる場合はリストの最後尾に移動
-          const prevButtonIndex = index - 1 < 0 ? totalLength - 1 : index - 1;
-          const prevButtonRef = buttonsRef.current[prevButtonIndex];
-          prevButtonRef.current?.focus();
-          handleClick(e, options[prevButtonIndex].id);
-          break;
-        }
-        case 'ArrowRight': {
-          // 基本的には1つ後の要素に移動。ただし、既に最後尾の要素にいる場合はリストの先頭に移動
-          const nextButtonIndex = index + 1 >= totalLength ? 0 : index + 1;
-          const nextButtonRef = buttonsRef.current[nextButtonIndex];
-          nextButtonRef.current?.focus();
-          handleClick(e, options[nextButtonIndex].id);
-          break;
-        }
-        case 'Enter': {
-          const targetButton = buttonsRef.current[index].current;
-          // 既に選択中の項目に対してEnterを押下した場合は無効にする
-          if (targetButton?.getAttribute('aria-selected') === 'true') {
-            e.preventDefault();
-          }
-          break;
-        }
-      }
-    },
-    [options, handleClick],
-  );
-
-  useEffect(() => {
-    buttonsRef.current = options.map(
-      (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
-    );
-  }, [options]);
+  const { selectedId, buttonsRef, handleClick, handleKeyDown } = useTabList({
+    defaultSelectedId,
+    options,
+    onClick,
+  });
 
   if (options.length === 0) {
     return null;
@@ -116,7 +51,7 @@ export const InlineTab: React.FC<Props> = ({
             type="button"
             ref={buttonsRef.current[index]}
             role="tab"
-            onClick={(e) => handleClick(e, id)}
+            onClick={(e) => handleClick(e, id, index)}
             onKeyDown={(e) => handleKeyDown(e, index)}
           >
             <span className={`${BLOCK_NAME}-label`}>{label}</span>

--- a/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.tsx
+++ b/packages/spindle-ui/src/NavigationTab/InlineTab/InlineTab.tsx
@@ -1,0 +1,128 @@
+import React, {
+  createRef,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+type Option = {
+  label: string;
+  id: string;
+};
+
+type Props = {
+  defaultSelectedId: string;
+  options: Option[];
+  onClick?: (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLButtonElement>,
+    id: string,
+  ) => void;
+};
+
+const BLOCK_NAME = 'spui-InlineTab';
+
+export const InlineTab: React.FC<Props> = ({
+  defaultSelectedId,
+  options,
+  onClick,
+}) => {
+  const [selectedId, setSelectedId] = useState(defaultSelectedId);
+
+  const buttonsRef = useRef<RefObject<HTMLButtonElement | null>[]>([]);
+
+  const handleClick = useCallback(
+    (
+      e:
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+      id: string,
+    ) => {
+      // 既に選択中の項目に対してクリックした場合は何もしない
+      if (id === selectedId) {
+        return;
+      }
+
+      setSelectedId(id);
+
+      if (typeof onClick === 'function') {
+        onClick(e, id);
+      }
+    },
+    [onClick, selectedId],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const totalLength = options.length;
+
+      switch (e.key) {
+        case 'ArrowLeft': {
+          // 基本的には1つ前の要素に移動。ただし、既に先頭の要素にいる場合はリストの最後尾に移動
+          const prevButtonIndex = index - 1 < 0 ? totalLength - 1 : index - 1;
+          const prevButtonRef = buttonsRef.current[prevButtonIndex];
+          prevButtonRef.current?.focus();
+          handleClick(e, options[prevButtonIndex].id);
+          break;
+        }
+        case 'ArrowRight': {
+          // 基本的には1つ後の要素に移動。ただし、既に最後尾の要素にいる場合はリストの先頭に移動
+          const nextButtonIndex = index + 1 >= totalLength ? 0 : index + 1;
+          const nextButtonRef = buttonsRef.current[nextButtonIndex];
+          nextButtonRef.current?.focus();
+          handleClick(e, options[nextButtonIndex].id);
+          break;
+        }
+        case 'Enter': {
+          const targetButton = buttonsRef.current[index].current;
+          // 既に選択中の項目に対してEnterを押下した場合は無効にする
+          if (targetButton?.getAttribute('aria-selected') === 'true') {
+            e.preventDefault();
+          }
+          break;
+        }
+      }
+    },
+    [options, handleClick],
+  );
+
+  useEffect(() => {
+    buttonsRef.current = options.map(
+      (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
+    );
+  }, [options]);
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={BLOCK_NAME} role="tablist">
+      {options.map((option, index) => {
+        const { label, id } = option;
+        const isSelected = id === selectedId;
+
+        return (
+          <button
+            aria-controls={`${id}-tabpanel`}
+            aria-selected={isSelected}
+            className={`${BLOCK_NAME}-button`}
+            key={id}
+            id={id}
+            tabIndex={isSelected ? 0 : -1}
+            type="button"
+            ref={buttonsRef.current[index]}
+            role="tab"
+            onClick={(e) => handleClick(e, id)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+          >
+            <span className={`${BLOCK_NAME}-label`}>{label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.mdx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.mdx
@@ -26,7 +26,7 @@ import '@openameba/spindle-ui/NavigationTab/index.css';
 />
 
 ## NavigationTabの種類
-NavigationTabには、Underline/Capsule/Inlineの3種類が存在します（※CapsuleとInlineはこれから実装予定です）
+NavigationTabには、Underline/Capsule/Inlineの3種類が存在します
 
 <table>
   <thead>

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.test.tsx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.test.tsx
@@ -23,7 +23,7 @@ describe('<UnderlineTab />', () => {
       expect(notSelectedButtons.length).toEqual(options.length);
     });
 
-    test('If defaultSelectedId is included in options, it must not be selected.', () => {
+    test('If defaultSelectedId is included in options, it must be selected.', () => {
       const defaultSelectedId = options[0].id;
       render(
         <UnderlineTab
@@ -153,6 +153,101 @@ describe('<UnderlineTab />', () => {
       expect(onClick).toHaveBeenCalled();
       const selectedButton = screen.getByRole('tab', { selected: true });
       expect(selectedButton.getAttribute('id')).toEqual(selectedId);
+    });
+
+    test('onClick must not be called when the selected item is clicked.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <UnderlineTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      await user.click(screen.getByRole('tab', { selected: true }));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Keyboard interaction', () => {
+    test('Pressing ArrowRight moves focus to the next tab and selects it.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <UnderlineTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowRight}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(options[1].id);
+      expect(selectedButton).toHaveFocus();
+      expect(onClick).toHaveBeenCalled();
+    });
+
+    test('Pressing ArrowRight on the last tab moves to the first tab.', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <UnderlineTab
+          defaultSelectedId={options[options.length - 1].id}
+          options={options}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowRight}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(options[0].id);
+      expect(selectedButton).toHaveFocus();
+    });
+
+    test('Pressing ArrowLeft on the first tab moves to the last tab.', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <UnderlineTab defaultSelectedId={options[0].id} options={options} />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{ArrowLeft}');
+
+      const selectedButton = screen.getByRole('tab', { selected: true });
+      expect(selectedButton.getAttribute('id')).toEqual(
+        options[options.length - 1].id,
+      );
+      expect(selectedButton).toHaveFocus();
+    });
+
+    test('Pressing Enter on the selected tab does not fire onClick.', async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <UnderlineTab
+          defaultSelectedId={options[0].id}
+          options={options}
+          onClick={onClick}
+        />,
+      );
+
+      screen.getByRole('tab', { selected: true }).focus();
+      await user.keyboard('{Enter}');
+
+      expect(onClick).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('tab', { selected: true }).getAttribute('id'),
+      ).toEqual(options[0].id);
     });
   });
 });

--- a/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.tsx
+++ b/packages/spindle-ui/src/NavigationTab/UnderlineTab/UnderlineTab.tsx
@@ -1,13 +1,7 @@
-import React, {
-  createRef,
-  type RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React from 'react';
 import ChevronLeftBold from '../../Icon/ChevronLeftBold';
 import ChevronRightBold from '../../Icon/ChevronRightBold';
+import { useScrollArrows, useTabList } from '../hooks';
 
 type Option = {
   label: string;
@@ -31,7 +25,6 @@ type Props = {
 };
 
 const BLOCK_NAME = 'spui-UnderlineTab';
-const SCROLL_DISTANCE = 150;
 
 export const UnderlineTab: React.FC<Props> = ({
   defaultSelectedId,
@@ -40,112 +33,13 @@ export const UnderlineTab: React.FC<Props> = ({
   variant = 'fixed',
   onClick,
 }) => {
-  const [selectedId, setSelectedId] = useState(defaultSelectedId);
-  const [showPrevButton, setShowPrevButton] = useState(false);
-  const [showNextButton, setShowNextButton] = useState(false);
-
-  const buttonsRef = useRef<RefObject<HTMLButtonElement | null>[]>([]);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const handleScroll = useCallback((direction: 'prev' | 'next') => {
-    const containerElement = containerRef.current;
-    if (!containerElement) {
-      return;
-    }
-
-    const scrollDistance =
-      direction === 'next' ? SCROLL_DISTANCE : -SCROLL_DISTANCE;
-    containerElement.scrollLeft = containerElement.scrollLeft + scrollDistance;
-  }, []);
-
-  const handleClick = useCallback(
-    (
-      e:
-        | React.MouseEvent<HTMLButtonElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-      id: string,
-    ) => {
-      const targetButtonElement = document.querySelector(`#${id}`);
-      // 既に選択中の項目に対してクリックした場合は何もしない
-      if (targetButtonElement?.getAttribute('aria-selected') === 'true') {
-        return;
-      }
-
-      setSelectedId(id);
-
-      if (typeof onClick === 'function') {
-        onClick(e, id);
-      }
-    },
-    [onClick],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
-      const totalLength = options.length;
-
-      switch (e.key) {
-        case 'ArrowLeft': {
-          // 基本的には1つ前の要素に移動。ただし、既に先頭の要素にいる場合はリストの最後尾に移動
-          const prevButtonIndex = index - 1 < 0 ? totalLength - 1 : index - 1;
-          const prevButtonRef = buttonsRef.current[prevButtonIndex];
-          prevButtonRef.current?.focus();
-          handleClick(e, options[prevButtonIndex].id);
-          break;
-        }
-        case 'ArrowRight': {
-          // 基本的には1つ後の要素に移動。ただし、既に最後尾の要素にいる場合はリストの先頭に移動
-          const nextButtonIndex = index + 1 >= totalLength ? 0 : index + 1;
-          const nextButtonRef = buttonsRef.current[nextButtonIndex];
-          nextButtonRef.current?.focus();
-          handleClick(e, options[nextButtonIndex].id);
-          break;
-        }
-        case 'Enter': {
-          const targetButton = buttonsRef.current[index].current;
-          // 既に選択中の項目に対してEnterを押下した場合は無効にする
-          if (targetButton?.getAttribute('aria-selected') === 'true') {
-            e.preventDefault();
-          }
-          break;
-        }
-      }
-    },
-    [options, handleClick],
-  );
-
-  useEffect(() => {
-    buttonsRef.current = options.map(
-      (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
-    );
-  }, [options]);
-
-  useEffect(() => {
-    if (variant !== 'scrollable') {
-      return;
-    }
-    const containerElement = containerRef.current;
-    if (!containerElement) {
-      return;
-    }
-
-    const updateDisplayedButton = () => {
-      setShowPrevButton(containerElement.scrollLeft > 0);
-      setShowNextButton(
-        containerElement.scrollWidth >
-          Math.ceil(containerElement.clientWidth + containerElement.scrollLeft),
-      );
-    };
-
-    updateDisplayedButton();
-    window.addEventListener('resize', updateDisplayedButton);
-    containerElement.addEventListener('scroll', updateDisplayedButton);
-
-    return () => {
-      window.removeEventListener('resize', updateDisplayedButton);
-      containerElement.removeEventListener('scroll', updateDisplayedButton);
-    };
-  }, [variant]);
+  const { selectedId, buttonsRef, handleClick, handleKeyDown } = useTabList({
+    defaultSelectedId,
+    options,
+    onClick,
+  });
+  const { containerRef, showPrevButton, showNextButton, handleScroll } =
+    useScrollArrows(variant === 'scrollable');
 
   if (options.length === 0) {
     return null;
@@ -209,7 +103,7 @@ export const UnderlineTab: React.FC<Props> = ({
               type="button"
               ref={buttonsRef.current[index]}
               role="tab"
-              onClick={(e) => handleClick(e, id)}
+              onClick={(e) => handleClick(e, id, index)}
               onKeyDown={(e) => handleKeyDown(e, index)}
             >
               <span className={`${BLOCK_NAME}-labelWrapper`}>

--- a/packages/spindle-ui/src/NavigationTab/hooks.ts
+++ b/packages/spindle-ui/src/NavigationTab/hooks.ts
@@ -32,6 +32,11 @@ export const useTabList = ({
   const [selectedId, setSelectedId] = useState(defaultSelectedId);
 
   const buttonsRef = useRef<RefObject<HTMLButtonElement | null>[]>([]);
+  // 初回レンダーからref属性に渡せるよう、レンダー中に遅延初期化する
+  // （useEffectで生成すると再レンダーまでrefがDOMに接続されず、初回のキーボード操作でフォーカス移動できない）
+  buttonsRef.current = options.map(
+    (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
+  );
 
   const handleClick = useCallback(
     (e: TabClickEvent, id: string, index: number) => {
@@ -86,12 +91,6 @@ export const useTabList = ({
     },
     [options, handleClick],
   );
-
-  useEffect(() => {
-    buttonsRef.current = options.map(
-      (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
-    );
-  }, [options]);
 
   return { selectedId, buttonsRef, handleClick, handleKeyDown };
 };

--- a/packages/spindle-ui/src/NavigationTab/hooks.ts
+++ b/packages/spindle-ui/src/NavigationTab/hooks.ts
@@ -1,0 +1,149 @@
+import {
+  createRef,
+  type KeyboardEvent,
+  type MouseEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+type TabClickEvent =
+  | MouseEvent<HTMLButtonElement>
+  | KeyboardEvent<HTMLButtonElement>;
+
+type UseTabListParams = {
+  defaultSelectedId: string;
+  options: { id: string }[];
+  onClick?: (event: TabClickEvent, id: string) => void;
+  onSelect?: (selectedButton: HTMLButtonElement | null) => void;
+};
+
+/**
+ * NavigationTab系コンポーネント共通のタブ選択状態とキーボード操作を提供する
+ */
+export const useTabList = ({
+  defaultSelectedId,
+  options,
+  onClick,
+  onSelect,
+}: UseTabListParams) => {
+  const [selectedId, setSelectedId] = useState(defaultSelectedId);
+
+  const buttonsRef = useRef<RefObject<HTMLButtonElement | null>[]>([]);
+
+  const handleClick = useCallback(
+    (e: TabClickEvent, id: string, index: number) => {
+      // 既に選択中の項目に対してクリックした場合は何もしない
+      if (id === selectedId) {
+        return;
+      }
+
+      setSelectedId(id);
+
+      if (typeof onSelect === 'function') {
+        onSelect(buttonsRef.current[index]?.current ?? null);
+      }
+
+      if (typeof onClick === 'function') {
+        onClick(e, id);
+      }
+    },
+    [onClick, onSelect, selectedId],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const totalLength = options.length;
+
+      switch (e.key) {
+        case 'ArrowLeft': {
+          // 基本的には1つ前の要素に移動。ただし、既に先頭の要素にいる場合はリストの最後尾に移動
+          const prevButtonIndex = index - 1 < 0 ? totalLength - 1 : index - 1;
+          const prevButtonRef = buttonsRef.current[prevButtonIndex];
+          prevButtonRef.current?.focus();
+          handleClick(e, options[prevButtonIndex].id, prevButtonIndex);
+          break;
+        }
+        case 'ArrowRight': {
+          // 基本的には1つ後の要素に移動。ただし、既に最後尾の要素にいる場合はリストの先頭に移動
+          const nextButtonIndex = index + 1 >= totalLength ? 0 : index + 1;
+          const nextButtonRef = buttonsRef.current[nextButtonIndex];
+          nextButtonRef.current?.focus();
+          handleClick(e, options[nextButtonIndex].id, nextButtonIndex);
+          break;
+        }
+        case 'Enter': {
+          const targetButton = buttonsRef.current[index].current;
+          // 既に選択中の項目に対してEnterを押下した場合は無効にする
+          if (targetButton?.getAttribute('aria-selected') === 'true') {
+            e.preventDefault();
+          }
+          break;
+        }
+      }
+    },
+    [options, handleClick],
+  );
+
+  useEffect(() => {
+    buttonsRef.current = options.map(
+      (_, index) => buttonsRef.current[index] ?? createRef<HTMLButtonElement>(),
+    );
+  }, [options]);
+
+  return { selectedId, buttonsRef, handleClick, handleKeyDown };
+};
+
+const SCROLL_DISTANCE = 150;
+
+/**
+ * NavigationTab系コンポーネント共通の横スクロールと矢印ボタンの表示制御を提供する
+ */
+export const useScrollArrows = (enabled: boolean) => {
+  const [showPrevButton, setShowPrevButton] = useState(false);
+  const [showNextButton, setShowNextButton] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useCallback((direction: 'prev' | 'next') => {
+    const containerElement = containerRef.current;
+    if (!containerElement) {
+      return;
+    }
+
+    const scrollDistance =
+      direction === 'next' ? SCROLL_DISTANCE : -SCROLL_DISTANCE;
+    containerElement.scrollLeft = containerElement.scrollLeft + scrollDistance;
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const containerElement = containerRef.current;
+    if (!containerElement) {
+      return;
+    }
+
+    const updateDisplayedButton = () => {
+      setShowPrevButton(containerElement.scrollLeft > 0);
+      setShowNextButton(
+        containerElement.scrollWidth >
+          Math.ceil(containerElement.clientWidth + containerElement.scrollLeft),
+      );
+    };
+
+    updateDisplayedButton();
+    window.addEventListener('resize', updateDisplayedButton);
+    containerElement.addEventListener('scroll', updateDisplayedButton);
+
+    return () => {
+      window.removeEventListener('resize', updateDisplayedButton);
+      containerElement.removeEventListener('scroll', updateDisplayedButton);
+    };
+  }, [enabled]);
+
+  return { containerRef, showPrevButton, showNextButton, handleScroll };
+};

--- a/packages/spindle-ui/src/NavigationTab/index.css
+++ b/packages/spindle-ui/src/NavigationTab/index.css
@@ -1,1 +1,3 @@
+@import './CapsuleTab/CapsuleTab.css';
+@import './InlineTab/InlineTab.css';
 @import './UnderlineTab/UnderlineTab.css';

--- a/packages/spindle-ui/src/NavigationTab/index.ts
+++ b/packages/spindle-ui/src/NavigationTab/index.ts
@@ -1,1 +1,3 @@
+export { CapsuleTab } from './CapsuleTab/CapsuleTab';
+export { InlineTab } from './InlineTab/InlineTab';
 export { UnderlineTab } from './UnderlineTab/UnderlineTab';


### PR DESCRIPTION
NavigationTabのCapsule StyleとInline Styleを追加しました。
それに際して、UnderlineTabに存在したロジックを一部hooksとして切り出し、それぞれで使う対応も加えています。

## 既存のバグ修正

テストケースとして、キーボード操作を担保するものを追加しており、それに伴って発見された初回レンダー時のfocus移動の問題を修正しました。

### 再現確認手順

1. https://ameba-spindle.web.app/?path=/story/navigationtab-underlinetab--variant-fixed へアクセスしtabでfocusを当てる
2. 隣の項目へ→キーを押下して移動
3. 選択値が変わるがfocusが移動していないことを確認
4. 新しいStoryで再度ためし解消されていることを確認